### PR TITLE
Hardcode error-overlay CSP hash

### DIFF
--- a/config/inlineCSP.js
+++ b/config/inlineCSP.js
@@ -38,7 +38,7 @@ function hash256(libName) {
   const newline = /\n|\r\n|\r/g;
   const matches = source.split(newline).filter(line => line.match(/^module\.exports.*/));
 
-  if (!matches) {
+  if (!matches || !matches.length) {
     console.warn('No exports matched');
     return null;
   }
@@ -48,12 +48,7 @@ function hash256(libName) {
   vm.createContext(sandbox);
   vm.runInContext(exportedSrc, sandbox);
 
-  // Newer versions of plugin contain source directly; older versions export a string
-  // TODO: remove legacy parsing above once we're sure it's unneeded
-  const clientSource = sandbox.module.exports || source;
-
-  // const cspHash = crypto.createHash('sha256').update(sandbox.module.exports).digest('base64');
-  const cspHash = crypto.createHash('sha256').update(clientSource).digest('base64');
+  const cspHash = crypto.createHash('sha256').update(sandbox.module.exports).digest('base64');
   return cspHash;
 }
 

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -93,9 +93,14 @@ const config = {
     // "REACT_APP_" is a recognized prefix (see config/env.js)
     new InterpolateHtmlPlugin({
       ...env.raw,
-      // Whitelist inlined content for the Content-Security-Policy header
-      REACT_APP_SCRIPT_SRC_CSP: `'sha256-${inlineCSP.hash256('react-error-overlay')}'`,
-      // Whitelist inlined content for the Content-Security-Policy header
+      // Whitelist inlined content in Content Security Policy
+      // REACT_APP_SCRIPT_SRC_CSP: `'sha256-${inlineCSP.hash256('react-error-overlay')}'`,
+      // Previously we whitelisted the react-error-overlay using the above code to
+      // generate an explicit hash. In the latest version of these tools multiple levels
+      // of indirection make getting at the code to hash very brittle.
+      // For now, hardcode to current version (react-error-overlay@5.0.0-next.3e165448)
+      REACT_APP_SCRIPT_SRC_CSP: "'sha256-gDC0EVcPe9MimCS3ZP14teSHr0GtEx+ggc0VQBfyvRI='",
+      // Whitelist dev server websockets content in Content Security Policy
       REACT_APP_CONNECT_SRC_CSP: 'ws://localhost:* wss://localhost:*',
     }),
     // Add module names to factory functions so they appear in browser profiler.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16906,8 +16906,7 @@
     "react-error-overlay": {
       "version": "5.0.0-next.3e165448",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.0.0-next.3e165448.tgz",
-      "integrity": "sha512-YEDoDZkZWU1+8F1ZvczRYjrMiIQKHqeEwrBcNFIcMWnFMkYT6r7gIH8oBX/mwQlvsCv7kUwbeuN68xal2b7mQw==",
-      "dev": true
+      "integrity": "sha512-YEDoDZkZWU1+8F1ZvczRYjrMiIQKHqeEwrBcNFIcMWnFMkYT6r7gIH8oBX/mwQlvsCv7kUwbeuN68xal2b7mQw=="
     },
     "react-is": {
       "version": "16.4.1",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "prop-types": "^15.6.2",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
+    "react-error-overlay": "^5.0.0-next.3e165448",
     "react-redux": "^4.4.9",
     "react-router-dom": "^4.3.1",
     "react-test-renderer": "^16.4.1",


### PR DESCRIPTION
I've left the CSP script in; hopefully we can revert to that in the future.

To test, add any error to the renderer code and load the app.