### PR TITLE
Dynamically detect port for Admin API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,8 +106,7 @@
     "address": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
-      "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg==",
-      "dev": true
+      "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
     },
     "after": {
       "version": "0.8.2",
@@ -4105,11 +4104,11 @@
       "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
     },
     "detect-port": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.1.0.tgz",
-      "integrity": "sha1-/edXRZHqPedERXgmQ8P5IbKkYYw=",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.2.2.tgz",
+      "integrity": "sha512-06H99JMCwgbYbA+codm97aBhFLAjABftetp+v+Z88Pvvlkawp2N+1bP/9J24+mihrvk9yBvUYTyIj3NixG1CsA==",
       "requires": {
+        "address": "1.0.3",
         "debug": "2.6.8"
       }
     },
@@ -4453,7 +4452,7 @@
             "minimist": "1.2.0",
             "nugget": "2.0.1",
             "path-exists": "3.0.0",
-            "rc": "1.2.1",
+            "rc": "1.2.6",
             "semver": "5.4.1",
             "sumchecker": "2.0.2"
           }
@@ -4815,7 +4814,7 @@
             "minimist": "1.2.0",
             "nugget": "2.0.1",
             "path-exists": "3.0.0",
-            "rc": "1.2.1",
+            "rc": "1.2.6",
             "semver": "5.4.1",
             "sumchecker": "2.0.2"
           },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "chalk": "1.1.3",
     "cross-env": "^5.1.4",
     "css-loader": "^0.28.10",
-    "detect-port": "1.1.0",
     "dotenv": "4.0.0",
     "electron": "^2.0.0-beta.5",
     "electron-builder": "^20.5.1",
@@ -94,6 +93,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "detect-port": "^1.2.2",
     "libsodium-wrappers": "^0.7.3",
     "mdns": "^2.3.4",
     "nedb": "^1.8.0",

--- a/src/main/components/mainWindow.js
+++ b/src/main/components/mainWindow.js
@@ -22,7 +22,6 @@ class MainWindow {
     if (this.window) { return; }
 
     this.window = new BrowserWindow({
-      nodeIntegration: false,
       width: 800,
       height: 600,
       center: true,

--- a/src/main/package.json
+++ b/src/main/package.json
@@ -10,15 +10,15 @@
     "npm": "5.3.0"
   },
   "dependencies": {
+    "detect-port": "^1.2.2",
     "ip": "^1.1.5",
     "electron-log": "^2.2.7",
     "libsodium-wrappers": "^0.7.3",
-    "lodash": "^4.17.4",
     "mdns": "^2.3.4",
     "nedb": "^1.8.0",
     "private-socket": "https://github.com/codaco/PrivateSocket.git",
     "restify": "^6.3.4",
-    "socket.io": "^2.0.3",
+    "restify-cors-middleware": "^1.1.0",
     "uuid": "^3.2.1"
   },
   "main": "./index.js"

--- a/src/main/worker/__tests__/Server-test.js
+++ b/src/main/worker/__tests__/Server-test.js
@@ -50,5 +50,9 @@ describe('Server', () => {
       server.advertiseDeviceService(deviceService);
       expect(mockAdvert.start.mock.calls.length).toBe(1);
     });
+
+    it('returns connection info', () => {
+      expect(server.connectionInfo).toMatchObject({ deviceService: expect.any(Object) });
+    });
   });
 });

--- a/src/main/worker/adminService.js
+++ b/src/main/worker/adminService.js
@@ -33,6 +33,7 @@ class AdminService {
         return;
       }
       this.api.listen(port, Host, () => {
+        this.port = port;
         logger.info(`${this.api.name} listening at ${this.api.url}`);
         resolve(this);
       });
@@ -42,6 +43,7 @@ class AdminService {
   stop() {
     return new Promise((resolve) => {
       this.api.close(() => {
+        this.port = null;
         resolve();
       });
     });

--- a/src/main/worker/adminService.js
+++ b/src/main/worker/adminService.js
@@ -1,16 +1,17 @@
 const restify = require('restify');
 const logger = require('electron-log');
+const corsMiddleware = require('restify-cors-middleware');
+const detectPort = require('detect-port');
 
 const DeviceManager = require('./deviceManager');
 const ProtocolImporter = require('../utils/ProtocolImporter');
 
-const corsMiddleware = require('restify-cors-middleware');
+const DefaultPort = 8080;
 
 const ApiName = 'AdminAPI';
 const ApiVersion = '0.0.1';
 
 // Admin API should listen *only* on loopback
-// TODO: IPC socket supported?
 const Host = '127.0.0.1';
 
 /**
@@ -26,18 +27,29 @@ class AdminService {
     this.protocolImporter = new ProtocolImporter(dataDir);
   }
 
-  start(port) {
-    return new Promise((resolve, reject) => {
-      if (!port) {
-        reject(new Error('Missing port'));
-        return;
+  /**
+   * Start API listening on an open port.
+   * @param  {[type]} port [description]
+   * @return {Promise}
+   */
+  start(port = DefaultPort) {
+    const portNum = parseInt(port, 10);
+    return detectPort(portNum).then((availablePort) => {
+      if (portNum !== availablePort) {
+        logger.info(`Port ${portNum} taken. Trying ${availablePort}...`);
       }
-      this.api.listen(port, Host, () => {
-        this.port = port;
-        logger.info(`${this.api.name} listening at ${this.api.url}`);
-        resolve(this);
+      return new Promise((resolve) => {
+        // Technically the port may no longer be available;
+        // Node sets SO_REUSEADDR so port # is reused.
+        // TODO: determine if we need something more resilient.
+        this.api.listen(availablePort, Host, () => {
+          this.port = availablePort;
+          logger.info(`${this.api.name} listening at ${this.api.url}`);
+          resolve(this);
+        });
       });
     });
+    // TODO: decide on service failure case/messaging. Crash for now.
   }
 
   stop() {

--- a/src/renderer/components/ServerPanel.js
+++ b/src/renderer/components/ServerPanel.js
@@ -1,33 +1,41 @@
+/* eslint-disable */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { PanelItem } from '../components';
-import AdminApiClient from '../utils/adminApiClient';
+import withApiClient from './withApiClient';
 
 const getKeySnippet = key => key && key.slice(400, 416);
 
 const defaultServerOverview = {
   ip: 'x.x.x.x',
-  clients: 0,
   uptime: 0,
   publicKey: '',
 };
 
 class ServerPanel extends Component {
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.apiClient != prevState.apiClient) {
+      return { apiClient: nextProps.apiClient };
+    }
+    return null;
+  }
+
   constructor() {
     super();
     this.state = {
       version: '0.0.0',
-      notes: '',
     };
-    this.api = new AdminApiClient();
   }
 
-  componentDidMount() {
-    this.getServerHealth();
+  componentDidUpdate() {
+    this.getServerHealth(this.state.apiClient);
   }
 
   getServerHealth() {
-    this.api.get('/health')
+    if (!this.state.apiClient || this.state.serverOverview) {
+      return;
+    }
+    this.state.apiClient.get('/health')
       .then((resp) => {
         const { uptime, ip, publicKey } = resp.serverStatus;
         this.setState({
@@ -68,4 +76,8 @@ ServerPanel.propTypes = {
   className: PropTypes.string,
 };
 
-export default ServerPanel;
+export default withApiClient(ServerPanel);
+
+export {
+  ServerPanel as UnwrappedServerPanel,
+};

--- a/src/renderer/components/__tests__/ServerPanel-test.js
+++ b/src/renderer/components/__tests__/ServerPanel-test.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import ServerPanel from '../ServerPanel';
+import { UnwrappedServerPanel as ServerPanel } from '../ServerPanel';
 
 jest.mock('../../utils/adminApiClient');
 

--- a/src/renderer/components/withApiClient.js
+++ b/src/renderer/components/withApiClient.js
@@ -1,0 +1,33 @@
+/* eslint-disable */
+import React, { Component } from 'react';
+import { ipcRenderer } from 'electron';
+
+import AdminApiClient from '../utils/adminApiClient';
+
+// TODO: Channels are shared with main. Support shared build target.
+const ApiConnectionInfoChannel = 'API_INFO';
+const RequestApiConnectionInfoChannel = 'REQUEST_API_INFO';
+
+function withApiClient(WrappedComponent) {
+  // TODO: API port may change in face of crash/restart.
+  class ApiClientComponent extends Component {
+    constructor(props) {
+      super(props);
+      this.state = { apiClient: null };
+      ipcRenderer.send(RequestApiConnectionInfoChannel);
+      ipcRenderer.once(ApiConnectionInfoChannel, (event, apiInfo) => {
+        this.setState({ apiClient: new AdminApiClient(apiInfo.port) });
+      });
+    }
+
+    render() {
+      return (
+        <WrappedComponent {...this.props} apiClient={this.state.apiClient} />
+      );
+    }
+  }
+
+  return ApiClientComponent;
+}
+
+export default withApiClient;

--- a/src/renderer/utils/adminApiClient.js
+++ b/src/renderer/utils/adminApiClient.js
@@ -1,7 +1,3 @@
-const adminApiUrl = 'http://localhost:8080'; // FIXME
-
-const resolveRoute = route => `${adminApiUrl}/${route.replace(/^\//, '')}`;
-
 const consumeResponse = resp => (
   resp.json()
     .then((respJson) => {
@@ -13,37 +9,6 @@ const consumeResponse = resp => (
       throw errJson;
     })
 );
-
-/**
- * @memberof AdminApiClient.prototype
- * @param  {string} route
- * @param  {Object} data will be JSON.stringified into the request body
- * @return {Promise}
- */
-const post = (route, data) => {
-  let json;
-  try {
-    json = JSON.stringify(data);
-  } catch (err) {
-    return Promise.reject(err);
-  }
-
-  return fetch(resolveRoute(route),
-    {
-      method: 'POST',
-      body: json,
-      headers: new Headers({ 'Content-Type': 'application/json' }),
-    })
-    .then(consumeResponse);
-};
-
-/**
- * @memberof AdminApiClient.prototype
- * @param  {string} route
- * @return {Promise}
- */
-const get = route => fetch(resolveRoute(route))
-  .then(consumeResponse);
 
 /**
  * @class AdminApiClient
@@ -60,9 +25,44 @@ const get = route => fetch(resolveRoute(route))
  * the value will contain a `message` property, with a short description of the problem.
  */
 class AdminApiClient {
-  constructor() {
-    this.get = get;
-    this.post = post;
+  constructor(listeningPort = 8080) {
+    this.port = listeningPort;
+  }
+
+  /**
+   * @param  {string} route
+   * @return {Promise}
+   */
+  get(route) {
+    return fetch(this.resolveRoute(route)).then(consumeResponse);
+  }
+
+  /**
+   * @param  {string} route
+   * @param  {Object} data will be JSON.stringified into the request body
+   * @return {Promise}
+   */
+  post(route, data) {
+    let json;
+    try {
+      json = JSON.stringify(data);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+
+    return fetch(this.resolveRoute(route),
+      {
+        method: 'POST',
+        body: json,
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+      })
+      .then(consumeResponse);
+  }
+
+  resolveRoute(route) {
+    // TODO: https
+    const protocol = 'http';
+    return `${protocol}://localhost:${this.port}/${route.replace(/^\//, '')}`;
   }
 }
 


### PR DESCRIPTION
This makes the Admin API find an available port when starting up, so that it doesn't clash with any process that might be running on a host machine. This API is opaque to the user; it only serves the GUI on localhost.

This adds `detect-port` as a direct dependency to do the real work. 

Resolves #57.

I believe there's an upcoming requirement to allow user configuration of the Device API; will address that as needed in the future (past alpha/v1).