### PR TITLE
Improve native navigation behavior

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -57,6 +57,7 @@ class BrowserWindow {
       on: jest.fn(),
       webContents: {
         getURL: jest.fn(),
+        on: jest.fn(),
         openDevTools: jest.fn(),
         send: jest.fn(),
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5737,9 +5737,9 @@
       "dev": true
     },
     "electron": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.4.tgz",
-      "integrity": "sha512-rtg6aW2IpWfiwMRk9gqr+a/xOrFlch9sgLNg0UJzCmtUUEGTrbaLxqANr3Ahlx+ODmh/V+WfF7IdEpD76bbssA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.6.tgz",
+      "integrity": "sha512-1UHBWHF2EMjjVyTvcdcUBmISnoxElY4cUgkFVslw5pM1HxTVzi2vev+8NBohdLLFGbIbPyNua5vcBg+bxo1rqw==",
       "dev": true,
       "requires": {
         "@types/node": "^8.0.24",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "cross-env": "^5.2.0",
     "css-loader": "^1.0.0",
     "dotenv": "^6.0.0",
-    "electron": "^2.0.4",
+    "electron": "^2.0.6",
     "electron-builder": "^20.19.2",
     "electron-log": "^2.2.16",
     "electron-packager": "^12.1.0",

--- a/src/main/MainApp.js
+++ b/src/main/MainApp.js
@@ -19,7 +19,7 @@ const createApp = () => {
   const mainWindow = new MainWindow();
   guiProxy.setMainWindow(mainWindow);
 
-  const openMainWindow = () => mainWindow.open('/overview');
+  const openMainWindow = () => mainWindow.open();
 
   const resetAppData = () => {
     const responseNum = dialog.showMessageBox(mainWindow.window, {
@@ -56,7 +56,7 @@ const createApp = () => {
   const trayMenu = [
     {
       label: 'Overview',
-      click: openMainWindow,
+      click: () => mainWindow.open('/overview'),
     },
     {
       label: 'Quit',
@@ -67,11 +67,6 @@ const createApp = () => {
   const MenuTemplate = [
     {
       submenu: [
-        // {
-        //   label: 'Settings',
-        //   click: () => mainWindow.open('/settings'),
-        // },
-        // { type: 'separator' },
         { role: 'about' },
         { type: 'separator' },
         { role: 'quit' },
@@ -128,11 +123,6 @@ const createApp = () => {
     // Get rid of the macOS primary menu
     MenuTemplate.shift();
     // Add those items elsewhere as appropriate
-    // MenuTemplate[0].submenu.push({ type: 'separator' });
-    // MenuTemplate[0].submenu.push({
-    //   label: 'Settings',
-    //   click: () => mainWindow.open('/settings'),
-    // });
     MenuTemplate[0].submenu.push({ type: 'separator' });
     MenuTemplate[0].submenu.push({ role: 'quit' });
   }
@@ -140,7 +130,7 @@ const createApp = () => {
   const appMenu = Menu.buildFromTemplate(MenuTemplate);
 
   app.on('ready', () => {
-    if (!process.env.DEV_SUPPRESS_WINDOW_DEFAULT_OPEN) {
+    if (!process.env.NC_DEV_SUPPRESS_WINDOW_DEFAULT_OPEN) {
       openMainWindow();
     }
     tray = createTray(trayMenu);

--- a/src/main/components/__tests__/mainWindow-test.js
+++ b/src/main/components/__tests__/mainWindow-test.js
@@ -34,7 +34,7 @@ describe('MainWindow', () => {
   });
 
   describe('.open()', () => {
-    it('It calls window.loadURL with the correct attributes', () => {
+    it('calls window.loadURL with the correct attributes', () => {
       const route = '/foobarbazbuzz';
 
       mainWindow.open(route);
@@ -50,16 +50,40 @@ describe('MainWindow', () => {
       expect(loadUrlCall).toEqual(mainWindowIndexPath);
     });
 
-    it('It focuses the window', () => {
+    it('focuses the window', () => {
       mainWindow.open('/');
       expect(mainWindow.window.show).toHaveBeenCalledTimes(1);
     });
 
-    it('It re-focuses the window', () => {
+    it('re-focuses the window', () => {
       mainWindow.open('/a');
       mainWindow.window.webContents.getURL = jest.fn().mockReturnValueOnce('a');
       mainWindow.open('/b');
       expect(mainWindow.window.show).toHaveBeenCalledTimes(2);
+    });
+
+    it('accepts URLs', () => {
+      const fileUrl = 'file://index.html';
+      mainWindow.open(fileUrl);
+      expect(mainWindow.window.loadURL).toHaveBeenCalledWith(fileUrl);
+    });
+
+    it('shows the default route if none provided', () => {
+      mainWindow.open();
+      expect(mainWindow.window.loadURL).toHaveBeenCalledWith(expect.stringMatching('file://'));
+      expect(mainWindow.window.show).toHaveBeenCalled();
+    });
+
+    it('shows the window without loading (if a URL is already loaded)', () => {
+      // Setup: open once to instantiate `window` & simulate a URL being loaded
+      mainWindow.open('/');
+      mainWindow.window.webContents.getURL = jest.fn().mockReturnValueOnce('a');
+      mainWindow.window.loadURL.mockClear();
+      mainWindow.window.show.mockClear();
+
+      mainWindow.open();
+      expect(mainWindow.window.loadURL).not.toHaveBeenCalled();
+      expect(mainWindow.window.show).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
This improves native navigation behavior:

- Prevent user-spawned new windows (shift/cmd-click); open in main window instead
- Don't force reload when foregrounding app (e.g., from dock)
- Set native window background color to match web app (less jarring when loading)
