### PR TITLE
Fix overlay script CSP for development

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -6,7 +6,7 @@ const getClientEnvironment = require('./env');
 
 const baseConfig = require('./webpack.config.js');
 
-const inlineCSP = require('./inlineCSP');
+// const inlineCSP = require('./inlineCSP');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
 
@@ -99,7 +99,7 @@ const config = {
       // generate an explicit hash. In the latest version of these tools multiple levels
       // of indirection make getting at the code to hash very brittle.
       // For now, hardcode to current version (react-error-overlay@5.0.0-next.3e165448)
-      REACT_APP_SCRIPT_SRC_CSP: "'sha256-gDC0EVcPe9MimCS3ZP14teSHr0GtEx+ggc0VQBfyvRI='",
+      REACT_APP_SCRIPT_SRC_CSP: "'sha256-krS8bpkNCT0q3QRkQCSGbnVy53cU1MDnfjOgdAhnj7w='",
       // Whitelist dev server websockets content in Content Security Policy
       REACT_APP_CONNECT_SRC_CSP: 'ws://localhost:* wss://localhost:*',
     }),


### PR DESCRIPTION
Updates the CSP hash for react-error-overlay, which was updated for the windows fix in #174.