### PR TITLE
Allow device unpairing from modal

### DIFF
--- a/src/main/data-managers/DeviceDB.js
+++ b/src/main/data-managers/DeviceDB.js
@@ -2,6 +2,9 @@
 const uuidv4 = require('uuid/v4');
 
 const DatabaseAdapter = require('./DatabaseAdapter');
+const { resolveOrReject } = require('../utils/db');
+
+const missingRequiredIdMessage = 'Cannot delete device without an id';
 
 const withDefaultName = dbDevice => ({
   name: `Device ${dbDevice._id.substr(0, 6)}`,
@@ -34,6 +37,13 @@ class DeviceDB extends DatabaseAdapter {
           resolve(numRemoved);
         }
       });
+    });
+  }
+
+  destroy(deviceId) {
+    return new Promise((resolve, reject) => {
+      if (!deviceId) { reject(new Error(missingRequiredIdMessage)); }
+      this.db.remove({ _id: deviceId }, { multi: false }, resolveOrReject(resolve, reject));
     });
   }
 }

--- a/src/main/data-managers/DeviceManager.js
+++ b/src/main/data-managers/DeviceManager.js
@@ -29,6 +29,10 @@ class DeviceManager {
   destroyAllDevices() {
     return this.db.destroyAll();
   }
+
+  destroy(deviceId) {
+    return this.db.destroy(deviceId);
+  }
 }
 
 module.exports = DeviceManager;

--- a/src/main/data-managers/__tests__/DeviceDB-test.js
+++ b/src/main/data-managers/__tests__/DeviceDB-test.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+/* eslint-disable no-underscore-dangle */
 const DeviceDB = require('../DeviceDB');
 
 const mockSecretHex = 'd7ff85d1ce04a59d848a87945f341c06323f7f9a356b5ac982c15481e0117fdc';
@@ -28,6 +29,17 @@ describe('the DeviceManager', () => {
     const numRemoved = await dbClient.destroyAll();
     expect(numRemoved).toBe(1);
     expect(await dbClient.all()).toHaveLength(0);
+  });
+
+  it('removes one device, and returns removed count', async () => {
+    const device = await dbClient.createWithSecretAndName(mockSecretHex);
+    const numRemoved = await dbClient.destroy(device._id);
+    expect(numRemoved).toBe(1);
+    expect(await dbClient.all()).toHaveLength(0);
+  });
+
+  it('requires an ID for deletion', async () => {
+    expect(dbClient.destroy()).rejects.toMatchErrorMessage('Cannot delete device without an id');
   });
 
   describe('when underlying db fails', () => {

--- a/src/main/data-managers/__tests__/DeviceManager-test.js
+++ b/src/main/data-managers/__tests__/DeviceManager-test.js
@@ -49,5 +49,10 @@ describe('the DeviceManager', () => {
       deviceManager.destroyAllDevices();
       expect(deviceManager.db.destroyAll).toHaveBeenCalled();
     });
+
+    it('removes a device', () => {
+      deviceManager.destroy('someId');
+      expect(deviceManager.db.destroy).toHaveBeenCalled();
+    });
   });
 });

--- a/src/main/server/AdminService.js
+++ b/src/main/server/AdminService.js
@@ -104,6 +104,16 @@ class AdminService {
         .then(() => next());
     });
 
+    api.del('/devices/:id', (req, res, next) => {
+      this.deviceManager.destroy(req.params.id)
+        .then(() => res.send({ status: 'ok' }))
+        .catch((err) => {
+          logger.error(err);
+          res.send(500, { status: 'error' });
+        })
+        .then(() => next());
+    });
+
     api.head('/pairing_requests/:id', (req, res, next) => {
       this.pairingRequestService.checkRequest(req.params.id)
         .then((pairingRequest) => {

--- a/src/main/server/__tests__/AdminService-test.js
+++ b/src/main/server/__tests__/AdminService-test.js
@@ -117,6 +117,7 @@ describe('the AdminService', () => {
 
         beforeAll(() => {
           DeviceManager.mockImplementation(() => ({
+            destroy: () => Promise.resolve({}),
             fetchDeviceList: () => Promise.resolve(mockDevices),
           }));
         });
@@ -126,15 +127,25 @@ describe('the AdminService', () => {
           expect(resp.json.devices).toEqual(mockDevices);
         });
 
+        it('deletes a device', async () => {
+          const res = await jsonClient.delete(`${endpoint}/1`);
+          expect(res.json).toEqual({ status: 'ok' });
+        });
+
         describe('when manager fails', () => {
           beforeAll(() => {
             DeviceManager.mockImplementation(() => ({
+              destroy: () => Promise.reject({ error: 'mock' }),
               fetchDeviceList: () => Promise.reject({ error: 'mock' }),
             }));
           });
 
-          it('sends an error', async () => {
+          it('sends an error for the device list', async () => {
             await expect(jsonClient.get(endpoint)).rejects.toMatchObject({ statusCode: 500 });
+          });
+
+          it('sends an error for device deletion', async () => {
+            await expect(jsonClient.delete(`${endpoint}/1`)).rejects.toMatchObject({ statusCode: 500 });
           });
         });
       });

--- a/src/renderer/components/DeviceList.js
+++ b/src/renderer/components/DeviceList.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import Instructions from './Instructions';
 import DeviceDetails from './DeviceDetails';
 
+import { Button } from '../ui/components';
+
 const EmptyDeviceList = () => (
   <div>
     <h2>No devices found.</h2>
@@ -11,20 +13,37 @@ const EmptyDeviceList = () => (
   </div>
 );
 
-const DeviceList = ({ devices }) => {
+const DeviceList = ({ deleteDevice, devices }) => {
+  const confirmDelete = (deviceId) => {
+    if (deleteDevice && confirm('Remove this device?')) { // eslint-disable-line no-alert
+      deleteDevice(deviceId);
+    }
+  };
+
   if (!devices || !devices.length) {
     return <EmptyDeviceList />;
   }
+
   return devices.map(device => (
-    <DeviceDetails key={device.id} device={device} />
+    <div className="device-list__device" key={device.id}>
+      <DeviceDetails device={device} />
+      {
+        deleteDevice &&
+        <Button size="small" color="neon-coral" onClick={() => confirmDelete(device.id)}>
+          Unpair
+        </Button>
+      }
+    </div>
   ));
 };
 
 DeviceList.defaultProps = {
+  deleteDevice: null,
   devices: null,
 };
 
 DeviceList.propTypes = {
+  deleteDevice: PropTypes.func,
   devices: PropTypes.array,
 };
 

--- a/src/renderer/components/Modal.js
+++ b/src/renderer/components/Modal.js
@@ -11,6 +11,7 @@ import { Modal as ModalTransition } from '../components/transitions';
  */
 function Modal(props) {
   const {
+    closeWhenBackgroundClicked,
     children,
     className,
     onCancel,
@@ -21,7 +22,7 @@ function Modal(props) {
 
   return (
     <ModalTransition in={show}>
-      <div key="modal" className={`modal ${className}`}>
+      <div key="modal" className={`modal ${className}`} onClick={closeWhenBackgroundClicked && (onCancel || onComplete)}>
         <div className="modal__background" transition-role="background" />
         <div className="modal__window" transition-role="window" onClick={e => e.stopPropagation()}>
           <div className="modal__layout">
@@ -53,6 +54,7 @@ function Modal(props) {
 }
 
 Modal.propTypes = {
+  closeWhenBackgroundClicked: PropTypes.bool,
   className: PropTypes.string,
   onCancel: PropTypes.func,
   onComplete: PropTypes.func,
@@ -62,6 +64,7 @@ Modal.propTypes = {
 };
 
 Modal.defaultProps = {
+  closeWhenBackgroundClicked: false,
   className: '',
   onCancel: null,
   onComplete: null,

--- a/src/renderer/components/Modal.js
+++ b/src/renderer/components/Modal.js
@@ -20,9 +20,14 @@ function Modal(props) {
     title,
   } = props;
 
+  let backgroundClickHandler = null;
+  if (closeWhenBackgroundClicked) {
+    backgroundClickHandler = onCancel || onComplete;
+  }
+
   return (
     <ModalTransition in={show}>
-      <div key="modal" className={`modal ${className}`} onClick={closeWhenBackgroundClicked && (onCancel || onComplete)}>
+      <div key="modal" className={`modal ${className}`} onClick={backgroundClickHandler}>
         <div className="modal__background" transition-role="background" />
         <div className="modal__window" transition-role="window" onClick={e => e.stopPropagation()}>
           <div className="modal__layout">

--- a/src/renderer/components/PairedDeviceModal.js
+++ b/src/renderer/components/PairedDeviceModal.js
@@ -3,8 +3,9 @@ import React from 'react';
 import Types, { PropTypes } from '../types';
 import { DeviceList, Modal, Overflow } from '../components';
 
-const PairedDeviceModal = ({ devices, onComplete, show }) => (
+const PairedDeviceModal = ({ deleteDevice, devices, onComplete, show }) => (
   <Modal
+    closeWhenBackgroundClicked
     show={show}
     title="Paired Devices"
     onComplete={onComplete}
@@ -12,19 +13,21 @@ const PairedDeviceModal = ({ devices, onComplete, show }) => (
   >
     <div className="paired-device-list">
       <Overflow size="huge">
-        <DeviceList devices={devices} />
+        <DeviceList deleteDevice={deleteDevice} devices={devices} />
       </Overflow>
     </div>
   </Modal>
 );
 
 PairedDeviceModal.defaultProps = {
+  deleteDevice: null,
   devices: [],
   onComplete: () => {},
   show: false,
 };
 
 PairedDeviceModal.propTypes = {
+  deleteDevice: PropTypes.func,
   devices: Types.devices,
   onComplete: PropTypes.func,
   show: PropTypes.bool,

--- a/src/renderer/components/__tests__/DeviceList-test.js
+++ b/src/renderer/components/__tests__/DeviceList-test.js
@@ -4,9 +4,11 @@ import { mount, shallow } from 'enzyme';
 
 import DeviceList from '../DeviceList';
 
+
 describe('<DeviceList />', () => {
+  const mockDevice = { id: '1', name: 'a', createdAt: new Date() };
+
   it('renders device details', () => {
-    const mockDevice = { id: '1', name: 'a', createdAt: new Date() };
     const wrapper = mount(<DeviceList devices={[mockDevice]} />);
     expect(wrapper.find('DeviceDetails')).toHaveLength(1);
   });
@@ -19,5 +21,21 @@ describe('<DeviceList />', () => {
   it('renders instructions when no devices saved', () => {
     const wrapper = mount(<DeviceList devices={[]} />);
     expect(wrapper.find('Instructions')).toHaveLength(1);
+  });
+
+  it('renders an unpair button when needed', () => {
+    const wrapper = mount(<DeviceList devices={[mockDevice]} deleteDevice={() => {}} />);
+    const button = wrapper.find('Button');
+    expect(button).toHaveLength(1);
+    expect(button.text()).toMatch('Unpair');
+  });
+
+  it('renders an unpair button when needed', () => {
+    global.confirm = jest.fn().mockReturnValue(true);
+    const deleteSpy = jest.fn();
+    const wrapper = mount(<DeviceList devices={[mockDevice]} deleteDevice={deleteSpy} />);
+    const button = wrapper.find('Button');
+    button.simulate('click');
+    expect(deleteSpy).toHaveBeenCalledWith(mockDevice.id);
   });
 });

--- a/src/renderer/components/__tests__/Modal-test.js
+++ b/src/renderer/components/__tests__/Modal-test.js
@@ -16,6 +16,12 @@ describe('Modal', () => {
     expect(props.onCancel).not.toHaveBeenCalled();
   });
 
+  it('is closed when clicking the background if requested', () => {
+    const modal = shallow(<Modal {...props} closeWhenBackgroundClicked />);
+    modal.find('.modal').simulate('click');
+    expect(props.onCancel).toHaveBeenCalled();
+  });
+
   it('is closed when clicking the cancel button', () => {
     const modal = shallow(<Modal {...props} />);
     modal.find('Button').simulate('click');

--- a/src/renderer/containers/DeviceStatus.js
+++ b/src/renderer/containers/DeviceStatus.js
@@ -31,7 +31,7 @@ class DeviceStatus extends Component {
   }
 
   render() {
-    const { dark, devices, hasPendingRequest } = this.props;
+    const { dark, deleteDevice, devices, hasPendingRequest } = this.props;
     let buttonClass = 'device-icon';
     if (dark) {
       buttonClass += ` ${buttonClass}--dark`;
@@ -47,6 +47,7 @@ class DeviceStatus extends Component {
           devices={devices}
           show={this.state.showModal && !hasPendingRequest}
           onComplete={this.toggleShow}
+          deleteDevice={deleteDevice}
         />
       </React.Fragment>
     );
@@ -56,12 +57,14 @@ class DeviceStatus extends Component {
 DeviceStatus.defaultProps = {
   dark: false,
   devices: [],
+  deleteDevice: null,
   hasPendingRequest: false,
   loadDevices: () => {},
 };
 
 DeviceStatus.propTypes = {
   dark: PropTypes.bool,
+  deleteDevice: PropTypes.func,
   devices: Types.devices,
   hasPendingRequest: PropTypes.bool,
   loadDevices: PropTypes.func,
@@ -73,6 +76,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
+  deleteDevice: bindActionCreators(actionCreators.deleteDevice, dispatch),
   loadDevices: bindActionCreators(actionCreators.loadDevices, dispatch),
 });
 

--- a/src/renderer/containers/PairDevice.js
+++ b/src/renderer/containers/PairDevice.js
@@ -49,6 +49,7 @@ class PairDevice extends Component {
     return (
       <div>
         <Modal
+          closeWhenBackgroundClicked
           show={pairingRequest.status === PairingStatus.Complete}
           title="All Set!"
           onComplete={dismissPairingRequest}

--- a/src/renderer/ducks/modules/__tests__/devices-test.js
+++ b/src/renderer/ducks/modules/__tests__/devices-test.js
@@ -34,8 +34,8 @@ describe('the devices module', () => {
         dispatcher.mockClear();
       });
 
-      it('exports an async "load" action', () => {
-        actionCreators.loadDevices()(dispatcher);
+      it('exports an async "load" action', async () => {
+        await actionCreators.loadDevices()(dispatcher);
         expect(dispatcher).toHaveBeenCalledWith({ type: actionTypes.LOAD_DEVICES });
         expect(mockApiClient.get).toHaveBeenCalled();
       });
@@ -44,6 +44,34 @@ describe('the devices module', () => {
         const err = new Error('mock error');
         mockApiClient.get.mockRejectedValue(err);
         await actionCreators.loadDevices()(dispatcher);
+        expect(dispatcher).toHaveBeenCalledWith(expect.objectContaining({ text: err.message }));
+      });
+    });
+
+    describe('deleteDevice', () => {
+      const dispatcher = jest.fn();
+      const mockApiClient = new AdminApiClient();
+
+      beforeEach(() => {
+        dispatcher.mockClear();
+        mockApiClient.get.mockResolvedValue([]);
+      });
+
+      it('exports an async "delete" action', async () => {
+        await actionCreators.deleteDevice('abc')(dispatcher);
+        expect(dispatcher).toHaveBeenCalledWith({ type: actionTypes.DELETE_DEVICE, deviceId: 'abc' });
+        expect(mockApiClient.delete).toHaveBeenCalled();
+      });
+
+      it('reloads after delete', async () => {
+        await actionCreators.deleteDevice('abc')(dispatcher);
+        expect(dispatcher).toHaveBeenCalledWith({ type: actionTypes.LOAD_DEVICES });
+      });
+
+      it('handles errors internally', async () => {
+        const err = new Error('mock error');
+        mockApiClient.get.mockRejectedValue(err);
+        await actionCreators.deleteDevice('abc')(dispatcher);
         expect(dispatcher).toHaveBeenCalledWith(expect.objectContaining({ text: err.message }));
       });
     });

--- a/src/renderer/ducks/modules/devices.js
+++ b/src/renderer/ducks/modules/devices.js
@@ -4,6 +4,7 @@ import { actionCreators as messageActionCreators } from './appMessages';
 
 const LOAD_DEVICES = 'LOAD_DEVICES';
 const DEVICES_LOADED = 'DEVICES_LOADED';
+const DELETE_DEVICE = 'DELETE_DEVICE';
 
 // Null state: Load has not completed
 const initialState = null;
@@ -27,30 +28,44 @@ const reducer = (state = initialState, action = {}) => {
   }
 };
 
-const loadDevicesDispatch = () => ({
+const loadDevicesAction = () => ({
   type: LOAD_DEVICES,
 });
 
-const devicesLoadedDispatch = devices => ({
+const devicesLoadedAction = devices => ({
   type: DEVICES_LOADED,
   devices: devices || [],
 });
 
 const loadDevices = () => (dispatch) => {
-  dispatch(loadDevicesDispatch());
+  dispatch(loadDevicesAction());
   return getApiClient().get('/devices')
     .then(resp => resp.devices)
-    .then(devices => dispatch(devicesLoadedDispatch(devices)))
+    .then(devices => dispatch(devicesLoadedAction(devices)))
+    .catch(err => dispatch(messageActionCreators.showMessage(err.message)));
+};
+
+const deleteDeviceAction = deviceId => ({
+  type: DELETE_DEVICE,
+  deviceId,
+});
+
+const deleteDevice = deviceId => (dispatch) => {
+  dispatch(deleteDeviceAction(deviceId));
+  return getApiClient().delete(`devices/${deviceId}`)
+    .then(() => loadDevices()(dispatch))
     .catch(err => dispatch(messageActionCreators.showMessage(err.message)));
 };
 
 const actionCreators = {
   loadDevices,
+  deleteDevice,
 };
 
 const actionTypes = {
   LOAD_DEVICES,
   DEVICES_LOADED,
+  DELETE_DEVICE,
 };
 
 export {

--- a/src/renderer/styles/_z-indexes.scss
+++ b/src/renderer/styles/_z-indexes.scss
@@ -1,5 +1,5 @@
 :root {
   --z-index-protocol-tooltip: 90;
-  --z-index-app-messages: 100;
-  --z-index-modal: 1000;
+  --z-index-modal: 100;
+  --z-index-app-messages: 1000;
 }

--- a/src/renderer/styles/components/_all.scss
+++ b/src/renderer/styles/components/_all.scss
@@ -2,6 +2,7 @@
 @import './counts-widget';
 @import './dashboard';
 @import './device';
+@import './device-list';
 @import './dismiss-button';
 @import './get-started';
 @import './header';

--- a/src/renderer/styles/components/_device-list.scss
+++ b/src/renderer/styles/components/_device-list.scss
@@ -1,0 +1,7 @@
+.device-list {
+  @include element(device) {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 2rem;
+  }
+}

--- a/src/renderer/styles/components/_device.scss
+++ b/src/renderer/styles/components/_device.scss
@@ -1,6 +1,4 @@
 .device {
-  margin-bottom: 2rem;
-
   @include element(name) {
     margin-bottom: spacing('tiny');
   }


### PR DESCRIPTION
Corresponds to https://github.com/codaco/Network-Canvas/pull/694, which enabled unpairing from the client. This adds an "unpair" button to each device in the device list so that a user can unpair a device without resetting all app data.

Also:
- restores the ability to close modals from BG click (opt-in; the pairing modals still do not close in this case.)
- displays the error message above the modal background. If an error is displayed as a result of modal action, it should be visible.
