### PR TITLE
Convert lint errors to warnings during webpack dev

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -110,7 +110,7 @@ const loaderRules = Object.freeze([
         options: {
           formatter: eslintFormatter,
           eslintPath: require.resolve('eslint'),
-
+          ...(isProduction ? {} : { emitWarning: true }),
         },
         loader: require.resolve('eslint-loader'),
       },


### PR DESCRIPTION
Import config change from [Architect](https://github.com/codaco/Architect/pull/152/commits/1a006e1ed428264ca0e6f2997cca6759393e7935).

Webpack-dev-server will display all lint errors as warnings during development; linting elsewhere is unchanged.