### PR TITLE
Feature/self signed cert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21558,19 +21558,17 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selfsigned": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.1.tgz",
-      "integrity": "sha1-v4y3uDJWxFUeMTR8YxF3jbme7FI=",
-      "dev": true,
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.3.tgz",
+      "integrity": "sha512-vmZenZ+8Al3NLHkWnhBQ0x6BkML1eCP2xEi3JE+f3D9wW9fipD9NNJHYtE9XJM4TsPaHGZJIamrSI6MTg1dU2Q==",
       "requires": {
-        "node-forge": "0.6.33"
+        "node-forge": "0.7.5"
       },
       "dependencies": {
         "node-forge": {
-          "version": "0.6.33",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.33.tgz",
-          "integrity": "sha1-RjgRh59XPUUVWtap9D3ClujoXrw=",
-          "dev": true
+          "version": "0.7.5",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+          "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "reselect": "^3.0.0",
     "restify": "^7.2.1",
     "restify-cors-middleware": "^1.1.1",
+    "selfsigned": "^1.10.3",
     "thread-loader": "^1.1.5",
     "uuid": "^3.3.2"
   },

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -26,7 +26,7 @@ createServer(DefaultApiPort, userDataDir).then((runningServer) => {
 
   ipcMain.on(RequestFileImportDialog, showImportProtocolDialog);
 }).catch((err) => {
-  logger.error(err);
+  logger.error('createServer failed', err);
   throw err;
 });
 

--- a/src/main/package.json
+++ b/src/main/package.json
@@ -21,6 +21,7 @@
     "prop-types": "^15.6.1",
     "restify": "^6.3.4",
     "restify-cors-middleware": "^1.1.0",
+    "selfsigned": "^1.10.3",
     "uuid": "^3.2.1"
   },
   "main": "./index.js"

--- a/src/main/server/Server.js
+++ b/src/main/server/Server.js
@@ -20,8 +20,9 @@ class Server extends EventEmitter {
    */
   startServices(port) {
     const dataDir = this.options.dataDir;
+    const keys = this.options.keys;
     this.adminService = new AdminService({ statusDelegate: this, dataDir });
-    this.deviceService = new DeviceService({ dataDir });
+    this.deviceService = new DeviceService({ dataDir, keys });
 
     return Promise.all([
       this.adminService.start(),

--- a/src/main/server/__tests__/Server-test.js
+++ b/src/main/server/__tests__/Server-test.js
@@ -6,7 +6,7 @@ const Server = require('../Server');
 const { DeviceService, deviceServiceEvents } = require('../devices/DeviceService');
 
 const testPortNumber = 51999;
-const serverOpts = { dataDir: 'db' };
+const serverOpts = { dataDir: 'db', keys: {} };
 
 jest.mock('electron-log');
 jest.mock('mdns');
@@ -81,7 +81,7 @@ describe('Server', () => {
 
     beforeEach(async () => {
       server = new Server();
-      deviceService = new DeviceService({});
+      deviceService = new DeviceService({ keys: {} });
     });
 
     it('advertises using MDNS', () => {

--- a/src/main/server/__tests__/ServerFactory-test.js
+++ b/src/main/server/__tests__/ServerFactory-test.js
@@ -3,6 +3,8 @@
 const path = require('path');
 const { createServer } = require('../ServerFactory');
 
+jest.mock('../ensurePemKeyPair');
+
 const mockServerMethods = {
   close: jest.fn(),
   startServices: jest.fn(() => Promise.resolve(mockServerMethods)), // startServices returns `this`

--- a/src/main/server/__tests__/ensurePemKeyPair-test.js
+++ b/src/main/server/__tests__/ensurePemKeyPair-test.js
@@ -1,0 +1,76 @@
+/* eslint-env jest */
+const selfsigned = require('selfsigned');
+
+const ensurePemKeyPair = require('../ensurePemKeyPair');
+const promisedFs = require('../../utils/promised-fs');
+
+jest.mock('selfsigned');
+jest.mock('electron-log');
+jest.mock('../../utils/promised-fs');
+
+describe('ensurePemKeyPair', () => {
+  const mockPems = {
+    cert: 'CERTIFICATE',
+    fingerprint: '::',
+    private: 'PRIVATE',
+    public: 'PUBLIC',
+  };
+
+  beforeAll(() => {
+    selfsigned.generate.mockReturnValue(mockPems);
+    promisedFs.mkdir.mockResolvedValue(undefined);
+    promisedFs.writeFile.mockResolvedValue('');
+  });
+
+  afterEach(() => {
+    promisedFs.readFile.mockClear();
+    promisedFs.writeFile.mockClear();
+  });
+
+  describe('when files do not exist', () => {
+    beforeAll(() => {
+      const noFileErr = new Error();
+      noFileErr.code = 'ENOENT';
+      promisedFs.readFile.mockRejectedValue(noFileErr);
+    });
+
+    it('writes pems to files', async () => {
+      const pair = await ensurePemKeyPair();
+      expect(promisedFs.writeFile).toHaveBeenCalledTimes(4);
+      expect(pair).toEqual(mockPems);
+    });
+
+    it('uses existing directory', async () => {
+      const alreadyExistsErr = new Error();
+      alreadyExistsErr.code = 'EEXIST';
+      promisedFs.mkdir.mockRejectedValue(alreadyExistsErr);
+      const pair = await ensurePemKeyPair();
+      expect(promisedFs.writeFile).toHaveBeenCalledTimes(4);
+      expect(pair).toEqual(mockPems);
+    });
+
+    it('throws if dir cannot be created', async () => {
+      const err = new Error('unknown fs error');
+      promisedFs.mkdir.mockRejectedValue(err);
+      await expect(ensurePemKeyPair()).rejects.toEqual(err);
+    });
+  });
+
+  describe('when files exist', () => {
+    beforeAll(() => {
+      promisedFs.readFile.mockResolvedValue('');
+    });
+
+    it('writes pems to files', async () => {
+      const pair = await ensurePemKeyPair();
+      expect(promisedFs.readFile).toHaveBeenCalledTimes(4);
+      Object.keys(mockPems).forEach(prop => expect(pair).toHaveProperty(prop));
+    });
+
+    it('throws if they cannot be read', async () => {
+      const err = new Error('unknown fs error');
+      promisedFs.readFile.mockRejectedValue(err);
+      await expect(ensurePemKeyPair()).rejects.toEqual(err);
+    });
+  });
+});

--- a/src/main/server/devices/DeviceAPI.js
+++ b/src/main/server/devices/DeviceAPI.js
@@ -209,6 +209,7 @@ class DeviceAPI extends EventEmitter {
     const authenticator = deviceAuthenticator(this.deviceManager, publicRoutes);
     this.server = this.createServer(authenticator, keys);
     this.outOfBandDelegate = outOfBandDelegate;
+    this.publicCert = keys.cert;
   }
 
   get name() { return this.server.name; }
@@ -558,7 +559,10 @@ class DeviceAPI extends EventEmitter {
           .then((device) => {
             // TODO: if responding with error, surface error instead of complete
             this.outOfBandDelegate.pairingDidComplete();
-            const payload = JSON.stringify({ device: Schema.device(device) });
+            const payload = JSON.stringify({
+              device: Schema.device(device),
+              cert: this.publicCert,
+            });
             res.json({ status: 'ok', data: { message: encrypt(payload, device.secretKey) } });
           })
           .catch(err => this.handlers.onError(err, res))

--- a/src/main/server/devices/DeviceAPI.js
+++ b/src/main/server/devices/DeviceAPI.js
@@ -200,14 +200,14 @@ const publicRoutes = ['/devices/new', '/devices', '/protocols/:filename'];
  * API Server for device endpoints
  */
 class DeviceAPI extends EventEmitter {
-  constructor(dataDir, outOfBandDelegate) {
+  constructor(dataDir, outOfBandDelegate, keys) {
     super();
     this.requestService = new PairingRequestService();
     this.protocolManager = new ProtocolManager(dataDir);
     this.deviceManager = new DeviceManager(dataDir);
 
     const authenticator = deviceAuthenticator(this.deviceManager, publicRoutes);
-    this.server = this.createServer(authenticator);
+    this.server = this.createServer(authenticator, keys);
     this.outOfBandDelegate = outOfBandDelegate;
   }
 
@@ -234,11 +234,15 @@ class DeviceAPI extends EventEmitter {
     });
   }
 
-  createServer(authenticatorPlugin) {
+  createServer(authenticatorPlugin/* , keys */) {
+    // if (!keys.cert || !keys.private) { /* TODO: throw */ }
     const server = restify.createServer({
       name: ApiName,
       onceNext: true,
       version: ApiVersion,
+      // TODO: Enable https:
+      // certificate: keys.cert,
+      // key: keys.private,
     });
 
     server.pre(restify.plugins.pre.sanitizePath());

--- a/src/main/server/devices/DeviceService.js
+++ b/src/main/server/devices/DeviceService.js
@@ -19,22 +19,23 @@ const emittedEvents = {
  * - Device Pairing
  */
 class DeviceService extends EventEmitter {
-  constructor({ dataDir }) {
+  constructor({ dataDir, keys }) {
     super();
-    this.api = this.createApi(dataDir);
+    this.api = this.createApi(dataDir, keys);
   }
 
   get port() { return this.api.port; }
 
-  createApi(dataDir) { // eslint-disable-line class-methods-use-this
-    return new DeviceAPI(dataDir, outOfBandDelegate);
+  createApi(dataDir, keys) { // eslint-disable-line class-methods-use-this
+    return new DeviceAPI(dataDir, outOfBandDelegate, keys);
   }
 
   start(port = DefaultApiPort) {
-    return this.api.listen(parseInt(port, 10)).then((api) => {
-      logger.info(`${api.name} listening at ${api.url}`);
-      return api;
-    });
+    return this.api.listen(parseInt(port, 10))
+      .then((api) => {
+        logger.info(`${api.name} listening at ${api.url}`);
+        return api;
+      });
   }
 
   /**

--- a/src/main/server/devices/__tests__/DeviceAPI-test.js
+++ b/src/main/server/devices/__tests__/DeviceAPI-test.js
@@ -47,7 +47,7 @@ describe('the DeviceAPI', () => {
 
   beforeEach(() => {
     // API factory: override mockAuthenticator as needed in beforeAll handler
-    deviceApi = new DeviceAPI(dataDir, mockDelegate);
+    deviceApi = new DeviceAPI(dataDir, mockDelegate, {});
     deviceApi.requestService.createRequest.mockResolvedValue(mockRequestDbEntry);
   });
 

--- a/src/main/server/ensurePemKeyPair.js
+++ b/src/main/server/ensurePemKeyPair.js
@@ -1,0 +1,103 @@
+const path = require('path');
+const selfsigned = require('selfsigned');
+const logger = require('electron-log');
+const { app } = require('electron');
+
+const promisedFs = require('../utils/promised-fs');
+
+const userDataDir = app.getPath('userData');
+const certDir = path.join(userDataDir, 'nc_certificates');
+const certPem = path.join(certDir, 'device-api-cert.pem');
+const privatePem = path.join(certDir, 'device-api-key.pem');
+const publicPem = path.join(certDir, 'device-api-pub.pem');
+const fingerprintFile = path.join(certDir, 'device-api-fingerprint.txt');
+
+/**
+ * If needed, creates a keypair and x.509 certificate and saves to disk.
+ * If the files already exist, returns their contents.
+ * @async
+ * @return {Object} Resolves with `{ private, public, cert, fingerprint }`
+ * @throws {Error} If files already exist
+ */
+const generatePemKeyPair = () => {
+  const AltNameTypeDNS = 2;
+  const AltNameTypeIP = 7;
+  const attrs = [{ name: 'commonName', value: 'Network Canvas (localhost)' }];
+  const extensions = [
+    {
+      name: 'basicConstraints',
+      cA: true,
+    },
+    {
+      name: 'keyUsage',
+      keyCertSign: true,
+      digitalSignature: true,
+      nonRepudiation: true,
+      keyEncipherment: true,
+      dataEncipherment: true,
+    },
+    {
+      name: 'subjectAltName',
+      altNames: [
+        {
+          type: AltNameTypeDNS,
+          value: 'localhost',
+        },
+        {
+          type: AltNameTypeIP,
+          ip: '127.0.0.1',
+        },
+      ],
+    },
+  ];
+
+  // TODO: Ed25519 and/or native implementation
+  const pems = selfsigned.generate(attrs, {
+    algorithm: 'sha256',
+    days: 365 * 10,
+    keySize: 2048,
+    extensions,
+  });
+
+  // Throw if attempting to overwrite an existing file
+  const writeOpts = { encoding: 'utf-8', flag: 'wx' };
+  return promisedFs.mkdir(certDir)
+    .catch((err) => {
+      if (err.code !== 'EEXIST') {
+        logger.error(err);
+        throw err;
+      }
+    })
+    .then(() => Promise.all([
+      promisedFs.writeFile(certPem, pems.cert, writeOpts),
+      promisedFs.writeFile(privatePem, pems.private, writeOpts),
+      promisedFs.writeFile(publicPem, pems.public, writeOpts),
+      promisedFs.writeFile(fingerprintFile, pems.fingerprint, writeOpts),
+    ]))
+    .then(() => pems);
+};
+
+const ensurePemKeyPair = () => (
+  Promise.all([
+    promisedFs.readFile(certPem, 'utf-8'),
+    promisedFs.readFile(privatePem, 'utf-8'),
+    promisedFs.readFile(publicPem, 'utf-8'),
+    promisedFs.readFile(fingerprintFile, 'utf-8'),
+  ])
+    .then(([cert, privateKey, publicKey, fingerprint]) => ({
+      private: privateKey,
+      public: publicKey,
+      cert,
+      fingerprint,
+    }))
+    .catch((err) => {
+      if (err.code === 'ENOENT') {
+        logger.info('Keys not found; creating');
+        return generatePemKeyPair();
+      }
+      logger.error(err);
+      throw err;
+    })
+);
+
+module.exports = ensurePemKeyPair;

--- a/src/main/utils/__tests__/promised-fs-test.js
+++ b/src/main/utils/__tests__/promised-fs-test.js
@@ -11,9 +11,11 @@ describe('promisified fs', () => {
   describe('on success', () => {
     const mockFileContents = Buffer.from([0x01]);
     beforeAll(() => {
+      fs.mkdir.mockImplementation((p, opts, cb) => (cb || opts)(undefined));
       fs.readFile.mockImplementation((f, opts, cb) => (cb || opts)(undefined, mockFileContents));
       fs.rename.mockImplementation((a, b, cb) => cb(undefined));
       fs.unlink.mockImplementation((f, cb) => cb(undefined));
+      fs.writeFile.mockImplementation((f, d, opts, cb) => (cb || opts)(undefined));
     });
 
     helpers.forEach((helper) => {
@@ -25,23 +27,53 @@ describe('promisified fs', () => {
     it('accepts options for readFile', async () => {
       await expect(pfs.readFile('.', {})).resolves.toEqual(mockFileContents);
     });
+
+    it('accepts options for writeFile', async () => {
+      await expect(pfs.writeFile('.', Buffer.from([]), {})).resolves.toBe(undefined);
+    });
+
+    it('accepts mode for mkdir', async () => {
+      await expect(pfs.mkdir('.', 0o777)).resolves.toBe(undefined);
+    });
   });
 
   describe('on error', () => {
     const mockErr = new Error('mock');
+    mockErr.code = 'ENOENT';
     beforeAll(() => {
+      fs.mkdir.mockImplementation((p, cb) => cb(mockErr));
       fs.readFile.mockImplementation((f, cb) => cb(mockErr));
       fs.rename.mockImplementation((a, b, cb) => cb(mockErr));
       fs.unlink.mockImplementation((f, cb) => cb(mockErr));
+      fs.writeFile.mockImplementation((f, d, cb) => cb(mockErr));
     });
 
     helpers.filter(h => (/try/).test(h)).forEach((helper) => {
-      it('resolves despite error', async () => {
-        await expect(pfs[helper]('.')).resolves;
+      it('resolves despite ENOENT error', async () => {
+        await expect(pfs[helper]('.')).resolves.toBe(undefined);
       });
     });
 
     helpers.filter(h => !(/try/).test(h)).forEach((helper) => {
+      it('rejects with error in callback', async () => {
+        await expect(pfs[helper]('.')).rejects.toMatchObject(mockErr);
+      });
+    });
+  });
+
+  describe('on synchronous error (invalid args)', () => {
+    const mockErr = new Error('mock');
+    beforeAll(() => {
+      fs.mkdir.mockImplementation(() => { throw mockErr; });
+      fs.readFile.mockImplementation(() => { throw mockErr; });
+      fs.rename.mockImplementation(() => { throw mockErr; });
+      fs.unlink.mockImplementation(() => { throw mockErr; });
+      fs.writeFile.mockImplementation(() => { throw mockErr; });
+    });
+
+    // fs methods throw (rather than calling back with error) on invalid input
+    // All helpers, even "try*", should reject in this case.
+    helpers.forEach((helper) => {
       it('rejects with error in callback', async () => {
         await expect(pfs[helper]('.')).rejects.toMatchObject(mockErr);
       });

--- a/src/main/utils/promised-fs.js
+++ b/src/main/utils/promised-fs.js
@@ -59,7 +59,9 @@ const unlink = path => (new Promise((resolve, reject) => {
   } catch (err) { reject(err); }
 }));
 
-const tryUnlink = path => unlink(path).catch(() => {});
+const tryUnlink = path => unlink(path).catch((err) => {
+  if (err.code !== 'ENOENT') { throw err; }
+});
 
 module.exports = {
   mkdir,

--- a/src/main/utils/promised-fs.js
+++ b/src/main/utils/promised-fs.js
@@ -1,5 +1,35 @@
 const fs = require('fs');
 
+const resolveOrRejectWith = (resolve, reject) => (err) => {
+  if (err) {
+    reject(err);
+  } else {
+    resolve();
+  }
+};
+
+const mkdir = (path, mode) => (new Promise((resolve, reject) => {
+  const args = [path];
+  if (mode) {
+    args.push(mode);
+  }
+  args.push(resolveOrRejectWith(resolve, reject));
+  try {
+    fs.mkdir.apply(null, args);
+  } catch (err) { reject(err); }
+}));
+
+const writeFile = (file, data, options) => (new Promise((resolve, reject) => {
+  const args = [file, data];
+  if (options) {
+    args.push(options);
+  }
+  args.push(resolveOrRejectWith(resolve, reject));
+  try {
+    fs.writeFile.apply(null, args);
+  } catch (err) { reject(err); }
+}));
+
 const readFile = (path, options) => (new Promise((resolve, reject) => {
   const args = [path];
   if (options) {
@@ -12,34 +42,30 @@ const readFile = (path, options) => (new Promise((resolve, reject) => {
       resolve(data);
     }
   });
-  fs.readFile.apply(null, args);
+  try {
+    fs.readFile.apply(null, args);
+  } catch (err) { reject(err); }
 }));
 
 const rename = (oldPath, newPath) => (new Promise((resolve, reject) => {
-  fs.rename(oldPath, newPath, (err) => {
-    if (err) {
-      reject(err);
-    } else {
-      resolve();
-    }
-  });
+  try {
+    fs.rename(oldPath, newPath, resolveOrRejectWith(resolve, reject));
+  } catch (err) { reject(err); }
 }));
 
 const unlink = path => (new Promise((resolve, reject) => {
-  fs.unlink(path, (err) => {
-    if (err) {
-      reject(err);
-    } else {
-      resolve();
-    }
-  });
+  try {
+    fs.unlink(path, resolveOrRejectWith(resolve, reject));
+  } catch (err) { reject(err); }
 }));
 
 const tryUnlink = path => unlink(path).catch(() => {});
 
 module.exports = {
+  mkdir,
   readFile,
   rename,
   tryUnlink,
   unlink,
+  writeFile,
 };


### PR DESCRIPTION
- Generate keys + a self-signed cert: Resolves #104.
- Provide cert to client during pairing: Resolves #105.

This uses a wrapper around node-forge, also used in Private Socket, to generate the keypair and cert at startup. There seems to be some variance in key generation times, and with larger RSA keysizes (3072), I saw unpredictably large execution times. Long-term, I'd like to investigate an alternative — linking against Node's OpenSSL, or including another native dependency.

For now, this will let us proceed with client-side development (https://github.com/codaco/Network-Canvas/issues/538 / https://github.com/codaco/Network-Canvas/issues/539 / https://github.com/codaco/Network-Canvas/issues/540) and verify cert formats.

### Testing

This doesn't provide much, end to end, but you can verify the following:

Keys and certs are stored on the filesystem; the latter are easy to inspect that way. You can verify they're stored by looking in electron's `userData` directory; [see docs for locations](https://electronjs.org/docs/api/app#appgetpathname).

To verify delivery of the public cert to the client, see the `prototype/log-server-cert` branch on Network Canvas, and [watch the logs](https://github.com/codaco/Network-Canvas/compare/prototype/log-server-cert#diff-c612de12c213fb6b993b9c4c08d0e676R131) when pairing with a server.
