### PR TITLE
Notify clients when GUI is closed during pairing request

### DIFF
--- a/src/main/MainApp.js
+++ b/src/main/MainApp.js
@@ -6,6 +6,8 @@ const { AdminService } = require('./server/AdminService');
 const { isWindows } = require('./utils/environment');
 const { createTray } = require('./components/tray');
 
+const guiProxy = require('./guiProxy');
+
 // TODO: move/centralize
 const FileImportUpdated = 'FILE_IMPORT_UPDATED';
 
@@ -15,6 +17,7 @@ const protocolManager = new ProtocolManager(userDataDir);
 
 const createApp = () => {
   const mainWindow = new MainWindow();
+  guiProxy.setMainWindow(mainWindow);
 
   const openMainWindow = () => mainWindow.open('/overview');
 

--- a/src/main/components/mainWindow.js
+++ b/src/main/components/mainWindow.js
@@ -26,6 +26,10 @@ const getAppUrl = (route) => {
   });
 };
 
+/**
+ * @class
+ * Manages the sole instance of the app's BrowserWindow (electron).
+ */
 class MainWindow {
   create() {
     if (this.window) { return; }

--- a/src/main/errors/IncompletePairingError.js
+++ b/src/main/errors/IncompletePairingError.js
@@ -20,6 +20,7 @@ const ErrorMessages = {
   PairingCancelledByUser: 'Pairing was cancelled',
   PairingRequestTimedOut: 'Pairing timed out',
   PairingCodeExpired: 'Pairing window expired',
+  PairingGuiUnavailable: 'The main window must be open on this Server',
 };
 
 module.exports = {

--- a/src/main/guiProxy.js
+++ b/src/main/guiProxy.js
@@ -1,0 +1,39 @@
+const logger = require('electron-log');
+
+/**
+ * Provides a single communication channel to the renderer's main window.
+ * @namespace guiProxy
+ */
+class GuiProxy {
+  /**
+   * Should be called once, by the main process, to set up a persistent connection
+   * to the main window
+   * @param {MainWindow} mainWindow The app's main window
+   * @memberOf guiProxy
+   */
+  setMainWindow(mainWindow) {
+    this.mainWindow = mainWindow;
+  }
+
+  /**
+   * Send a message to the main window's web contents, if open.
+   * @memberOf guiProxy
+   * @param {...string} args See https://electronjs.org/docs/api/web-contents#contentssendchannel-arg1-arg2-
+   * @return {boolean} `false` if the window is closed, or has not been initialized;
+   *                         `true` if the message was sent successfully.
+   */
+  send(...args) {
+    if (this.mainWindow) {
+      return this.mainWindow.send(...args);
+    }
+    logger.warn('mainWindow is not set');
+    return false;
+  }
+}
+
+const sharedInstance = new GuiProxy();
+
+module.exports = {
+  sendToGui: sharedInstance.send.bind(sharedInstance),
+  setMainWindow: sharedInstance.setMainWindow.bind(sharedInstance),
+};

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2,7 +2,7 @@ const { ipcMain } = require('electron');
 const logger = require('electron-log');
 
 const { createApp, userDataDir } = require('./MainApp');
-const { createServer, serverEvents } = require('./server/ServerFactory');
+const { createServer } = require('./server/ServerFactory');
 const { DefaultApiPort } = require('./server/devices/DeviceService');
 
 const ApiConnectionInfoChannel = 'API_INFO';
@@ -25,21 +25,6 @@ createServer(DefaultApiPort, userDataDir).then((runningServer) => {
   });
 
   ipcMain.on(RequestFileImportDialog, showImportProtocolDialog);
-
-  server.on(serverEvents.SESSIONS_IMPORTED, () => mainWindow.send(serverEvents.SESSIONS_IMPORTED));
-
-  // TODO: if send() returns false, let server know so client request can be dropped?
-  server.on(serverEvents.PAIRING_CODE_AVAILABLE, (data) => {
-    mainWindow.send(serverEvents.PAIRING_CODE_AVAILABLE, data);
-  });
-
-  server.on(serverEvents.PAIRING_TIMED_OUT, () => {
-    mainWindow.send(serverEvents.PAIRING_TIMED_OUT);
-  });
-
-  server.on(serverEvents.PAIRING_COMPLETE, (data) => {
-    mainWindow.send(serverEvents.PAIRING_COMPLETE, data);
-  });
 }).catch((err) => {
   logger.error(err);
   throw err;

--- a/src/main/server/devices/DeviceService.js
+++ b/src/main/server/devices/DeviceService.js
@@ -1,23 +1,15 @@
-/* eslint no-underscore-dangle: ["error", { "allow": ["_id"] }] */
 const { EventEmitter } = require('events');
-const { ipcMain } = require('electron');
 const logger = require('electron-log');
 
 const { DeviceAPI, apiEvents } = require('./DeviceAPI');
-const { IncompletePairingError, ErrorMessages } = require('../../errors/IncompletePairingError');
+const { emittedEvents: pairingEvents, outOfBandDelegate } = require('./OutOfBandDelegate');
 
 const DefaultApiPort = process.env.DEVICE_SERVICE_PORT || 51001;
 
 const emittedEvents = {
   ...apiEvents,
-  PAIRING_CODE_AVAILABLE: 'PAIRING_CODE_AVAILABLE',
-  PAIRING_COMPLETE: 'PAIRING_COMPLETE',
-  PAIRING_TIMED_OUT: 'PAIRING_TIMED_OUT',
+  ...pairingEvents,
 };
-
-const ObserverTimeoutDurationMillis = 30000;
-const PairingAckObservers = {};
-const ObserverTimeouts = {};
 
 /**
  * Provides APIs for external client devices running
@@ -34,8 +26,8 @@ class DeviceService extends EventEmitter {
 
   get port() { return this.api.port; }
 
-  createApi(dataDir) {
-    return new DeviceAPI(dataDir, this.outOfBandDelegate);
+  createApi(dataDir) { // eslint-disable-line class-methods-use-this
+    return new DeviceAPI(dataDir, outOfBandDelegate);
   }
 
   start(port = DefaultApiPort) {
@@ -51,90 +43,6 @@ class DeviceService extends EventEmitter {
    */
   stop() {
     return this.api.close();
-  }
-
-  // TODO: May return boolean to indicate nothing registered as listener;
-  // may want to adjust client response (error code) in that case. (TBD.)
-  get outOfBandDelegate() {
-    return {
-      /**
-       * When a pairing request is created:
-       * - emit availability to GUI.
-       * - register an acknowledgement observer, and return the promise of acknowledgement
-       *
-       * At this point, one of three things can happen:
-       * - Request acknowledged: promise is resolved
-       * - Request dismissed: promise is rejected
-       * - Request times out: promise is rejected
-       *
-       *  Each of these states has a handler, which upon firing cleans up other handlers
-       * and resolves or rejects the acknowledgement promise, allowing the API to respond to client.
-       *
-       * @param {Object} pairingRequest
-       * @return {Object} containing a `promise`d acknowledgement, and an `abort` function
-       *   to support client-side request cancellations.
-       */
-      pairingDidBeginWithRequest: (pairingRequest) => {
-        const requestId = pairingRequest._id;
-
-        this.emit(
-          emittedEvents.PAIRING_CODE_AVAILABLE,
-          { pairingCode: pairingRequest.pairingCode },
-        );
-
-        const dequeueObserver = () => {
-          const promise = PairingAckObservers[requestId];
-          delete PairingAckObservers[requestId];
-          return promise;
-        };
-
-        // register with renderer for ack
-        const onPairingCodeAcknowledged = () => {
-          removeListeners(); // eslint-disable-line no-use-before-define
-          const promise = dequeueObserver();
-          promise.resolve(pairingRequest);
-        };
-
-        const onPairingCodeDismissed = () => {
-          removeListeners(); // eslint-disable-line no-use-before-define
-          const promise = dequeueObserver();
-          promise.reject(new IncompletePairingError(ErrorMessages.PairingCancelledByUser));
-        };
-
-        // Timeout: request error (408)? Gateway (504)?
-        const onPairingTimeout = () => {
-          removeListeners(); // eslint-disable-line no-use-before-define
-          // Main process can notify GUI
-          this.emit(emittedEvents.PAIRING_TIMED_OUT);
-          const promise = dequeueObserver();
-          promise.reject(new IncompletePairingError(ErrorMessages.PairingRequestTimedOut));
-        };
-
-        const removeListeners = () => {
-          const timeout = ObserverTimeouts[requestId];
-          clearTimeout(timeout);
-          delete ObserverTimeouts[requestId];
-          ipcMain.removeListener('PairingCodeAcknowledged', onPairingCodeAcknowledged);
-          ipcMain.removeListener('PairingCodeDismissed', onPairingCodeDismissed);
-        };
-
-        ipcMain.once('PairingCodeAcknowledged', onPairingCodeAcknowledged);
-        ipcMain.once('PairingCodeDismissed', onPairingCodeDismissed);
-
-        ObserverTimeouts[requestId] = setTimeout(onPairingTimeout, ObserverTimeoutDurationMillis);
-
-        return {
-          promise: new Promise((resolve, reject) => {
-            PairingAckObservers[requestId] = { resolve, reject };
-          }),
-          abort: onPairingTimeout,
-        };
-      },
-
-      pairingDidComplete: () => {
-        this.emit(emittedEvents.PAIRING_COMPLETE);
-      },
-    };
   }
 
   on(name, cb) {

--- a/src/main/server/devices/OutOfBandDelegate.js
+++ b/src/main/server/devices/OutOfBandDelegate.js
@@ -1,0 +1,114 @@
+/* eslint no-underscore-dangle: ["error", { "allow": ["_id"] }] */
+const { ipcMain } = require('electron');
+
+const { sendToGui } = require('../../guiProxy');
+const { IncompletePairingError, ErrorMessages } = require('../../errors/IncompletePairingError');
+
+const emittedEvents = {
+  PAIRING_CODE_AVAILABLE: 'PAIRING_CODE_AVAILABLE',
+  PAIRING_COMPLETE: 'PAIRING_COMPLETE',
+  PAIRING_TIMED_OUT: 'PAIRING_TIMED_OUT',
+};
+
+const PairingAckObservers = {};
+const ObserverTimeouts = {};
+const ObserverTimeoutDurationMillis = 30000;
+
+/**
+ * outOfBandDelegate provides hooks between the device API and GUI for the out-of-band
+ * pairing process.
+ * @type {Object}
+ * @namespace outOfBandDelegate
+ */
+const outOfBandDelegate = {
+  /**
+   * @description
+   * When a pairing request is created:
+   * - emit availability to GUI.
+   * - register an acknowledgement observer, and return the promise of acknowledgement
+   *
+   * At this point, one of three things can happen:
+   * - Request acknowledged: promise is resolved
+   * - Request dismissed: promise is rejected
+   * - Request times out: promise is rejected
+   *
+   *  Each of these states has a handler, which upon firing cleans up other handlers
+   * and resolves or rejects the acknowledgement promise, allowing the API to respond to client.
+   *
+   * @param {Object} pairingRequest
+   * @return {Object} containing a `promise`d acknowledgement, and an `abort` function
+   *   to support client-side request cancellations.
+   */
+  pairingDidBeginWithRequest: (pairingRequest) => {
+    const requestId = pairingRequest._id;
+
+    const dequeueObserver = () => {
+      const promise = PairingAckObservers[requestId];
+      delete PairingAckObservers[requestId];
+      return promise;
+    };
+
+    // register with renderer for ack
+    const onPairingCodeAcknowledged = () => {
+      removeListeners(); // eslint-disable-line no-use-before-define
+      const promise = dequeueObserver();
+      promise.resolve(pairingRequest);
+    };
+
+    const onPairingCodeDismissed = () => {
+      removeListeners(); // eslint-disable-line no-use-before-define
+      const promise = dequeueObserver();
+      promise.reject(new IncompletePairingError(ErrorMessages.PairingCancelledByUser));
+    };
+
+    const onPairingTimeout = () => {
+      removeListeners(); // eslint-disable-line no-use-before-define
+      sendToGui(emittedEvents.PAIRING_TIMED_OUT);
+      const promise = dequeueObserver();
+      promise.reject(new IncompletePairingError(ErrorMessages.PairingRequestTimedOut));
+    };
+
+    const removeListeners = () => {
+      const timeout = ObserverTimeouts[requestId];
+      clearTimeout(timeout);
+      delete ObserverTimeouts[requestId];
+      ipcMain.removeListener('PairingCodeAcknowledged', onPairingCodeAcknowledged);
+      ipcMain.removeListener('PairingCodeDismissed', onPairingCodeDismissed);
+    };
+
+    const guiIsReady = sendToGui(emittedEvents.PAIRING_CODE_AVAILABLE,
+      { pairingCode: pairingRequest.pairingCode });
+
+    let promise;
+
+    if (guiIsReady) {
+      promise = new Promise((resolve, reject) => {
+        PairingAckObservers[requestId] = { resolve, reject };
+      });
+      ObserverTimeouts[requestId] = setTimeout(onPairingTimeout, ObserverTimeoutDurationMillis);
+
+      ipcMain.once('PairingCodeAcknowledged', onPairingCodeAcknowledged);
+      ipcMain.once('PairingCodeDismissed', onPairingCodeDismissed);
+    } else {
+      promise = Promise.reject(new IncompletePairingError(ErrorMessages.PairingGuiUnavailable));
+    }
+
+    return {
+      promise,
+      abort: onPairingTimeout,
+    };
+  },
+
+  /**
+   * When a pairing request has been confirmed by the client (via the API), notifies the GUI
+   * @return {void}
+   */
+  pairingDidComplete: () => {
+    sendToGui(emittedEvents.PAIRING_COMPLETE);
+  },
+};
+
+module.exports = {
+  emittedEvents,
+  outOfBandDelegate,
+};

--- a/src/main/server/devices/PairingCodeFactory.js
+++ b/src/main/server/devices/PairingCodeFactory.js
@@ -3,6 +3,11 @@ const crypto = require('crypto');
 const { PairingCodeLength, CharacterSet } = require('../../utils/shared-api/pairingCodeConfig');
 
 /**
+ * @namespace PairingCodeFactory
+ * @type {Object}
+ */
+
+/**
  * Generate a random passcode that can be used for out-of-band pairing.
  *
  * Basic approach:
@@ -16,6 +21,7 @@ const { PairingCodeLength, CharacterSet } = require('../../utils/shared-api/pair
  * You can estimate the entropy of a pairing code based on its character set and length:
  * `Math.log2(charSet.length ** PairingCodeLength)`.
  *
+ * @memberOf PairingCodeFactory
  * @async
  * @return {string} random pairing code
  * @throws {Error} Rejects if random code couldn't be created

--- a/src/main/server/devices/__tests__/DeviceService-test.js
+++ b/src/main/server/devices/__tests__/DeviceService-test.js
@@ -1,12 +1,10 @@
 /* eslint-env jest */
-const { DeviceService, deviceServiceEvents } = require('../DeviceService');
+const { DeviceService } = require('../DeviceService');
 const { apiEvents } = require('../DeviceAPI');
 
 jest.mock('electron-log');
 jest.mock('../PairingRequestService');
 jest.mock('../DeviceAPI');
-
-const mockPairingCode = '123';
 
 describe('Device Service', () => {
   let deviceService;
@@ -15,23 +13,6 @@ describe('Device Service', () => {
     deviceService = new DeviceService({});
     deviceService.emit = jest.fn();
     deviceService.api.on.mockClear();
-  });
-
-  it('emits an event when a new PIN is created (for out-of-band transfer)', (done) => {
-    deviceService.emit.mockImplementation((msg, data) => {
-      expect(msg).toMatch(deviceServiceEvents.PAIRING_CODE_AVAILABLE);
-      expect(data).toMatchObject({ pairingCode: mockPairingCode });
-      done();
-    });
-    deviceService.outOfBandDelegate.pairingDidBeginWithRequest({ pairingCode: mockPairingCode });
-  });
-
-  it('emits an event when pairing is complete', (done) => {
-    deviceService.emit.mockImplementation((msg) => {
-      expect(msg).toMatch(deviceServiceEvents.PAIRING_COMPLETE);
-      done();
-    });
-    deviceService.outOfBandDelegate.pairingDidComplete();
   });
 
   it('delegates session import event to API', () => {
@@ -44,5 +25,21 @@ describe('Device Service', () => {
   it('ignores other events', () => {
     deviceService.on('not-an-event', jest.fn());
     expect(deviceService.api.on).not.toHaveBeenCalled();
+  });
+
+  describe('API', () => {
+    beforeEach(() => {
+      deviceService.api.listen.mockResolvedValue({});
+    });
+
+    it('starts the API on a default port', () => {
+      deviceService.start();
+      expect(deviceService.api.listen).toHaveBeenCalledWith(expect.any(Number));
+    });
+
+    it('ensures API is given a number for port', () => {
+      deviceService.start('9999');
+      expect(deviceService.api.listen).toHaveBeenCalledWith(9999);
+    });
   });
 });

--- a/src/main/server/devices/__tests__/OutOfBandDelegate-test.js
+++ b/src/main/server/devices/__tests__/OutOfBandDelegate-test.js
@@ -1,0 +1,69 @@
+/* eslint-env jest */
+const { ipcMain } = require('electron');
+const { emittedEvents, outOfBandDelegate } = require('../OutOfBandDelegate');
+const { ErrorMessages } = require('../../../errors/IncompletePairingError');
+
+const guiProxy = require('../../../guiProxy');
+
+jest.mock('../../../guiProxy');
+
+const pairingCode = '123';
+
+describe('outOfBandDelegate', () => {
+  afterEach(() => {
+    guiProxy.sendToGui.mockReset();
+  });
+
+  it('notifies the GUI when a new PIN is created (for out-of-band transfer)', () => {
+    guiProxy.sendToGui.mockReturnValue(true);
+    outOfBandDelegate.pairingDidBeginWithRequest({ pairingCode });
+    expect(guiProxy.sendToGui)
+      .toHaveBeenCalledWith(emittedEvents.PAIRING_CODE_AVAILABLE, { pairingCode });
+  });
+
+  it('warns when proxy window is unavilable', () => {
+    guiProxy.sendToGui.mockReturnValue(false);
+    const result = outOfBandDelegate.pairingDidBeginWithRequest({ pairingCode });
+    expect(result.promise).rejects.toMatchErrorMessage(ErrorMessages.PairingGuiUnavailable);
+  });
+
+  it('emits an event when pairing is complete', () => {
+    outOfBandDelegate.pairingDidComplete();
+    expect(guiProxy.sendToGui).toHaveBeenCalledWith(emittedEvents.PAIRING_COMPLETE);
+  });
+
+  describe('IPC', () => {
+    beforeEach(() => {
+      guiProxy.sendToGui.mockReturnValue(true);
+      ipcMain.removeListener = jest.fn();
+      ipcMain.once.mockReset();
+      ipcMain.removeListener.mockClear();
+    });
+
+    it('resolves with the pairing request when acknowledged', () => {
+      ipcMain.once.mockImplementation((channel, cb) => {
+        if (channel === 'PairingCodeAcknowledged') { cb(); }
+      });
+      const res = outOfBandDelegate.pairingDidBeginWithRequest({ pairingCode });
+      expect(res.promise).resolves.toMatchObject({ pairingCode });
+      expect(ipcMain.removeListener).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects when dismissed', () => {
+      ipcMain.once.mockImplementation((channel, cb) => {
+        if (channel === 'PairingCodeDismissed') { cb(); }
+      });
+      const res = outOfBandDelegate.pairingDidBeginWithRequest({ pairingCode });
+      expect(res.promise).rejects.toMatchErrorMessage(ErrorMessages.PairingCancelledByUser);
+      expect(ipcMain.removeListener).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects on timeout', () => {
+      jest.useFakeTimers();
+      const res = outOfBandDelegate.pairingDidBeginWithRequest({ pairingCode });
+      jest.runAllTimers();
+      expect(res.promise).rejects.toMatchErrorMessage(ErrorMessages.PairingRequestTimedOut);
+      expect(ipcMain.removeListener).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/main/server/devices/__tests__/PairingCodeFactory-test.js
+++ b/src/main/server/devices/__tests__/PairingCodeFactory-test.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+const crypto = require('crypto');
 
 const Factory = require('../PairingCodeFactory');
 
@@ -8,5 +9,19 @@ describe('the PairingCodeFactory', () => {
   it('can generate a pairing code', async () => {
     const code = await Factory.generatePairingCodeAsync();
     expect(code).toMatch(new RegExp(`[a-z]{${PairingCodeLength}}`));
+  });
+
+  it('rejects on error', () => {
+    const spy = jest.spyOn(crypto, 'randomBytes');
+    spy.mockImplementation((size, cb) => cb(new Error('mockErr')));
+    expect(Factory.generatePairingCodeAsync()).rejects.toMatchErrorMessage('mockErr');
+    spy.mockRestore();
+  });
+
+  it('rejects if it cannot create a suitable passcode', () => {
+    const spy = jest.spyOn(crypto, 'randomBytes');
+    spy.mockImplementation((size, cb) => cb(null, Buffer.from([0x10])));
+    expect(Factory.generatePairingCodeAsync()).rejects.toMatchErrorMessage('Could not generate long-enough passcode');
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
Resolves #100. Resolves #96.

This simplifies some of the IPC code in Server (which no longer has a separate background process to worry about). This enables the API to return an error code to the client when the GUI isn't ready to display a pairing request.

### To test

Open Server, and close the main window (but leave running in the background). Open a Network Canvas client, reset if needed, and attempt to pair with the server.

If anyone has better ideas for the error message, I'd love to hear. (I used "this" since it comes immediately after clicking a server icon, of which there may be multiple.)

![no-gui](https://user-images.githubusercontent.com/39674/42902728-9a80350c-8a9d-11e8-87db-3ed49875a2dd.png)
