### PR TITLE
Ignore optional ws dependencies

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -317,6 +317,11 @@ module.exports = {
     // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
     // You can remove this if you don't use Moment.js:
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+    // bufferutil and utf-8-validate are optional dependencies of `ws` (which is
+    // required by socket.io). They have native dependencies; for now, we'll
+    // ignore them.
+    new webpack.IgnorePlugin(/^bufferutil$/),
+    new webpack.IgnorePlugin(/^utf-8-validate$/),
   ],
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.


### PR DESCRIPTION
Travis builds are failing; this should fix (we'll see...)

These are native dependencies of `ws` which is included but not used (though may be soon). If they're desired for performance on the server side, we'll need to adjust the build/dist process anyway.