### PR TITLE
Clarify "not found" message for import failure

### DIFF
--- a/src/main/data-managers/ProtocolManager.js
+++ b/src/main/data-managers/ProtocolManager.js
@@ -361,7 +361,7 @@ class ProtocolManager {
     return this.getProtocol(protocolId)
       .then((protocol) => {
         if (!protocol) {
-          throw new RequestError(ErrorMessages.NotFound);
+          throw new RequestError(ErrorMessages.ProtocolNotFoundForSession);
         }
         return this.sessionDb.insertAllForProtocol(sessionOrSessions, protocol);
       })

--- a/src/main/data-managers/__tests__/ProtocolManager-test.js
+++ b/src/main/data-managers/__tests__/ProtocolManager-test.js
@@ -401,7 +401,7 @@ describe('ProtocolManager', () => {
       it('rejects if adding to an unknown protocol', async () => {
         manager.db.get = jest.fn().mockResolvedValue(null);
         await expect(manager.addSessionData(null, []))
-          .rejects.toMatchErrorMessage(errorMessages.NotFound);
+          .rejects.toMatchErrorMessage(errorMessages.ProtocolNotFoundForSession);
       });
     });
   });

--- a/src/main/errors/RequestError.js
+++ b/src/main/errors/RequestError.js
@@ -26,6 +26,7 @@ const ErrorMessages = {
   InvalidZip: 'Invalid ZIP File',
   MissingProtocolFile: 'Missing protocol file',
   NotFound: 'Not Found',
+  ProtocolNotFoundForSession: 'The associated protocol does not exist on this server',
   VerificationFailed: 'Request verification failed',
 };
 


### PR DESCRIPTION
Currently, error message is displayed directly to users, and "Not Found" is unclear.