### PR TITLE
Make it harder to accidentally close Pairing Code modal

### DIFF
--- a/src/renderer/components/Modal.js
+++ b/src/renderer/components/Modal.js
@@ -21,7 +21,7 @@ function Modal(props) {
 
   return (
     <ModalTransition in={show}>
-      <div key="modal" className={`modal ${className}`} onClick={onCancel || onComplete}>
+      <div key="modal" className={`modal ${className}`}>
         <div className="modal__background" transition-role="background" />
         <div className="modal__window" transition-role="window" onClick={e => e.stopPropagation()}>
           <div className="modal__layout">

--- a/src/renderer/components/__tests__/Modal-test.js
+++ b/src/renderer/components/__tests__/Modal-test.js
@@ -1,0 +1,24 @@
+/* eslint-env jest */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Modal from '../Modal';
+
+const props = {
+  title: 'mock',
+  onCancel: jest.fn(),
+};
+
+describe('Modal', () => {
+  it('is not closed when clicking the background', () => {
+    const modal = shallow(<Modal {...props} />);
+    modal.find('.modal').simulate('click');
+    expect(props.onCancel).not.toHaveBeenCalled();
+  });
+
+  it('is closed when clicking the cancel button', () => {
+    const modal = shallow(<Modal {...props} />);
+    modal.find('Button').simulate('click');
+    expect(props.onCancel).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This requires the user to click the Cancel button to dismiss the Pairing Code modal.

If a user double-clicks or otherwise unintentionally clicks the modal background, then the pairing code is lost and cannot be retrieved on the UI and they would need to restart the pairing process.

Partial fix for #163.