### PR TITLE
Require device tokens as usernames

### DIFF
--- a/src/main/data-managers/DatabaseAdapter.js
+++ b/src/main/data-managers/DatabaseAdapter.js
@@ -44,6 +44,36 @@ class DatabaseAdapter {
       this.db.find({}).sort(mostRecent).exec(resolveOrReject(resolve, reject));
     });
   }
+
+  /**
+   * Get the first document matching the query
+   * @async
+   * @param {Object} query
+   * @return {Object|null} the matching document, or null if not found
+   * @throws {Error}
+   */
+  first(query) {
+    return new Promise((resolve, reject) => {
+      this.db.findOne(query, (err, doc) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(doc);
+        }
+      });
+    });
+  }
+
+  /**
+   * Get the document matching ID
+   * @async
+   * @param {string} id
+   * @return {Object|null} the document, or null if not found
+   * @throws {Error}
+   */
+  get(id) {
+    return this.first({ _id: id });
+  }
 }
 
 module.exports = DatabaseAdapter;

--- a/src/main/data-managers/DeviceDB.js
+++ b/src/main/data-managers/DeviceDB.js
@@ -10,6 +10,7 @@ const withDefaultName = dbDevice => ({
 
 /**
  * @class
+ * @extends DatabaseAdapter
  */
 class DeviceDB extends DatabaseAdapter {
   create(secretHex, deviceName) {

--- a/src/main/data-managers/DeviceManager.js
+++ b/src/main/data-managers/DeviceManager.js
@@ -8,6 +8,10 @@ class DeviceManager {
     this.db = new DeviceDB(dbFile);
   }
 
+  exists(deviceId) {
+    return this.db.get(deviceId);
+  }
+
   // TODO: see notes in cipher.js; may want to persist derivation config per-device.
   // TODO: Validate format/lengths. Require arg names for clarity?
   createDeviceDocument(secretHex, deviceName) {

--- a/src/main/data-managers/ProtocolDB.js
+++ b/src/main/data-managers/ProtocolDB.js
@@ -22,6 +22,7 @@ const validatedModifyTime = (protocol) => {
 
 /**
  * @class
+ * @extends DatabaseAdapter
  */
 class ProtocolDB extends DatabaseAdapter {
   /**
@@ -116,36 +117,6 @@ class ProtocolDB extends DatabaseAdapter {
         }
       });
     });
-  }
-
-  /**
-   * Get the first protocol matching the query
-   * @async
-   * @param {Object} query
-   * @return {Object} a persisted protocol
-   * @throws {Error}
-   */
-  first(query) {
-    return new Promise((resolve, reject) => {
-      this.db.findOne(query, (err, doc) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(doc);
-        }
-      });
-    });
-  }
-
-  /**
-   * Get the protocol matching ID
-   * @async
-   * @param {Object} id
-   * @return {Object} a persisted protocol
-   * @throws {Error}
-   */
-  get(id) {
-    return this.first({ _id: id });
   }
 }
 

--- a/src/main/data-managers/SessionDB.js
+++ b/src/main/data-managers/SessionDB.js
@@ -10,6 +10,7 @@ const sessionDataField = 'data';
 
 /**
  * @class
+ * @extends DatabaseAdapter
  */
 class SessionDB extends DatabaseAdapter {
   /**

--- a/src/main/server/devices/__tests__/deviceAuthenticator-test.js
+++ b/src/main/server/devices/__tests__/deviceAuthenticator-test.js
@@ -1,0 +1,65 @@
+/* eslint-env jest */
+import { InvalidCredentialsError, NotAuthorizedError } from 'restify-errors';
+
+import deviceAuthenticator from '../deviceAuthenticator';
+
+let authHandler;
+
+const req = {
+  authorization: {},
+  getRoute: jest.fn().mockReturnValue(''),
+};
+
+const reqWithAuth = {
+  ...req,
+  authorization: { scheme: 'Basic' },
+  username: 'a692d57c-ab0f-4aa4-8e52-565a585990da',
+};
+
+const res = { header: jest.fn() };
+const next = jest.fn().mockReturnValue(33);
+
+describe('deviceAuthenticator', () => {
+  beforeEach(() => {
+    authHandler = deviceAuthenticator({ exists: jest.fn().mockResolvedValue(true) });
+  });
+
+  describe('when request has valid credentials', () => {
+    it('passes to next handler', async () => {
+      await authHandler(reqWithAuth, res, next);
+      expect(next).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('when request doesn’t use Basic auth', () => {
+    it('passes to next handler', async () => {
+      await authHandler(req, res, next);
+      expect(next).toHaveBeenCalledWith(expect.any(InvalidCredentialsError));
+    });
+  });
+
+  describe('when Basic auth request has no credentials', () => {
+    it('passes to next handler', async () => {
+      await authHandler({ ...req, authorization: { scheme: 'Basic' } }, res, next);
+      expect(next).toHaveBeenCalledWith(expect.any(InvalidCredentialsError));
+    });
+  });
+
+  describe('when request has invalid credentials', () => {
+    it('passes to next handler', async () => {
+      authHandler = deviceAuthenticator({ exists: jest.fn().mockResolvedValue(false) });
+      await authHandler(reqWithAuth, res, next);
+      expect(next).toHaveBeenCalledWith(expect.any(NotAuthorizedError));
+    });
+  });
+
+  describe('when path doesn’t require auth', () => {
+    it('passes to next handler', async () => {
+      const publicPath = '/no-auth-required';
+      req.getRoute.mockReturnValue({ path: publicPath });
+      authHandler = deviceAuthenticator({}, [publicPath]);
+      await authHandler(req, res, next);
+      expect(next).toHaveBeenCalledWith();
+    });
+  });
+});

--- a/src/main/server/devices/deviceAuthenticator.js
+++ b/src/main/server/devices/deviceAuthenticator.js
@@ -19,12 +19,12 @@ const deviceAuthenticator = (deviceManager, exceptPaths = []) => (req, res, next
 
   if (!req.authorization.scheme || req.authorization.scheme !== 'Basic') {
     res.header('WWW-Authenticate', 'Basic');
-    next(new InvalidCredentialsError());
+    next(new InvalidCredentialsError('Invalid Credentials'));
     return;
   }
 
   if (!req.username || req.username === 'anonymous') {
-    next(new InvalidCredentialsError());
+    next(new InvalidCredentialsError('Invalid Credentials'));
     return;
   }
 
@@ -32,7 +32,7 @@ const deviceAuthenticator = (deviceManager, exceptPaths = []) => (req, res, next
     if (exists) {
       next();
     } else {
-      next(new NotAuthorizedError());
+      next(new NotAuthorizedError('Unauthorized'));
     }
   });
 };

--- a/src/main/server/devices/deviceAuthenticator.js
+++ b/src/main/server/devices/deviceAuthenticator.js
@@ -1,0 +1,40 @@
+const { InvalidCredentialsError, NotAuthorizedError } = require('restify-errors');
+
+/**
+ * Server plugin for client auth.
+ * Requires "authorization" and "username" to be set on request
+ * (as with the restify authorizationParser plugin).
+ *
+ * Preliminary (insecure) version: checks device ID on request. Eventually,
+ * will check client certs or use encrypted payloads (TBD).
+ *
+ * @param {Object} deviceManager a device manager used to check credentials
+ * @param {Array} exceptPaths whitelist for routes not needing auth
+ */
+const deviceAuthenticator = (deviceManager, exceptPaths = []) => (req, res, next) => {
+  if (exceptPaths.indexOf(req.getRoute().path) > -1) {
+    next();
+    return;
+  }
+
+  if (!req.authorization.scheme || req.authorization.scheme !== 'Basic') {
+    res.header('WWW-Authenticate', 'Basic');
+    next(new InvalidCredentialsError());
+    return;
+  }
+
+  if (!req.username || req.username === 'anonymous') {
+    next(new InvalidCredentialsError());
+    return;
+  }
+
+  deviceManager.exists(req.username).then((exists) => {
+    if (exists) {
+      next();
+    } else {
+      next(new NotAuthorizedError());
+    }
+  });
+};
+
+module.exports = deviceAuthenticator;


### PR DESCRIPTION
Resolves #106. For non-pairing endpoints, Server checks that the username part of HTTP Basic Auth is a valid device ID.

See [Network Canvas #580](https://github.com/codaco/Network-Canvas/pull/580); to test, use the [feature/api-tokens](https://github.com/codaco/Network-Canvas/compare/feature/api-tokens) branch of NC.

Each PR requires the other.