### PR TITLE
Reload main window after app reset

### DIFF
--- a/src/main/MainApp.js
+++ b/src/main/MainApp.js
@@ -20,6 +20,7 @@ const createApp = () => {
   guiProxy.setMainWindow(mainWindow);
 
   const openMainWindow = () => mainWindow.open();
+  const reloadHomeScreen = () => mainWindow.open('/overview');
 
   const resetAppData = () => {
     const responseNum = dialog.showMessageBox(mainWindow.window, {
@@ -30,7 +31,7 @@ const createApp = () => {
       defaultId: 0,
     });
     if (responseNum === 0) {
-      adminService.resetData().then(openMainWindow);
+      adminService.resetData().then(reloadHomeScreen);
     }
   };
 
@@ -56,11 +57,11 @@ const createApp = () => {
   const trayMenu = [
     {
       label: 'Overview',
-      click: () => mainWindow.open('/overview'),
+      click: reloadHomeScreen,
     },
     {
       label: 'Quit',
-      click: () => { app.quit(); },
+      click: () => app.quit(),
     },
   ];
 


### PR DESCRIPTION
Fixes #153.

When a user selects "Reset Data..." via the File menu, the application UI should reload, displaying no data. `mainWindow.open` was recently updated to not reload the view unnecessarily, so to force a reload, the call here needs to include the '/overview' route.