### PR TITLE
Update UI when sessions are imported

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -19,11 +19,13 @@ createServer(8080, userDataDir).then((runningServer) => {
   // Renderer may be ready before server, in which case send:
   mainWindow.send(ApiConnectionInfoChannel, server.connectionInfo.adminService);
 
-  ipcMain.on(RequestFileImportDialog, showImportProtocolDialog);
-
   ipcMain.on(RequestApiConnectionInfoChannel, (evt) => {
     evt.sender.send(ApiConnectionInfoChannel, server.connectionInfo.adminService);
   });
+
+  ipcMain.on(RequestFileImportDialog, showImportProtocolDialog);
+
+  server.on(serverEvents.SESSIONS_IMPORTED, () => mainWindow.send(serverEvents.SESSIONS_IMPORTED));
 
   // TODO: if send() returns false, let server know so client request can be dropped?
   server.on(serverEvents.PAIRING_CODE_AVAILABLE, (data) => {

--- a/src/main/server/devices/__tests__/DeviceService-test.js
+++ b/src/main/server/devices/__tests__/DeviceService-test.js
@@ -1,6 +1,8 @@
 /* eslint-env jest */
 const { DeviceService, deviceServiceEvents } = require('../DeviceService');
+const { apiEvents } = require('../DeviceAPI');
 
+jest.mock('electron-log');
 jest.mock('../PairingRequestService');
 jest.mock('../DeviceAPI');
 
@@ -12,6 +14,7 @@ describe('Device Service', () => {
   beforeEach(() => {
     deviceService = new DeviceService({});
     deviceService.emit = jest.fn();
+    deviceService.api.on.mockClear();
   });
 
   it('emits an event when a new PIN is created (for out-of-band transfer)', (done) => {
@@ -29,5 +32,17 @@ describe('Device Service', () => {
       done();
     });
     deviceService.outOfBandDelegate.pairingDidComplete();
+  });
+
+  it('delegates session import event to API', () => {
+    const listener = jest.fn();
+    const evtName = apiEvents.SESSIONS_IMPORTED;
+    deviceService.on(evtName, listener);
+    expect(deviceService.api.on).toHaveBeenCalledWith(evtName, listener);
+  });
+
+  it('ignores other events', () => {
+    deviceService.on('not-an-event', jest.fn());
+    expect(deviceService.api.on).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/containers/SessionPanel.js
+++ b/src/renderer/containers/SessionPanel.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import logger from 'electron-log';
+import { ipcRenderer } from 'electron';
 
 import withApiClient from '../components/withApiClient';
 import viewModelMapper from '../utils/baseViewModelMapper';
@@ -22,6 +23,7 @@ class SessionPanel extends Component {
 
   componentDidMount() {
     this.loadSessions();
+    ipcRenderer.on('SESSIONS_IMPORTED', this.onSessionsImported);
   }
 
   componentDidUpdate(prevProps) {
@@ -31,6 +33,12 @@ class SessionPanel extends Component {
       this.loadSessions();
     }
   }
+
+  componentWillUnmount() {
+    ipcRenderer.removeListener('SESSIONS_IMPORTED', this.onSessionsImported);
+  }
+
+  onSessionsImported = () => this.loadSessions()
 
   get sessionsEndpoint() {
     const id = this.props.protocolId;

--- a/src/renderer/containers/__tests__/SessionPanel-test.js
+++ b/src/renderer/containers/__tests__/SessionPanel-test.js
@@ -2,6 +2,8 @@
 
 import React from 'react';
 import { mount, shallow } from 'enzyme';
+import { ipcRenderer } from 'electron';
+
 import { UnwrappedSessionPanel as SessionPanel } from '../SessionPanel';
 import viewModelMapper from '../../utils/baseViewModelMapper';
 
@@ -51,8 +53,23 @@ describe('<SessionPanel />', () => {
 
     it('loads again on update', () => {
       const subject = shallow(<SessionPanel protocolId={'1'} apiClient={mockApiClient} />);
+      subject.instance().loadPromise = null;
       subject.setProps({ protocolId: '2' });
       expect(apiClient.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('loads again when imports available', () => {
+      const subject = shallow(<SessionPanel protocolId={'1'} apiClient={mockApiClient} />);
+      subject.instance().loadPromise = null;
+      subject.instance().onSessionsImported();
+      expect(apiClient.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes ipc handler before unmount', () => {
+      const subject = shallow(<SessionPanel protocolId={'1'} apiClient={mockApiClient} />);
+      const handler = subject.instance().onSessionsImported;
+      subject.unmount();
+      expect(ipcRenderer.removeListener).toHaveBeenCalledWith('SESSIONS_IMPORTED', handler);
     });
 
     describe('deletion', () => {


### PR DESCRIPTION
When data is imported from a device, the relevant session panel should refresh if it's visible. (Currently, the user has to refresh.)