### PR TITLE
Detect expired pairing requests and update UI

### DIFF
--- a/config/jest/setupTestEnv.js
+++ b/config/jest/setupTestEnv.js
@@ -81,6 +81,8 @@ const jsonClient = (useHttps) => {
 
     delete: uri => agent.request(uri, null, 'DELETE'),
 
+    head: uri => agent.request(uri, null, 'HEAD'),
+
     request: (uri, reqData, method) => (
       new Promise((resolve, reject) => {
         let client = http;

--- a/src/main/data-managers/DatabaseAdapter.js
+++ b/src/main/data-managers/DatabaseAdapter.js
@@ -9,7 +9,6 @@ const DbConfig = {
 };
 
 class DatabaseAdapter {
-  // TODO: See comments at DeviceManager.dbClient
   static dbClient(filename, config = {}) {
     if (!this.dbClients) {
       this.dbClients = {};
@@ -73,6 +72,25 @@ class DatabaseAdapter {
    */
   get(id) {
     return this.first({ _id: id });
+  }
+
+  /**
+   * Insert a record into the DB
+   * @async
+   * @param  {Object} data document to insert
+   * @return {Object} the inserted document
+   * @throws {Error} if DB error or document returned from DB is null
+   */
+  create(data) {
+    return new Promise((resolve, reject) => {
+      this.db.insert(data, (err, doc) => {
+        if (err || !doc) {
+          reject(err || new Error('Insert failed'));
+        } else {
+          resolve(doc);
+        }
+      });
+    });
   }
 }
 

--- a/src/main/data-managers/DeviceDB.js
+++ b/src/main/data-managers/DeviceDB.js
@@ -13,19 +13,11 @@ const withDefaultName = dbDevice => ({
  * @extends DatabaseAdapter
  */
 class DeviceDB extends DatabaseAdapter {
-  create(secretHex, deviceName) {
-    return new Promise((resolve, reject) => {
-      this.db.insert({
-        secretKey: secretHex,
-        name: deviceName,
-        _id: uuidv4(),
-      }, (err, doc) => {
-        if (err || !doc) {
-          reject(err || new Error('Insert failed'));
-        } else {
-          resolve(doc);
-        }
-      });
+  createWithSecretAndName(secretHex, deviceName) {
+    return this.create({
+      secretKey: secretHex,
+      name: deviceName,
+      _id: uuidv4(),
     });
   }
 

--- a/src/main/data-managers/DeviceManager.js
+++ b/src/main/data-managers/DeviceManager.js
@@ -9,7 +9,7 @@ class DeviceManager {
   }
 
   exists(deviceId) {
-    return this.db.get(deviceId);
+    return this.db.get(deviceId).then(Boolean);
   }
 
   // TODO: see notes in cipher.js; may want to persist derivation config per-device.
@@ -18,7 +18,7 @@ class DeviceManager {
     if (!secretHex) {
       return Promise.reject(new Error('Invalid input'));
     }
-    return this.db.create(secretHex, deviceName);
+    return this.db.createWithSecretAndName(secretHex, deviceName);
   }
 
   fetchDeviceList() {

--- a/src/main/data-managers/PairingRequestDB.js
+++ b/src/main/data-managers/PairingRequestDB.js
@@ -1,5 +1,28 @@
+const logger = require('electron-log');
 const DatabaseAdapter = require('./DatabaseAdapter');
 
-class PairingRequestDB extends DatabaseAdapter {}
+const dbConfig = {
+  // Note: with in-memory, closing the app will cancel the pairing process.
+  inMemoryOnly: true,
+};
+
+const DeviceRequestTTLSeconds = 5 * 60;
+
+class PairingRequestDB extends DatabaseAdapter {
+  constructor(dbName, additionalConfig = {}) {
+    super(dbName, { ...dbConfig, ...additionalConfig });
+
+    this.db.ensureIndex({
+      fieldName: 'createdAt',
+      expireAfterSeconds: DeviceRequestTTLSeconds,
+    }, (err) => {
+      if (err) { logger.error(err); }
+    });
+
+    Object.defineProperty(this,
+      'deviceRequestTTLSeconds',
+      { configurable: false, writable: false, value: DeviceRequestTTLSeconds });
+  }
+}
 
 module.exports = PairingRequestDB;

--- a/src/main/data-managers/PairingRequestDB.js
+++ b/src/main/data-managers/PairingRequestDB.js
@@ -1,0 +1,5 @@
+const DatabaseAdapter = require('./DatabaseAdapter');
+
+class PairingRequestDB extends DatabaseAdapter {}
+
+module.exports = PairingRequestDB;

--- a/src/main/data-managers/__tests__/DatabaseAdapter-test.js
+++ b/src/main/data-managers/__tests__/DatabaseAdapter-test.js
@@ -1,0 +1,18 @@
+/* eslint-env jest */
+const DatabaseAdapter = require('../DatabaseAdapter');
+
+jest.mock('nedb', () => class nedb {
+  insert = jest.fn().mockImplementation((data, cb) => { cb(null, null); })
+});
+
+describe('abstract DatabaseAdapter', () => {
+  let adapter;
+
+  beforeEach(() => {
+    adapter = new DatabaseAdapter('test', { inMemoryOnly: true });
+  });
+
+  it('rejects with a custom error if insert returns no document', async () => {
+    await expect(adapter.create({})).rejects.toMatchErrorMessage('Insert failed');
+  });
+});

--- a/src/main/data-managers/__tests__/DeviceDB-test.js
+++ b/src/main/data-managers/__tests__/DeviceDB-test.js
@@ -12,19 +12,19 @@ describe('the DeviceManager', () => {
   });
 
   it('creates a new device', async () => {
-    const doc = await dbClient.create(mockSecretHex);
+    const doc = await dbClient.createWithSecretAndName(mockSecretHex);
     expect(doc).toHaveProperty('_id');
   });
 
   it('loads all devices', async () => {
-    await dbClient.create(mockSecretHex);
+    await dbClient.createWithSecretAndName(mockSecretHex);
     const devices = await dbClient.all();
     expect(devices).toBeInstanceOf(Array);
     expect(devices).toHaveLength(1);
   });
 
   it('removes all devices, and returns removed count', async () => {
-    await dbClient.create(mockSecretHex);
+    await dbClient.createWithSecretAndName(mockSecretHex);
     const numRemoved = await dbClient.destroyAll();
     expect(numRemoved).toBe(1);
     expect(await dbClient.all()).toHaveLength(0);
@@ -38,7 +38,7 @@ describe('the DeviceManager', () => {
     });
 
     it('rejects a create', async () => {
-      await expect(dbClient.create(mockSecretHex)).rejects.toThrow(mockError);
+      await expect(dbClient.createWithSecretAndName(mockSecretHex)).rejects.toThrow(mockError);
     });
 
     it('rejects a destroy', async () => {

--- a/src/main/data-managers/__tests__/DeviceDB-test.js
+++ b/src/main/data-managers/__tests__/DeviceDB-test.js
@@ -7,7 +7,7 @@ describe('the DeviceManager', () => {
   let dbClient;
 
   beforeEach((done) => {
-    dbClient = new DeviceDB(null, true);
+    dbClient = new DeviceDB(null, { inMemoryOnly: true });
     dbClient.db.remove({}, { multi: true }, done);
   });
 

--- a/src/main/data-managers/__tests__/DeviceManager-test.js
+++ b/src/main/data-managers/__tests__/DeviceManager-test.js
@@ -14,13 +14,23 @@ describe('the DeviceManager', () => {
 
   it('creates a new device', () => {
     deviceManager.createDeviceDocument(mockSecretHex);
-    expect(deviceManager.db.create).toHaveBeenCalledWith(mockSecretHex, undefined);
+    expect(deviceManager.db.createWithSecretAndName).toHaveBeenCalledWith(mockSecretHex, undefined);
+  });
+
+  it('returns existence (not found)', async () => {
+    deviceManager.db.get.mockResolvedValue(null);
+    expect(await deviceManager.exists('notfound')).toBe(false);
+  });
+
+  it('returns existence (found)', async () => {
+    deviceManager.db.get.mockResolvedValue({});
+    expect(await deviceManager.exists('notfound')).toBe(true);
   });
 
   it('creates a new device with a name', () => {
     const mockName = 'myDevice';
     deviceManager.createDeviceDocument(mockSecretHex, mockName);
-    expect(deviceManager.db.create).toHaveBeenCalledWith(mockSecretHex, mockName);
+    expect(deviceManager.db.createWithSecretAndName).toHaveBeenCalledWith(mockSecretHex, mockName);
   });
 
   it('will not create without a valid secret', async () => {

--- a/src/main/data-managers/__tests__/ProtocolDB-test.js
+++ b/src/main/data-managers/__tests__/ProtocolDB-test.js
@@ -10,7 +10,7 @@ describe('ProtocolDB', () => {
   const mockProtocol = { name: 'a', description: 'v1' };
   let db;
   beforeEach(() => {
-    db = new ProtocolDB(null, true);
+    db = new ProtocolDB(null, { inMemoryOnly: true });
   });
 
   it('persists protocol metadata', async () => {

--- a/src/main/data-managers/__tests__/SessionDB-test.js
+++ b/src/main/data-managers/__tests__/SessionDB-test.js
@@ -10,7 +10,7 @@ describe('SessionDB', () => {
   const mockSessions = [{ uuid: '1', data: {} }, { uuid: '2', data: {} }];
   let sessions;
   beforeEach(() => {
-    sessions = new SessionDB(null, true);
+    sessions = new SessionDB(null, { inMemoryOnly: true });
   });
 
   it('won’t persist without a session', async () => {

--- a/src/main/server/AdminService.js
+++ b/src/main/server/AdminService.js
@@ -6,7 +6,7 @@ const detectPort = require('detect-port');
 const apiRequestLogger = require('./apiRequestLogger');
 const DeviceManager = require('../data-managers/DeviceManager');
 const ProtocolManager = require('../data-managers/ProtocolManager');
-const { DeviceRequestTTLSeconds, PairingRequestService } = require('./devices/PairingRequestService');
+const { PairingRequestService } = require('./devices/PairingRequestService');
 
 const DefaultPort = 8080;
 
@@ -107,7 +107,8 @@ class AdminService {
       this.pairingRequestService.checkRequest(req.params.id)
         .then((pairingRequest) => {
           if (pairingRequest) {
-            const expiresAt = pairingRequest.createdAt.getTime() + (DeviceRequestTTLSeconds * 1000);
+            const ttl = this.pairingRequestService.deviceRequestTTLSeconds * 1000;
+            const expiresAt = pairingRequest.createdAt.getTime() + ttl;
             res.header('Expires', new Date(expiresAt).toJSON());
             res.send(200);
           } else {

--- a/src/main/server/devices/OutOfBandDelegate.js
+++ b/src/main/server/devices/OutOfBandDelegate.js
@@ -77,7 +77,7 @@ const outOfBandDelegate = {
     };
 
     const guiIsReady = sendToGui(emittedEvents.PAIRING_CODE_AVAILABLE,
-      { pairingCode: pairingRequest.pairingCode });
+      { pairingCode: pairingRequest.pairingCode, id: pairingRequest._id });
 
     let promise;
 

--- a/src/main/server/devices/__tests__/DeviceService-test.js
+++ b/src/main/server/devices/__tests__/DeviceService-test.js
@@ -5,6 +5,7 @@ const { apiEvents } = require('../DeviceAPI');
 jest.mock('electron-log');
 jest.mock('../PairingRequestService');
 jest.mock('../DeviceAPI');
+jest.mock('../../../data-managers/DeviceDB');
 
 describe('Device Service', () => {
   let deviceService;

--- a/src/main/server/devices/__tests__/PairingRequestService-test.js
+++ b/src/main/server/devices/__tests__/PairingRequestService-test.js
@@ -16,11 +16,15 @@ describe('PairingRequest Service', () => {
     reqSvc = new PairingRequestService();
   });
 
+  afterEach((done) => {
+    reqSvc.sharedDb.db.remove({}, { multi: true }, () => done());
+  });
+
   it('creates a new request', (done) => {
-    reqSvc.db.count({}, (err, initialCount) => {
+    reqSvc.sharedDb.db.count({}, (err, initialCount) => {
       reqSvc.createRequest()
         .then(() => {
-          reqSvc.db.count({}, (err2, count) => {
+          reqSvc.sharedDb.db.count({}, (err2, count) => {
             expect(count).toBe(initialCount + 1);
             done();
           });
@@ -57,6 +61,11 @@ describe('PairingRequest Service', () => {
     await expect(
       reqSvc.verifyAndExpireRequest(),
     ).rejects.toBeInstanceOf(Error);
+  });
+
+  it('checks for validity', async () => {
+    const req = await reqSvc.createRequest();
+    expect(await reqSvc.checkRequest(req._id)).toEqual(req);
   });
 
   describe('encrypted request', () => {

--- a/src/renderer/containers/App.js
+++ b/src/renderer/containers/App.js
@@ -65,7 +65,7 @@ class App extends Component {
     });
 
     ipcRenderer.on(IPC.PAIRING_CODE_AVAILABLE, (event, data) => {
-      props.newPairingRequest(data.pairingCode);
+      props.newPairingRequest(data.id, data.pairingCode);
     });
 
     ipcRenderer.on(IPC.PAIRING_TIMED_OUT, () => {

--- a/src/renderer/containers/PairDevice.js
+++ b/src/renderer/containers/PairDevice.js
@@ -19,10 +19,9 @@ class PairDevice extends Component {
         apiClient.checkPairingCodeExpired(pairingRequest.id)
           .then(({ isExpired, expiresAt }) => {
             if (isExpired) {
-              clearTimeout(this.timer);
-              this.timer = null;
               dismissPairingRequest();
               showMessage('Pairing timed out');
+              this.timer = null;
             } else {
               let expiresIn = new Date(expiresAt) - new Date();
               if (isNaN(expiresIn) || expiresIn < DefaultExpiredCheckInterval) {

--- a/src/renderer/containers/PairDevice.js
+++ b/src/renderer/containers/PairDevice.js
@@ -1,52 +1,100 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
+import withApiClient from '../components/withApiClient';
 import { actionCreators, PairingStatus } from '../ducks/modules/pairingRequest';
+import { actionCreators as messageActionCreators } from '../ducks/modules/appMessages';
 import { Modal, PairPin } from '../components';
 
-const PairDevice = ({ pairingRequest, dismissPairingRequest }) => (
-  <div>
-    <Modal
-      show={pairingRequest.status === PairingStatus.Complete}
-      title="All Set!"
-      onComplete={dismissPairingRequest}
-      className="modal--pairing-confirmation"
-    >
-      <p>
-        Your device is now paired with this installation of Server.
-        You can now access interview protocols stored on Server and upload data from the field.
-      </p>
-    </Modal>
-    <Modal
-      show={(pairingRequest.status === PairingStatus.Acknowledged)}
-      title="Pair a Device"
-      onCancel={dismissPairingRequest}
-      unmountOnExit
-    >
-      <PairPin code={pairingRequest.pairingCode} />
-    </Modal>
-  </div>
-);
+const DefaultExpiredCheckInterval = 1000;
+
+class PairDevice extends Component {
+  componentDidUpdate() {
+    if (!this.timer &&
+        this.props.pairingRequest.status === PairingStatus.Acknowledged) {
+      const { apiClient, dismissPairingRequest, showMessage, pairingRequest } = this.props;
+      const doCheck = () => {
+        apiClient.checkPairingCodeExpired(pairingRequest.id)
+          .then(({ isExpired, expiresAt }) => {
+            if (isExpired) {
+              clearTimeout(this.timer);
+              this.timer = null;
+              dismissPairingRequest();
+              showMessage('Pairing timed out');
+            } else {
+              let expiresIn = new Date(expiresAt) - new Date();
+              if (isNaN(expiresIn) || expiresIn < DefaultExpiredCheckInterval) {
+                expiresIn = DefaultExpiredCheckInterval;
+              }
+              this.timer = setTimeout(doCheck, expiresIn);
+            }
+          });
+      };
+      this.timer = setTimeout(doCheck, DefaultExpiredCheckInterval);
+    }
+
+    if (this.timer && this.props.pairingRequest.status !== PairingStatus.Acknowledged) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.timer);
+  }
+
+  render() {
+    const { pairingRequest, dismissPairingRequest } = this.props;
+    return (
+      <div>
+        <Modal
+          show={pairingRequest.status === PairingStatus.Complete}
+          title="All Set!"
+          onComplete={dismissPairingRequest}
+          className="modal--pairing-confirmation"
+        >
+          <p>
+            Your device is now paired with this installation of Server.
+            You can now access interview protocols stored on Server and upload data from the field.
+          </p>
+        </Modal>
+        <Modal
+          show={(pairingRequest.status === PairingStatus.Acknowledged)}
+          title="Pair a Device"
+          onCancel={dismissPairingRequest}
+          unmountOnExit
+        >
+          <PairPin code={pairingRequest.pairingCode} />
+        </Modal>
+      </div>
+    );
+  }
+}
 
 PairDevice.propTypes = {
+  apiClient: PropTypes.object.isRequired,
   dismissPairingRequest: PropTypes.func.isRequired,
   pairingRequest: PropTypes.shape({
+    id: PropTypes.string,
     pairingCode: PropTypes.string,
     status: PropTypes.string,
   }).isRequired,
+  showMessage: PropTypes.func.isRequired,
 };
 
 const mapDispatchToProps = dispatch => ({
   dismissPairingRequest: bindActionCreators(actionCreators.dismissPairingRequest, dispatch),
+  showMessage: bindActionCreators(messageActionCreators.showMessage, dispatch),
 });
 
 const mapStateToProps = ({ pairingRequest }) => ({
   pairingRequest,
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(PairDevice);
+export default connect(mapStateToProps, mapDispatchToProps)(withApiClient(PairDevice));
+
 export {
   PairDevice as UnconnectedPairDevice,
 };

--- a/src/renderer/containers/__tests__/PairDevice-test.js
+++ b/src/renderer/containers/__tests__/PairDevice-test.js
@@ -9,7 +9,11 @@ import { PairingStatus } from '../../ducks/modules/pairingRequest';
 const mockPin = '1a';
 
 const makeProps = status => ({
-  dismissPairingRequest: () => {},
+  apiClient: {
+    checkPairingCodeExpired: jest.fn().mockResolvedValue({}),
+  },
+  showMessage: jest.fn(),
+  dismissPairingRequest: jest.fn(),
   pairingRequest: {
     pairingCode: status ? mockPin : null,
     status,
@@ -37,6 +41,15 @@ describe('<PairDevice />', () => {
   it('render a completion message', () => {
     const subject = shallow(<PairDevice {...makeProps(PairingStatus.Complete)} />);
     expect(subject.find('p').text()).toMatch(/device is now paired/);
+  });
+
+  it('checks for updates', () => {
+    jest.useFakeTimers();
+    const props = { ...makeProps(PairingStatus.Acknowledged) };
+    const subject = shallow(<PairDevice {...props} />);
+    subject.setProps({ update: true });
+    jest.runAllTimers();
+    expect(props.apiClient.checkPairingCodeExpired).toHaveBeenCalled();
   });
 
   describe('Connected', () => {

--- a/src/renderer/ducks/modules/__tests__/pairingRequest-test.js
+++ b/src/renderer/ducks/modules/__tests__/pairingRequest-test.js
@@ -2,14 +2,16 @@
 
 import reducer, { actionCreators, actionTypes, PairingStatus, selectors } from '../pairingRequest';
 
+const id = 'request1';
 const pairingCode = 'abc123';
 
 describe('the pairing request module', () => {
   describe('action creator', () => {
     it('exports a new action', () => {
-      expect(actionCreators.newPairingRequest(pairingCode)).toEqual({
+      expect(actionCreators.newPairingRequest(id, pairingCode)).toEqual({
         type: actionTypes.NEW_PAIRING_REQUEST,
         pairingCode,
+        id,
       });
     });
 
@@ -38,7 +40,7 @@ describe('the pairing request module', () => {
     });
 
     it('moves to the pending state', () => {
-      const state = reducer(undefined, actionCreators.newPairingRequest(pairingCode));
+      const state = reducer(undefined, actionCreators.newPairingRequest(id, pairingCode));
       expect(state.status).toEqual(PairingStatus.Pending);
     });
 
@@ -55,7 +57,7 @@ describe('the pairing request module', () => {
     });
 
     it('handles dissmissing', () => {
-      const initialState = actionCreators.newPairingRequest(pairingCode);
+      const initialState = actionCreators.newPairingRequest(id, pairingCode);
       const state = reducer(initialState, actionCreators.dismissPairingRequest());
       expect(state.status).toBeUndefined();
       expect(state.pairingCode).toBeUndefined();

--- a/src/renderer/ducks/modules/pairingRequest.js
+++ b/src/renderer/ducks/modules/pairingRequest.js
@@ -34,6 +34,7 @@ const reducer = (state = initialState, action = {}) => {
         ...state,
         status: PairingStatus.Pending,
         pairingCode: action.pairingCode,
+        id: action.id,
       };
     default:
       return state;
@@ -60,9 +61,10 @@ const dismissPairingRequest = () => (
   }
 );
 
-const newPairingRequest = pairingCode => (
+const newPairingRequest = (id, pairingCode) => (
   {
     type: NEW_PAIRING_REQUEST,
+    id,
     pairingCode,
   }
 );

--- a/src/renderer/utils/adminApiClient.js
+++ b/src/renderer/utils/adminApiClient.js
@@ -44,7 +44,8 @@ class AdminApiClient {
           isExpired,
           expiresAt: resp.headers.get('expires'),
         };
-      });
+      })
+      .catch(() => ({ isExpired: undefined, expiresAt: undefined }));
   }
 
   head(route) {

--- a/src/renderer/utils/adminApiClient.js
+++ b/src/renderer/utils/adminApiClient.js
@@ -33,6 +33,24 @@ class AdminApiClient {
     return this.constructor.port || null;
   }
 
+  checkPairingCodeExpired(pairingRequestId) {
+    return this.head(`/pairing_requests/${pairingRequestId}`)
+      .then((resp) => {
+        let isExpired;
+        if (resp.status === 404) { isExpired = true; }
+        if (resp.status === 200) { isExpired = false; }
+        // else (server error): undefined
+        return {
+          isExpired,
+          expiresAt: resp.headers.get('expires'),
+        };
+      });
+  }
+
+  head(route) {
+    return fetch(this.resolveRoute(route), { method: 'HEAD' });
+  }
+
   /**
    * @param  {string} route
    * @return {Promise}


### PR DESCRIPTION
Resolves #133.

When a pairing code is acknowledged, but then expires (after 5 minutes), the Server UI should automatically replace the displayed pairing code with an error message saying that the code has expired.

To verify this, you may want to change the [request TTL in PairingRequestDB](https://github.com/codaco/Server/compare/feature/detect-expired-code?expand=1#diff-e703823244bc2b6d315210e56c57b25dR9) from 5 minutes to something like 30 seconds. Then:

- Start the pairing process from NC
- Acknowledge the request in Server
- Wait for at least [TTL] seconds

Server UI should update as described above.