### PR TITLE
Fix content sizing

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -29,6 +29,11 @@ const dialog = {
   showOpenDialog: jest.fn(),
 };
 
+const remote = {
+  process: {
+    platform: '',
+  },
+};
 
 const Tray = jest.fn().mockImplementation(() => ({
   setContextMenu: jest.fn(),
@@ -66,6 +71,7 @@ module.exports = {
   dialog,
   ipcMain,
   ipcRenderer,
+  remote,
 };
 
 exports.BrowserWindow = BrowserWindow;

--- a/src/renderer/components/charts/PieChart.js
+++ b/src/renderer/components/charts/PieChart.js
@@ -24,7 +24,6 @@ const PieChart = ({ className, data }) => (
         data={data}
         dataKey="value"
         nameKey="name"
-        outerRadius={100}
       >
         {data.map((entry, index) => <Cell key={index} fill={colors[index % colors.length]} />)}
       </Pie>

--- a/src/renderer/containers/App.js
+++ b/src/renderer/containers/App.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { ipcRenderer } from 'electron';
+import { ipcRenderer, remote } from 'electron';
 import { withRouter } from 'react-router-dom';
 
 import AppRoutes from './AppRoutes';
@@ -12,6 +12,8 @@ import { AnimatedPairPrompt } from '../components/pairing/PairPrompt';
 import { actionCreators, PairingStatus } from '../ducks/modules/pairingRequest';
 import { actionCreators as deviceActionCreators } from '../ducks/modules/devices';
 import { actionCreators as messageActionCreators } from '../ducks/modules/appMessages';
+
+const isFrameless = remote.process.platform === 'darwin';
 
 // This prevents user from being able to drop a file anywhere on the app
 // (which by default triggers a 'save' dialog). If we want to support this,
@@ -64,8 +66,11 @@ class App extends Component {
       appMessages,
       pairingRequest,
     } = this.props;
+
+    const appClass = isFrameless ? 'app app--frameless' : 'app';
+
     return (
-      <div className="app">
+      <div className={appClass}>
         <div role="Button" tabIndex="0" className="app__flash" onClick={dismissAppMessages}>
           { appMessages.map(msg => <AppMessage key={msg.timestamp} {...msg} />) }
         </div>

--- a/src/renderer/styles/_variables.scss
+++ b/src/renderer/styles/_variables.scss
@@ -10,6 +10,7 @@
   --recessed-border-color: var(--color-platinum);
 
   // Type
+  --base-font-size: 14px;
   --code-font: monospace;
 
   // Layout

--- a/src/renderer/styles/components/_dashboard.scss
+++ b/src/renderer/styles/components/_dashboard.scss
@@ -1,11 +1,12 @@
 .dashboard {
   $min-grid-row: 18rem;
   $top-grid-row: 1rem;
+  $column-count: 3;
 
   display: grid;
   grid-auto-rows: minmax($min-grid-row, auto);
   grid-gap: spacing(medium);
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat($column-count, 1fr);
   grid-template-rows: minmax($top-grid-row, auto) auto;
 
   @include element(panel) {
@@ -13,7 +14,7 @@
     padding: spacing(small);
 
     @include modifier(server-stats) {
-      grid-area: 1 / span 2;
+      grid-area: 1 / span $column-count;
     }
   }
 }

--- a/src/renderer/styles/components/_protocol-thumbnail.scss
+++ b/src/renderer/styles/components/_protocol-thumbnail.scss
@@ -14,7 +14,7 @@
   display: block;
   font-size: 2rem;
   height: var(--thumbnail-size);
-  line-height: calc(var(--thumbnail-size) - var(--border-width));
+  line-height: calc(var(--thumbnail-size) - 2 * var(--border-width));
   margin: spacing('medium') auto;
   overflow: visible;
   position: relative;

--- a/src/renderer/styles/components/_tab-bar.scss
+++ b/src/renderer/styles/components/_tab-bar.scss
@@ -1,7 +1,4 @@
 .tab-bar {
-  background-color: var(--recessed-background-color);
-  padding-top: var(--app-titlebar-height);
-
   @include element(link) {
     border-right: 1px solid var(--base-border-color);
     color: palette(text-dark);

--- a/src/renderer/styles/components/pairing-instructions.scss
+++ b/src/renderer/styles/components/pairing-instructions.scss
@@ -33,7 +33,7 @@
   &__add-icon {
     &[name='add-a-screen'] {
       height: var(--icon-height);
-      vertical-align: -11px;
+      vertical-align: -.5rem;
       width: var(--icon-height);
     }
   }

--- a/src/renderer/styles/containers/_app.scss
+++ b/src/renderer/styles/containers/_app.scss
@@ -28,6 +28,7 @@
     color: var(--inverse-text-color);
     flex: none;
     height: 100%;
+    padding-top: var(--app-titlebar-height);
     width: var(--app-sidebar-width);
 
     // Ensure contained content fills entire height

--- a/src/renderer/styles/containers/_app.scss
+++ b/src/renderer/styles/containers/_app.scss
@@ -1,18 +1,26 @@
 .app {
+  background-color: var(--recessed-background-color);
   display: flex;
   flex-direction: column;
   height: 100%;
 
-  @include element(titlebar) {
-    -webkit-app-region: drag; // sass-lint:disable-line no-vendor-prefixes
-    display: block;
-    height: var(--app-titlebar-height);
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-    visibility: visible;
-    width: 100%;
+  @include modifier(frameless) {
+    .app__titlebar {
+      -webkit-app-region: drag; // sass-lint:disable-line no-vendor-prefixes
+      display: block;
+      height: var(--app-titlebar-height);
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+      visibility: visible;
+      width: 100%;
+    }
+
+    .app__sidebar,
+    .app__screen {
+      padding-top: var(--app-titlebar-height);
+    }
   }
 
   // everything below the header


### PR DESCRIPTION
Resolves #116

- Update base font size to 14px
- Use three cols for workspace; looks a little better with smaller text
- Only show title bar (padding) when frameless

Note: titlebar height is set in `px`, but if we're looking for screen pixels and not CSS pixels (so that user zoom doesn't affect the size of the top draggable area on macOS), then I'll need to do some more work. Possibly setting those values to a calculated % or vh unit, and recalculating on window resize.

Mac:
![macos](https://user-images.githubusercontent.com/39674/41304747-0274baa0-6e3f-11e8-888e-00f58c0f1220.png)

Win:
![win](https://user-images.githubusercontent.com/39674/41304748-02815b2a-6e3f-11e8-9a73-9416ce0b97e1.png)
