### PR TITLE
Add additional chart/data integration

### DIFF
--- a/src/main/server/AdminService.js
+++ b/src/main/server/AdminService.js
@@ -155,6 +155,7 @@ class AdminService {
         .then(() => next());
     });
 
+    // "counts": { "sessions": 1, "nodes": 20, "edges": 0 }
     api.get('/protocols/:id/reports/total_counts', (req, res, next) => {
       this.reportDb.totalCounts(req.params.id)
         .then(counts => res.send({ status: 'ok', counts }))

--- a/src/renderer/components/DummyDashboardFragment.js
+++ b/src/renderer/components/DummyDashboardFragment.js
@@ -7,7 +7,7 @@ import { interviewData, barData, pieData, lineData } from '../utils/dummy_data';
 const DummyDashboardFragment = ({ className }) => (
   <React.Fragment>
     <div className={`${className}__panel ${className}__panel-mock`}><InterviewWidget data={interviewData} /></div>
-    <div className={`${className}__panel ${className}__panel-mock`}><BarChart data={barData} /></div>
+    <div className={`${className}__panel ${className}__panel-mock`}><BarChart data={barData} dataKeys={['pv', 'uv']} /></div>
     <div className={`${className}__panel ${className}__panel-mock`}><PieChart data={pieData} /></div>
     <div className={`${className}__panel ${className}__panel-mock`}><LineChart data={lineData} /></div>
   </React.Fragment>

--- a/src/renderer/components/SessionHistoryPanel.js
+++ b/src/renderer/components/SessionHistoryPanel.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import BarChart from './charts/BarChart';
+import EmptyData from './charts/EmptyData';
+
+const buildChartContent = (sessions) => {
+  if (!sessions.length) {
+    return <EmptyData />;
+  }
+
+  const dataLabel = 'Interviews';
+  const countsByDay = {};
+
+  // Group by date & format for bar chart:
+  // [{ updatedAt: Date('2018-x-x'), _id: '' }, ...]
+  // => { '2018-x-x': n, ... }
+  // => [{ name: '2018-x-x', Interviews: n }, ...],
+
+  sessions.forEach((session) => {
+    const dateStr = new Date(session.updatedAt.getTime()).toDateString();
+    countsByDay[dateStr] = countsByDay[dateStr] || 0;
+    countsByDay[dateStr] += 1;
+  });
+
+  const barData = Object.entries(countsByDay)
+    .map(([dateStr, count]) => ({ name: dateStr, [dataLabel]: count }))
+    .reverse();
+
+  return <BarChart data={barData} dataKeys={[dataLabel]} />;
+};
+
+/**
+ * Displays a bar chart of session counts, grouped by day
+ */
+const SessionHistoryPanel = ({ sessions }) => (
+  <div className="dashboard__panel dashboard__panel--chart">
+    <h4>Interviews by import date</h4>
+    <div className="dashboard__chartContainer">
+      { buildChartContent(sessions) }
+    </div>
+  </div>
+);
+
+SessionHistoryPanel.propTypes = {
+  sessions: PropTypes.array.isRequired,
+};
+
+export default SessionHistoryPanel;

--- a/src/renderer/components/__tests__/SessionHistoryPanel-test.js
+++ b/src/renderer/components/__tests__/SessionHistoryPanel-test.js
@@ -1,0 +1,17 @@
+/* eslint-env jest */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import SessionHistoryPanel from '../SessionHistoryPanel';
+
+describe('SessionHistoryPanel', () => {
+  it('renders a bar chart of sessions', () => {
+    const wrapper = shallow(<SessionHistoryPanel sessions={[{ updatedAt: new Date() }]} />);
+    expect(wrapper.find('BarChart')).toHaveLength(1);
+  });
+
+  it('renders no chart when sessions are empty', () => {
+    const wrapper = shallow(<SessionHistoryPanel sessions={[]} />);
+    expect(wrapper.find('BarChart')).toHaveLength(0);
+  });
+});

--- a/src/renderer/components/charts/BarChart.js
+++ b/src/renderer/components/charts/BarChart.js
@@ -2,25 +2,38 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { BarChart as RechartBarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 
-import { getCSSValueDict } from '../../utils/css-variables';
+import { getCSSValueDict, getCSSValues } from '../../utils/css-variables';
 
-const colorDict = getCSSValueDict('--graph-data-1', '--graph-tooltip');
+const colorDict = getCSSValueDict('--graph-tooltip');
+const barColors = getCSSValues(
+  '--graph-data-1',
+  '--graph-data-2',
+  '--graph-data-3',
+  '--graph-data-4',
+);
 
 // 99% width to work around recharts problem with resizing
-const BarChart = ({ className, data }) => (
+const BarChart = ({ className, data, dataKeys }) => (
   <ResponsiveContainer height="100%" width="99%">
     <RechartBarChart
       data={data}
       barGap={0}
       barCategoryGap={0}
+      maxBarSize={50}
       className={className}
     >
       <XAxis dataKey="name" />
       <YAxis />
       <CartesianGrid strokeDasharray="3 3" />
       <Tooltip labelStyle={{ color: colorDict['--graph-tooltip'] }} />
-      <Legend />
-      <Bar dataKey="pv" fill={colorDict['--graph-data-1']} />
+      {
+        dataKeys.length > 1 ? <Legend /> : null
+      }
+      {
+        dataKeys.map((dataKey, i) => (
+          <Bar key={dataKey} dataKey={dataKey} fill={barColors[i % barColors.length]} />
+        ))
+      }
     </RechartBarChart>
   </ResponsiveContainer>
 );
@@ -32,6 +45,7 @@ BarChart.defaultProps = {
 BarChart.propTypes = {
   className: PropTypes.string,
   data: PropTypes.array.isRequired,
+  dataKeys: PropTypes.array.isRequired,
 };
 
 export default BarChart;

--- a/src/renderer/components/charts/EmptyData.js
+++ b/src/renderer/components/charts/EmptyData.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default () => (
+  <div className="dashboard__emptyData">
+    <p>No data to display</p>
+  </div>
+);

--- a/src/renderer/components/charts/__tests__/BarChart-test.js
+++ b/src/renderer/components/charts/__tests__/BarChart-test.js
@@ -5,7 +5,7 @@ import BarChart from '../BarChart';
 
 describe('<BarChart />', () => {
   it('defines a Bar series', () => {
-    const wrapper = shallow(<BarChart data={[]} />);
+    const wrapper = shallow(<BarChart data={[{ name: 'a', val: 1 }]} dataKeys={['val']} />);
     expect(wrapper.find('Bar').length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/src/renderer/components/charts/__tests__/EmptyData-test.js
+++ b/src/renderer/components/charts/__tests__/EmptyData-test.js
@@ -1,0 +1,11 @@
+/* eslint-env jest */
+import React from 'react';
+import { shallow } from 'enzyme';
+import EmptyData from '../EmptyData';
+
+describe('<EmptyData />', () => {
+  it('renders a message ', () => {
+    const wrapper = shallow(<EmptyData />);
+    expect(wrapper.text()).toMatch('No data');
+  });
+});

--- a/src/renderer/components/index.js
+++ b/src/renderer/components/index.js
@@ -20,5 +20,6 @@ export { default as PieChart } from './charts/PieChart';
 export { default as Scrollable } from './Scrollable';
 export { default as ScrollingPanelItem } from './ScrollingPanelItem';
 export { default as ServerPanel } from './ServerPanel';
+export { default as SessionHistoryPanel } from './SessionHistoryPanel';
 export { default as SessionPanel } from './SessionPanel';
 export { default as TabBar } from './TabBar';

--- a/src/renderer/containers/ProtocolCountsPanel.js
+++ b/src/renderer/containers/ProtocolCountsPanel.js
@@ -3,11 +3,14 @@ import PropTypes from 'prop-types';
 
 import CountsWidget from '../components/charts/CountsWidget';
 import withApiClient from '../components/withApiClient';
+import { formatDecimal } from '../utils/formatters';
 
 const shapeCountData = (nodeCount, edgeCount, sessionCount) => ([
-  { name: 'Node count', count: nodeCount },
-  { name: 'Edge count', count: edgeCount },
-  { name: 'Interview count', count: sessionCount },
+  { name: 'Total Nodes', count: nodeCount },
+  { name: 'Total Edges', count: edgeCount },
+  { name: 'Total Interviews', count: sessionCount },
+  { name: 'Mean Nodes / Interview', count: sessionCount && formatDecimal(nodeCount / sessionCount) },
+  { name: 'Mean Edges / Interview', count: sessionCount && formatDecimal(edgeCount / sessionCount) },
 ]);
 
 class ProtocolCountsPanel extends Component {

--- a/src/renderer/containers/WorkspaceScreen.js
+++ b/src/renderer/containers/WorkspaceScreen.js
@@ -8,9 +8,15 @@ import Types from '../types';
 import ProtocolCountsPanel from './ProtocolCountsPanel';
 import withApiClient from '../components/withApiClient';
 import viewModelMapper from '../utils/baseViewModelMapper';
-import { DummyDashboardFragment, ProtocolPanel, ServerPanel, SessionPanel } from '../components';
 import { Spinner } from '../ui';
 import { selectors } from '../ducks/modules/protocols';
+import {
+  DummyDashboardFragment,
+  ProtocolPanel,
+  ServerPanel,
+  SessionHistoryPanel,
+  SessionPanel,
+} from '../components';
 
 class WorkspaceScreen extends Component {
   static getDerivedStateFromProps(props, state) {
@@ -97,7 +103,7 @@ class WorkspaceScreen extends Component {
   render() {
     const { protocol } = this.props;
     const { sessions, totalSessionsCount } = this.state;
-    if (!protocol) {
+    if (!protocol || !sessions) {
       return <div className="workspace--loading"><Spinner /></div>;
     }
     return (
@@ -105,18 +111,21 @@ class WorkspaceScreen extends Component {
         <div className="dashboard">
           <ServerPanel className="dashboard__panel dashboard__panel--server-stats" />
           <ProtocolPanel protocol={protocol} />
-          <SessionPanel
-            sessions={sessions}
-            totalCount={totalSessionsCount}
-            deleteAllSessions={() => this.deleteAllSessions()}
-            deleteSession={sessionId => this.deleteSession(sessionId)}
-          />
           <ProtocolCountsPanel
             key={`protocol-counts-${protocol.id}`}
             protocolId={protocol.id}
             updatedAt={protocol.updatedAt}
             sessionCount={totalSessionsCount}
           />
+          <SessionPanel
+            sessions={sessions}
+            totalCount={totalSessionsCount}
+            deleteAllSessions={() => this.deleteAllSessions()}
+            deleteSession={sessionId => this.deleteSession(sessionId)}
+          />
+          {
+            sessions && <SessionHistoryPanel sessions={sessions} />
+          }
           <DummyDashboardFragment key={`dummy-${protocol.id}`} />
         </div>
       </div>

--- a/src/renderer/containers/__tests__/ProtocolCountsPanel-test.js
+++ b/src/renderer/containers/__tests__/ProtocolCountsPanel-test.js
@@ -1,34 +1,48 @@
 /* eslint-env jest */
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
-import ProtocolCountsPanel from '../ProtocolCountsPanel';
+import ConnectedProtocolCountsPanel, { UnconnectedProtocolCountsPanel } from '../ProtocolCountsPanel';
 import AdminApiClient from '../../utils/adminApiClient';
+
+jest.mock('../../utils/adminApiClient');
 
 const props = {
   protocolId: '1',
 };
 
-jest.mock('../../utils/adminApiClient');
-
 describe('ProtocolCountsPanel', () => {
   let subject;
   let mockApiClient;
 
+  beforeEach(() => {
+    mockApiClient = new AdminApiClient();
+  });
+
   it('renders a dashboard panel', () => {
-    subject = mount(<ProtocolCountsPanel {...props} />);
+    subject = shallow(<UnconnectedProtocolCountsPanel {...props} apiClient={mockApiClient} />);
     expect(subject.find('.dashboard__panel')).toHaveLength(1);
   });
 
   it('renders counts in a widget', () => {
-    subject = mount(<ProtocolCountsPanel {...props} />);
+    subject = shallow(<UnconnectedProtocolCountsPanel {...props} apiClient={mockApiClient} />);
     expect(subject.find('CountsWidget')).toHaveLength(1);
+  });
+
+  it('displays totals and averages', async () => {
+    mockApiClient.get.mockResolvedValueOnce({ counts: { sessions: 2, nodes: 15, edges: 13 } });
+    subject = await mount(<UnconnectedProtocolCountsPanel {...props} apiClient={mockApiClient} />);
+    subject.update();
+    const text = subject.find('CountsWidget').text();
+    expect(text).toMatch(/Total Nodes: 15/);
+    expect(text).toMatch(/Total Edges: 13/);
+    expect(text).toMatch(/Mean.*: 7\.5/);
+    expect(text).toMatch(/Mean.*: 6\.5/);
   });
 
   describe('api client', () => {
     beforeEach(() => {
-      subject = mount(<ProtocolCountsPanel {...props} />);
-      mockApiClient = new AdminApiClient();
+      subject = mount(<ConnectedProtocolCountsPanel {...props} />);
     });
 
     it('loads data from API on mount', () => {

--- a/src/renderer/containers/__tests__/WorkspaceScreen-test.js
+++ b/src/renderer/containers/__tests__/WorkspaceScreen-test.js
@@ -29,6 +29,18 @@ describe('<WorkspaceScreen />', () => {
     expect(wrapper.find('Spinner')).toHaveLength(1);
   });
 
+  it('renders a loading state until sessions load', () => {
+    wrapper.setProps({ protocol: mockProtocol });
+    expect(wrapper.find('Spinner')).toHaveLength(1);
+  });
+
+  it('renders dashboard panels once loaded', () => {
+    wrapper.setProps({ protocol: mockProtocol });
+    wrapper.setState({ sessions: [] });
+    expect(wrapper.find('Spinner')).toHaveLength(0);
+    expect(wrapper.find('.dashboard__panel').length).toBeGreaterThan(0);
+  });
+
   it('loads sessions when new set imported', () => {
     wrapper.instance().loadSessions = jest.fn();
     wrapper.instance().onSessionsImported();
@@ -70,11 +82,6 @@ describe('<WorkspaceScreen />', () => {
     const state = { prevProtocolId: 1 };
     const props = { protocol: { id: 2 } };
     expect(WorkspaceScreen.getDerivedStateFromProps(state, props)).toBe(null);
-  });
-
-  it('renders dashboard panels', () => {
-    wrapper.setProps({ protocol: mockProtocol });
-    expect(wrapper.find('.dashboard__panel').length).toBeGreaterThan(0);
   });
 
   it('deletes one session', () => {

--- a/src/renderer/styles/components/_dashboard.scss
+++ b/src/renderer/styles/components/_dashboard.scss
@@ -25,6 +25,12 @@
       }
     }
 
+    @include modifier(chart) {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+
     @include modifier(scrollable) {
       --scrolling-panel-header-height: 1rem;
       --scrolling-panel-header-margin: #{spacing(medium)};
@@ -42,5 +48,18 @@
     @include modifier(server-stats) {
       grid-area: 1 / span $column-count;
     }
+  }
+
+  @include element(chartContainer) {
+    flex: 0 1 100%;
+  }
+
+  @include element(emptyData) {
+    color: var(--color-platinum--dark);
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: center;
+    text-align: center;
   }
 }

--- a/src/renderer/utils/formatters.js
+++ b/src/renderer/utils/formatters.js
@@ -1,7 +1,11 @@
 const dateOpts = { year: '2-digit', month: 'numeric', day: 'numeric' };
 
-const formatDate = d => d && d.toLocaleString(undefined, dateOpts);
+const decimalFormatter = new Intl.NumberFormat();
+
+const formatDate = d => (d ? d.toLocaleString(undefined, dateOpts) : '');
+const formatDecimal = n => (isNaN(n) ? '' : decimalFormatter.format(n));
 
 export {
-  formatDate, // eslint-disable-line import/prefer-default-export
+  formatDate,
+  formatDecimal,
 };


### PR DESCRIPTION
This adds a couple more simple data displays to the dashboard:

|interview counts by date|averages on widget|
|-|-|
|![bar](https://user-images.githubusercontent.com/39674/45169572-eac42280-b1cb-11e8-90e9-5776d5dc6646.png)|![counts](https://user-images.githubusercontent.com/39674/45169825-66be6a80-b1cc-11e8-8f1e-713bd6689a4f.png)|
| no data imported: ||
|![empty](https://user-images.githubusercontent.com/39674/45169577-ec8de600-b1cb-11e8-8e3a-9a398f13d250.png)|![counts-empty](https://user-images.githubusercontent.com/39674/45169904-94a3af00-b1cc-11e8-8bae-32b75a418b78.png)|


