### PR TITLE
Fix window & app behavior when re-opening

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -22,6 +22,7 @@ const app = {
   getVersion: jest.fn(() => ''),
   getName: jest.fn(() => 'test'),
   getPath: jest.fn(() => '.'),
+  makeSingleInstance: jest.fn(),
   on: jest.fn(),
   quit: jest.fn(),
 };


### PR DESCRIPTION
Fixes #132, and similar behavior on macOS: when the Server app is open but all windows are closed, it's still running in the background (with a tray icon). If the user re-opens the app (from Finder or Explorer), the app should re-open a window.

On Windows, this uses `makeSingleInstance`; on macOS, this uses the 'activate' event.

[Update] To test this, you'll need to create distribution builds (`npm run build && npm run dist:[platform]`, and then open the generated app. You don't need the full installer.