### PR TITLE
Fix startup states

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -3,6 +3,7 @@ const logger = require('electron-log');
 
 const { createApp, userDataDir } = require('./MainApp');
 const { createServer, serverEvents } = require('./server/ServerFactory');
+const { DefaultApiPort } = require('./server/devices/DeviceService');
 
 const ApiConnectionInfoChannel = 'API_INFO';
 const RequestApiConnectionInfoChannel = 'REQUEST_API_INFO';
@@ -11,7 +12,7 @@ const RequestFileImportDialog = 'REQUEST_FILE_IMPORT_DIALOG';
 const { app, mainWindow, showImportProtocolDialog } = createApp();
 
 let server = null;
-createServer(8080, userDataDir).then((runningServer) => {
+createServer(DefaultApiPort, userDataDir).then((runningServer) => {
   server = runningServer;
 
   app.on('before-quit', () => server.close());

--- a/src/main/server/Server.js
+++ b/src/main/server/Server.js
@@ -24,9 +24,8 @@ class Server extends EventEmitter {
     this.deviceService = new DeviceService({ dataDir });
 
     return Promise.all([
-      // TODO: use port param for device Service
-      this.adminService.start(port),
-      this.deviceService.start().then(service => this.advertiseDeviceService(service)),
+      this.adminService.start(),
+      this.deviceService.start(port).then(service => this.advertiseDeviceService(service)),
     ]).then(() => this);
   }
 
@@ -41,15 +40,16 @@ class Server extends EventEmitter {
     };
   }
 
-  // TODO: return promise of all
   close() {
+    const promises = [];
     if (this.deviceService) {
-      this.deviceService.stop();
+      promises.push(this.deviceService.stop());
     }
     if (this.adminService) {
-      this.adminService.stop();
+      promises.push(this.adminService.stop());
     }
     this.stopAdvertisements();
+    return Promise.all(promises);
   }
 
   advertiseDeviceService(deviceService) {

--- a/src/main/server/devices/DeviceAPI.js
+++ b/src/main/server/devices/DeviceAPI.js
@@ -25,7 +25,7 @@ const lanIP = () => {
   return iface && iface.address;
 };
 
-const ApiName = 'DevciceAPI';
+const ApiName = 'DeviceAPI';
 const ApiVersion = '0.0.9';
 const ApiHostName = '0.0.0.0'; // IPv4 for compatibility with Travis (& unknown installations)
 

--- a/src/main/server/devices/DeviceService.js
+++ b/src/main/server/devices/DeviceService.js
@@ -45,6 +45,10 @@ class DeviceService extends EventEmitter {
     });
   }
 
+  /**
+   * @async
+   * @return {Promise}
+   */
   stop() {
     return this.api.close();
   }

--- a/src/renderer/components/ProtocolThumbnails.js
+++ b/src/renderer/components/ProtocolThumbnails.js
@@ -7,7 +7,7 @@ import Types from '../types';
 const ProtocolThumbnails = ({ location, protocols, onClickAddProtocol }) => (
   <div>
     {
-      protocols.map(protocol => (
+      protocols && protocols.map(protocol => (
         <ProtocolThumbnail location={location} protocol={protocol} key={protocol.id} />
       ))
     }

--- a/src/renderer/components/ServerPanel.js
+++ b/src/renderer/components/ServerPanel.js
@@ -19,6 +19,10 @@ class ServerPanel extends Component {
     };
   }
 
+  componentWillMount() {
+    this.getServerHealth();
+  }
+
   componentDidUpdate() {
     this.getServerHealth();
   }

--- a/src/renderer/components/__tests__/withApiClient-test.js
+++ b/src/renderer/components/__tests__/withApiClient-test.js
@@ -22,42 +22,4 @@ describe('withApiClient HOC', () => {
     expect(wrapped.prop('apiClient')).toBeDefined();
     expect(wrapped.is('MockComponent')).toBe(true);
   });
-
-  describe('IPC', () => {
-    it('requests API connection info when created', () => {
-      React.createElement(withApiClient(MockComponent));
-      expect(ipcRenderer.send).toHaveBeenCalledWith(IPC.RequestApiConnectionInfoChannel);
-    });
-
-    it('registers a callback for API connection info', () => {
-      React.createElement(withApiClient(MockComponent));
-      expect(ipcRenderer.once).toHaveBeenCalledWith(
-        IPC.ApiConnectionInfoChannel,
-        expect.any(Function),
-      );
-    });
-
-    describe('when notified by server', () => {
-      let callOnce;
-      beforeAll(() => {
-        ipcRenderer.once.mockImplementation((channel, cb) => {
-          callOnce = cb;
-        });
-      });
-
-      it('creates an apiClient in state when server ready', () => {
-        const mounted = mount(React.createElement(withApiClient(MockComponent)));
-        expect(mounted.state('apiClient')).toBeNull();
-        callOnce(IPC.ApiConnectionInfoChannel, { port: 12345 });
-        expect(mounted.state('apiClient')).toBeInstanceOf(AdminApiClient);
-      });
-
-      it('passes apiClient state to child props', () => {
-        const mounted = mount(React.createElement(withApiClient(MockComponent)));
-        callOnce(IPC.ApiConnectionInfoChannel, { port: 12345 });
-        mounted.mount(); // re-mount to force props change from state
-        expect(mounted.find('MockComponent').prop('apiClient')).toBeInstanceOf(AdminApiClient);
-      });
-    });
-  });
 });

--- a/src/renderer/components/__tests__/withApiClient-test.js
+++ b/src/renderer/components/__tests__/withApiClient-test.js
@@ -1,10 +1,8 @@
 /* eslint-env jest */
 import React from 'react';
-import { mount, shallow } from 'enzyme';
-import { ipcRenderer } from 'electron';
+import { shallow } from 'enzyme';
 
-import withApiClient, { IPC } from '../withApiClient';
-import AdminApiClient from '../../utils/adminApiClient';
+import withApiClient from '../withApiClient';
 
 jest.mock('electron');
 

--- a/src/renderer/components/withApiClient.js
+++ b/src/renderer/components/withApiClient.js
@@ -1,22 +1,12 @@
 import React, { Component } from 'react';
-import { ipcRenderer } from 'electron';
 
 import AdminApiClient from '../utils/adminApiClient';
 
-// TODO: Channels are shared with main. Support shared build target.
-const ApiConnectionInfoChannel = 'API_INFO';
-const RequestApiConnectionInfoChannel = 'REQUEST_API_INFO';
-
 function withApiClient(WrappedComponent) {
-  // TODO: API port may change in face of crash/restart.
   class ApiClientComponent extends Component {
     constructor(props) {
       super(props);
-      this.state = { apiClient: null };
-      ipcRenderer.send(RequestApiConnectionInfoChannel);
-      ipcRenderer.once(ApiConnectionInfoChannel, (event, apiInfo) => {
-        this.setState({ apiClient: new AdminApiClient(apiInfo.port) });
-      });
+      this.state = { apiClient: new AdminApiClient() };
     }
 
     render() {
@@ -30,12 +20,3 @@ function withApiClient(WrappedComponent) {
 }
 
 export default withApiClient;
-
-const IPC = {
-  ApiConnectionInfoChannel,
-  RequestApiConnectionInfoChannel,
-};
-
-export {
-  IPC,
-};

--- a/src/renderer/containers/DeviceStatus.js
+++ b/src/renderer/containers/DeviceStatus.js
@@ -31,7 +31,7 @@ class DeviceStatus extends Component {
       <React.Fragment>
         <button className={buttonClass} onClick={this.toggleShow}>
           <span className="device-icon__badge">
-            {devices.length}
+            {devices ? devices.length : ''}
           </span>
         </button>
         <PairedDeviceModal

--- a/src/renderer/containers/OverviewScreen.js
+++ b/src/renderer/containers/OverviewScreen.js
@@ -18,7 +18,11 @@ class OverviewScreen extends Component {
     if (protocols && protocols.length) {
       return <Redirect to={`/workspaces/${protocols[0].id}`} />;
     }
-    return <Instructions devices={devices} />;
+    if (devices) {
+      return <Instructions devices={devices} />;
+    }
+    // else still loading...
+    return null;
   }
 }
 

--- a/src/renderer/containers/WorkspaceScreen.js
+++ b/src/renderer/containers/WorkspaceScreen.js
@@ -36,7 +36,7 @@ class WorkspaceScreen extends Component {
 }
 
 const mapStateToProps = ({ currentProtocolId, protocols }) => ({
-  protocol: protocols.find(p => p.id === currentProtocolId),
+  protocol: protocols && protocols.find(p => p.id === currentProtocolId),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/renderer/containers/__tests__/DeviceStatus-test.js
+++ b/src/renderer/containers/__tests__/DeviceStatus-test.js
@@ -33,4 +33,15 @@ describe('<DeviceStatus />', () => {
     shallow(<DeviceStatus loadDevices={mockLoader} />);
     expect(mockLoader).toHaveBeenCalledTimes(1);
   });
+
+  it('renders an empty badge before load', () => {
+    const subject = shallow(<DeviceStatus devices={null} />);
+    expect(subject.find('.device-icon__badge').text()).toEqual('');
+  });
+
+  it('renders a dark button variant', () => {
+    const subject = shallow(<DeviceStatus dark />);
+    const btnClass = subject.find('button').prop('className');
+    expect(btnClass).toContain('--dark');
+  });
 });

--- a/src/renderer/containers/__tests__/OverviewScreen-test.js
+++ b/src/renderer/containers/__tests__/OverviewScreen-test.js
@@ -7,8 +7,14 @@ import { UnconnectedOverviewScreen as OverviewScreen } from '../OverviewScreen';
 describe('<OverviewScreen />', () => {
   const loadDevices = jest.fn();
 
-  it('renders startup instructions', () => {
+  it('renders nothing while loading', () => {
     const subject = shallow(<OverviewScreen loadDevices={loadDevices} />);
+    expect(subject.find('Instructions')).toHaveLength(0);
+  });
+
+  it('renders startup instructions when empty data loaded', () => {
+    const props = { loadDevices, devices: [] };
+    const subject = shallow(<OverviewScreen {...props} />);
     expect(subject.find('Instructions')).toHaveLength(1);
   });
 

--- a/src/renderer/ducks/modules/__tests__/devices-test.js
+++ b/src/renderer/ducks/modules/__tests__/devices-test.js
@@ -6,12 +6,17 @@ jest.mock('../../../utils/adminApiClient');
 
 describe('the devices module', () => {
   describe('reducer', () => {
-    it('has empty state by default', () => {
-      expect(reducer(undefined)).toEqual([]);
+    it('has null state by default', () => {
+      expect(reducer(undefined)).toEqual(null);
     });
 
     it('is unchanged when loading', () => {
       const state = reducer(undefined, { type: actionTypes.LOAD_DEVICES });
+      expect(state).toEqual(null);
+    });
+
+    it('is array when done loading', () => {
+      const state = reducer(undefined, { type: actionTypes.DEVICES_LOADED, devices: [] });
       expect(state).toEqual([]);
     });
 

--- a/src/renderer/ducks/modules/__tests__/protocols-test.js
+++ b/src/renderer/ducks/modules/__tests__/protocols-test.js
@@ -6,12 +6,20 @@ jest.mock('../../../utils/adminApiClient');
 
 describe('the protocols module', () => {
   describe('reducer', () => {
-    it('has empty state by default', () => {
-      expect(reducer(undefined)).toEqual([]);
+    it('has null state by default', () => {
+      expect(reducer(undefined)).toEqual(null);
     });
 
     it('is unchanged when loading', () => {
       const state = reducer(undefined, { type: actionTypes.LOAD_PROTOCOLS });
+      expect(state).toEqual(null);
+    });
+
+    it('is array when done loading', () => {
+      const state = reducer(undefined, {
+        type: actionTypes.PROTOCOLS_LOADED,
+        protocols: [],
+      });
       expect(state).toEqual([]);
     });
 

--- a/src/renderer/ducks/modules/devices.js
+++ b/src/renderer/ducks/modules/devices.js
@@ -6,9 +6,16 @@ import viewModelMapper from '../../utils/baseViewModelMapper';
 const LOAD_DEVICES = 'LOAD_DEVICES';
 const DEVICES_LOADED = 'DEVICES_LOADED';
 
-const initialState = [];
+// Null state: Load has not completed
+const initialState = null;
 
-const apiClient = new AdminApiClient();
+let sharedApiClient = null;
+const getApiClient = () => {
+  if (!sharedApiClient) {
+    sharedApiClient = new AdminApiClient();
+  }
+  return sharedApiClient;
+};
 
 const reducer = (state = initialState, action = {}) => {
   switch (action.type) {
@@ -27,12 +34,12 @@ const loadDevicesDispatch = () => ({
 
 const devicesLoadedDispatch = devices => ({
   type: DEVICES_LOADED,
-  devices,
+  devices: devices || [],
 });
 
 const loadDevices = () => (dispatch) => {
   dispatch(loadDevicesDispatch());
-  apiClient.get('/devices')
+  getApiClient().get('/devices')
     .then(resp => resp.devices)
     .then(devices => dispatch(devicesLoadedDispatch(devices)))
     .catch((err) => {

--- a/src/renderer/ducks/modules/protocols.js
+++ b/src/renderer/ducks/modules/protocols.js
@@ -27,7 +27,7 @@ const loadProtocolsDispatch = () => ({
 
 const protocolsLoadedDispatch = protocols => ({
   type: PROTOCOLS_LOADED,
-  protocols,
+  protocols: protocols || [],
 });
 
 const loadProtocols = () => (dispatch) => {

--- a/src/renderer/ducks/modules/protocols.js
+++ b/src/renderer/ducks/modules/protocols.js
@@ -6,9 +6,16 @@ import viewModelMapper from '../../utils/baseViewModelMapper';
 const LOAD_PROTOCOLS = 'LOAD_PROTOCOLS';
 const PROTOCOLS_LOADED = 'PROTOCOLS_LOADED';
 
-const initialState = [];
+// Null state: Load has not completed
+const initialState = null;
 
-const apiClient = new AdminApiClient();
+let sharedApiClient = null;
+const getApiClient = () => {
+  if (!sharedApiClient) {
+    sharedApiClient = new AdminApiClient();
+  }
+  return sharedApiClient;
+};
 
 const reducer = (state = initialState, action = {}) => {
   switch (action.type) {
@@ -32,7 +39,7 @@ const protocolsLoadedDispatch = protocols => ({
 
 const loadProtocols = () => (dispatch) => {
   dispatch(loadProtocolsDispatch());
-  apiClient.get('/protocols')
+  getApiClient().get('/protocols')
     .then(resp => resp.protocols)
     .then(protocols => dispatch(protocolsLoadedDispatch(protocols)))
     .catch((err) => {

--- a/src/renderer/styles/containers/_app.scss
+++ b/src/renderer/styles/containers/_app.scss
@@ -4,6 +4,13 @@
   flex-direction: column;
   height: 100%;
 
+  @include modifier(loading) {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    width: 100%;
+  }
+
   @include modifier(frameless) {
     .app__titlebar {
       -webkit-app-region: drag; // sass-lint:disable-line no-vendor-prefixes

--- a/src/renderer/utils/__tests__/adminApiClient-test.js
+++ b/src/renderer/utils/__tests__/adminApiClient-test.js
@@ -12,6 +12,15 @@ describe('an AdminApiClient', () => {
     fetch.resetMocks();
   });
 
+  it('has no static port', () => {
+    expect(new AdminApiClient().port).toBe(null);
+  });
+
+  it('sets port for all clients', () => {
+    AdminApiClient.setPort(123);
+    expect(new AdminApiClient().port).toBe(123);
+  });
+
   it('can get the server status', async () => {
     const mockStatus = { uptime: 100 };
     fetch.mockResponse(JSON.stringify({ serverStatus: mockStatus }));

--- a/src/renderer/utils/adminApiClient.js
+++ b/src/renderer/utils/adminApiClient.js
@@ -25,8 +25,12 @@ const consumeResponse = resp => (
  * the value will contain a `message` property, with a short description of the problem.
  */
 class AdminApiClient {
-  constructor(listeningPort = 8080) {
-    this.port = listeningPort;
+  static setPort(port) {
+    this.port = port;
+  }
+
+  get port() {
+    return this.constructor.port || null;
   }
 
   /**


### PR DESCRIPTION
- Centralize API port handling & ensure ready before app rendering. Fixes #122.
- Do not flash Instructions while data is still loading
- Use port argument for API to clean up some tests

To test the port fix:
- Have an instance of server with added data (protocols, etc)
- Start any other service on port 8080
- Expect to see "Port 8080 taken. Trying [next available port]..." in server startup logs
- Expect UI to render saved data (protocols, etc)
    - (On master, this step fails; API clients from ducks/modules are using incorrect port)
