### PR TITLE
Improve error text for incorrect pairing

### DIFF
--- a/src/main/errors/RequestError.js
+++ b/src/main/errors/RequestError.js
@@ -16,16 +16,16 @@ class RequestError extends Error {
 }
 
 const ErrorMessages = {
-  DecryptionFailed: 'Decryption failed',
   EmptyFilelist: 'Empty filelist',
   FilelistNotSingular: 'Multiple files must be uploaded separately',
-  InvalidContainerFile: 'Invalid File',
+  InvalidContainerFile: 'Invalid file',
   InvalidContainerFileExtension: 'File must have a ".netcanvas" extension',
-  InvalidProtocolFormat: 'Invalid Protocol Format',
+  InvalidPairingCode: 'Incorrect pairing code',
+  InvalidProtocolFormat: 'Invalid protocol format',
   InvalidRequestBody: 'Could not parse request data',
-  InvalidZip: 'Invalid ZIP File',
+  InvalidZip: 'Invalid ZIP file',
   MissingProtocolFile: 'Missing protocol file',
-  NotFound: 'Not Found',
+  NotFound: 'Not found',
   ProtocolNotFoundForSession: 'The associated protocol does not exist on this server',
   VerificationFailed: 'Request verification failed',
 };

--- a/src/main/server/devices/PairingRequestService.js
+++ b/src/main/server/devices/PairingRequestService.js
@@ -50,9 +50,10 @@ class PairingRequestService {
           const secretBytes = deriveSecretKeyBytes(doc.pairingCode, fromHex(doc.salt));
           plaintext = decrypt(messageHex, toHex(secretBytes));
         } catch (decipherErr) {
-          // This could be from either derivation or decryption
+          // This could be from either derivation or decryption; by far the most likely
+          // issue is a mis-typed pairing code.
           logger.debug(decipherErr);
-          reject(new RequestError(ErrorMessages.DecryptionFailed));
+          reject(new RequestError(ErrorMessages.InvalidPairingCode));
           return;
         }
         try {


### PR DESCRIPTION
Fixes https://github.com/codaco/Network-Canvas/issues/749. The message is now "Incorrect pairing code". NC can eventually produce its own strings if needed, but this is a reasonable user-facing error message to have in Server anyway.

Also standardizes case on all messages.