### PR TITLE
Make mdns optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
     "electron": "electron ./www",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",
+    "predist:mac": "node scripts/check-env.js darwin",
+    "predist:linux": "node scripts/check-env.js linux",
+    "predist:win": "node scripts/check-env.js win32",
     "dist:mac": "npm run build && electron-builder -m --publish=always",
     "dist:linux": "npm run build && electron-builder -l --publish=always",
     "dist:win": "npm run build && electron-builder -w --publish=always",
-    "dist:all": "npm run build && electron-builder -mlw --publish=always",
     "generate-icons": "node scripts/generate-app-icons.js",
     "preflight": "npm run lint && npm run sass-lint -- --max-warnings 0 && npm run build-docs && node scripts/build-api-spec && npm test -- --coverage"
   },

--- a/scripts/check-env.js
+++ b/scripts/check-env.js
@@ -1,0 +1,22 @@
+/* eslint-env node */
+/* eslint-disable no-console */
+
+const process = require('process');
+const chalk = require('chalk');
+
+const supportedPlatforms = [
+  'darwin',
+  'linux',
+  'win32',
+];
+
+const desiredPlatform = process.argv[2];
+if (!desiredPlatform || !supportedPlatforms.includes(desiredPlatform)) {
+  console.log(chalk.yellow(`Usage: node ${__filename} [darwin|linux|win32]`));
+  process.exit(1);
+}
+
+if (desiredPlatform !== process.platform) {
+  console.log(chalk.red(`This script must be run under ${desiredPlatform}. Current platform: ${process.platform}`));
+  process.exit(2);
+}

--- a/src/main/server/__tests__/mdnsProvider-test.js
+++ b/src/main/server/__tests__/mdnsProvider-test.js
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+/* eslint-disable global-require */
+
+const mockMdns = {};
+const mockLoadError = new Error('error loading module');
+
+jest.mock('electron-log');
+
+describe('mdnsProvider', () => {
+  describe('when MDNS available', () => {
+    beforeAll(() => {
+      jest.resetModules();
+      jest.doMock('mdns', () => mockMdns);
+    });
+
+    it('', () => {
+      const mdnsProvider = require('../mdnsProvider');
+      expect(mdnsProvider.mdnsIsSupported).toBe(true);
+      expect(mdnsProvider.mdns).toBe(mockMdns);
+    });
+  });
+
+  describe('when MDNS throws on require', () => {
+    beforeAll(() => {
+      jest.resetModules();
+      jest.doMock('mdns', () => {
+        throw mockLoadError;
+      });
+    });
+
+    it('', () => {
+      const mdnsProvider = require('../mdnsProvider');
+      expect(mdnsProvider.mdnsIsSupported).toBe(false);
+      expect(mdnsProvider.mdns).toBe(null);
+    });
+  });
+});

--- a/src/main/server/mdnsProvider.js
+++ b/src/main/server/mdnsProvider.js
@@ -1,0 +1,15 @@
+const logger = require('electron-log');
+
+// MDNS is optional; ignore load errors caused by runtime config.
+let mdns = null;
+try {
+  mdns = require('mdns'); // eslint-disable-line global-require
+} catch (err) {
+  logger.warn('MDNS unavailable');
+  logger.warn(err);
+}
+
+module.exports = {
+  mdns,
+  mdnsIsSupported: mdns !== null,
+};

--- a/src/renderer/components/ServerPanel.js
+++ b/src/renderer/components/ServerPanel.js
@@ -3,14 +3,6 @@ import PropTypes from 'prop-types';
 import { PanelItem } from '../components';
 import withApiClient from './withApiClient';
 
-const getKeySnippet = key => key && key.slice(400, 416);
-
-const defaultServerOverview = {
-  ip: 'x.x.x.x',
-  uptime: 0,
-  publicKey: '',
-};
-
 class ServerPanel extends Component {
   constructor() {
     super();
@@ -34,13 +26,24 @@ class ServerPanel extends Component {
     }
     apiClient.get('/health')
       .then((resp) => {
-        const { deviceApiPort, hostname, ip, publicKey, uptime } = resp.serverStatus;
+        const {
+          deviceApiPort,
+          hostname,
+          ip,
+          isAdvertising,
+          mdnsIsSupported,
+          uptime,
+        } = resp.serverStatus;
+        let mdnsStatus = isAdvertising ? 'Active' : 'Pending';
+        if (!mdnsIsSupported) {
+          mdnsStatus = 'Unsupported';
+        }
         this.setState({
           serverOverview: {
             hostname,
             ip: ip && ip.address,
             deviceApiPort,
-            publicKey: getKeySnippet(publicKey),
+            mdnsStatus,
             uptime,
           },
         });
@@ -55,15 +58,15 @@ class ServerPanel extends Component {
   render() {
     const { serverOverview } = this.state;
     const { className } = this.props;
-    const overview = { ...defaultServerOverview, ...serverOverview };
-    const uptimeDisplay = overview.uptime &&
-      `${parseInt(overview.uptime / 1000 / 60, 10)}m`;
+    const overview = { ...serverOverview };
+    const uptimeDisplay = overview.uptime && `${parseInt(overview.uptime / 1000 / 60, 10)}m`;
     return (
       <div className={`server-panel ${className}`}>
         <PanelItem label="Local Server IP" value={overview.ip || 'Offline'} />
         <PanelItem label="Server Port" value={overview.deviceApiPort || '-'} />
-        <PanelItem label="Uptime" value={uptimeDisplay} />
+        <PanelItem label="Uptime" value={uptimeDisplay || '-'} />
         <PanelItem label="Server Hostname" value={overview.hostname || '-'} />
+        <PanelItem label="Service Advertising" value={overview.mdnsStatus || '-'} />
       </div>
     );
   }


### PR DESCRIPTION
This makes MDNS an optional dependency, as runtime OS configuration can cause it to fail when required (see #152). The status of device advertisements is shown in the server panel (along with hostname, uptime etc.)

This also updates the build scripts to prevent cross-compilation, which will always cause MDNS to fail at runtime.

Fixes #152.
