### PR TITLE
Speed up ServerFactory test

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,9 @@
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}"
     ],
+    "modulePathIgnorePatterns": [
+      "electron-dev/"
+    ],
     "setupFiles": [
       "<rootDir>/config/polyfills.js",
       "<rootDir>/config/jest/polyfills.js",

--- a/src/main/server/__tests__/ServerFactory-test.js
+++ b/src/main/server/__tests__/ServerFactory-test.js
@@ -8,6 +8,10 @@ const mockServerMethods = {
   startServices: jest.fn(() => Promise.resolve(mockServerMethods)), // startServices returns `this`
 };
 
+jest.mock('private-socket', () => ({
+  generatePemKeyPair: jest.fn().mockResolvedValue({}),
+}));
+
 jest.mock('../Server', () => function MockServer() {
   return mockServerMethods;
 });


### PR DESCRIPTION
Don't generate PEM keypair, which is intentionally slow. Hopefully this is the source of intermittent Travis timeouts, and resolves #90.