### PR TITLE
Allow electron to start even if dev extensions fail

### DIFF
--- a/src/main/components/mainWindow.js
+++ b/src/main/components/mainWindow.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const url = require('url');
+const chalk = require('chalk');
 const { BrowserWindow } = require('electron');
 
 const loadDevToolsExtensions = () => {
@@ -7,7 +8,15 @@ const loadDevToolsExtensions = () => {
   if (process.env.NODE_ENV !== 'development' || !extensions) {
     return;
   }
-  extensions.split(';').forEach(filepath => BrowserWindow.addDevToolsExtension(filepath));
+  try {
+    extensions.split(';').forEach(filepath => BrowserWindow.addDevToolsExtension(filepath));
+  } catch (err) {
+    /* eslint-disable no-console */
+    console.warn(err);
+    console.warn(chalk.yellow('A Chrome dev tools extension failed to load. If the extension has upgraded, update your NC_DEVTOOLS_EXENSION_PATH:'));
+    console.warn(chalk.yellow(process.env.NC_DEVTOOLS_EXENSION_PATH));
+    /* eslint-enable */
+  }
 };
 
 const getAppUrl = (route) => {


### PR DESCRIPTION
In development, if you've set a path to a load devtools extension that
includes a version number, and the extension is upgraded, the call to
addDevToolsExtension throws an error we should catch.