### PR TITLE
Fix tray disappearing after launch

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -7,6 +7,7 @@ require('./server-starter');
 
 const mainWindow = createMainWindow();
 
+let tray; // Keep reference; if tray is GCed, it disappears
 const trayMenu = [
   {
     label: 'Overview',
@@ -24,7 +25,7 @@ const trayMenu = [
 
 app.on('ready', () => {
   app.dock.hide();
-  createTray(trayMenu);
+  tray = createTray(trayMenu);
 });
 
 // Don't quit when all windows are closed.


### PR DESCRIPTION
The app tray disappears if no reference is retained. This happens somewhat rarely during development, but is easily testable in an app generated from the dist task.