### PR TITLE
Fix: server should exit when app quits

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -3,7 +3,7 @@ const { createMainWindow } = require('./components/mainWindow');
 const { createTray } = require('./components/tray');
 
 // start the server
-require('./server-starter');
+const serverControl = require('./server-starter');
 
 const mainWindow = createMainWindow();
 
@@ -25,6 +25,10 @@ const trayMenu = [
 app.on('ready', () => {
   app.dock.hide();
   createTray(trayMenu);
+});
+
+app.on('quit', () => {
+  serverControl.stop();
 });
 
 // Don't quit when all windows are closed.

--- a/src/main/server-starter.js
+++ b/src/main/server-starter.js
@@ -28,3 +28,11 @@ createServer(port, dbSettings)
 });
 
 console.log(`Server running on port ${port}`);
+
+const ServerControl = {
+  stop: () => {
+    if (server) { server.stop(); }
+  }
+};
+
+module.exports = ServerControl;

--- a/src/main/worker/Server.js
+++ b/src/main/worker/Server.js
@@ -36,10 +36,6 @@ class Server extends Emitter {
     this.listen();
   }
 
-  close() {
-    this.socketServer.close();
-  }
-
   listen() {
     io.on('connect', (socket) => {
       console.log('connected');
@@ -60,10 +56,6 @@ class Server extends Emitter {
         console.log('SERVER REQUESTED');
         ps.socket.emit('SERVER_STATUS', JSON.stringify(this.status()));
       });
-    });
-
-    this.on('STOP_SERVER', () => {
-      this.close();
     });
   }
 

--- a/src/main/worker/Server.js
+++ b/src/main/worker/Server.js
@@ -38,7 +38,6 @@ class Server extends Emitter {
 
   close() {
     this.socketServer.close();
-    this.socketServer.destroy();
   }
 
   listen() {


### PR DESCRIPTION
Prior to this, quitting the app as an end user (e.g., Cmd-Q) would leave the background process running. We need more robust process management in general, but this solves a common case (where I have to manually kill the node processes).