### PR TITLE
Prevent navigation to unexpected URLs

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -39,7 +39,7 @@ const remote = {
   },
 };
 
-const Tray = jest.fn().mockImplementation(() => ({
+const Tray = jest.fn(() => ({
   on: jest.fn(),
   setContextMenu: jest.fn(),
   setToolTip: jest.fn(),
@@ -50,22 +50,18 @@ const Menu = {
   setApplicationMenu: jest.fn(),
 };
 
-class BrowserWindow {
-  constructor() {
-    return {
-      loadURL: jest.fn(),
-      maximize: jest.fn(),
-      show: jest.fn(),
-      on: jest.fn(),
-      webContents: {
-        getURL: jest.fn(),
-        on: jest.fn(),
-        openDevTools: jest.fn(),
-        send: jest.fn(),
-      },
-    };
-  }
-}
+const BrowserWindow = jest.fn(() => ({
+  loadURL: jest.fn(),
+  maximize: jest.fn(),
+  show: jest.fn(),
+  on: jest.fn(),
+  webContents: {
+    getURL: jest.fn(),
+    on: jest.fn(),
+    openDevTools: jest.fn(),
+    send: jest.fn(),
+  },
+}));
 
 BrowserWindow.getAllWindows = jest.fn().mockReturnValue([]);
 

--- a/src/main/components/__tests__/mainWindow-test.js
+++ b/src/main/components/__tests__/mainWindow-test.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const url = require('url');
 const { EventEmitter } = require('events');
+const { BrowserWindow } = require('electron');
 
 const MainWindow = require('../mainWindow');
 
@@ -98,6 +99,33 @@ describe('MainWindow', () => {
     it('Drops messages when no window open', () => {
       const sent = mainWindow.send('foo');
       expect(sent).toBe(false);
+    });
+  });
+
+  describe('webContent', () => {
+    let mockEvt;
+    beforeEach(() => {
+      const mockWebContents = new EventEmitter();
+      mockWebContents.getURL = jest.fn();
+      mockEvt = { preventDefault: jest.fn() };
+      BrowserWindow.mockImplementationOnce(() => ({
+        getURL: jest.fn(),
+        loadURL: jest.fn(),
+        on: jest.fn(),
+        show: jest.fn(),
+        webContents: mockWebContents,
+      }));
+      mainWindow.create();
+    });
+
+    it('prevents navigation away from app', () => {
+      mainWindow.window.webContents.emit('will-navigate', mockEvt, 'http://example.com');
+      expect(mockEvt.preventDefault).toHaveBeenCalled();
+    });
+
+    it('prevents new windows form opening', () => {
+      mainWindow.window.webContents.emit('new-window', mockEvt, 'http://example.com');
+      expect(mockEvt.preventDefault).toHaveBeenCalled();
     });
   });
 });

--- a/src/main/components/mainWindow.js
+++ b/src/main/components/mainWindow.js
@@ -75,6 +75,12 @@ class MainWindow {
       evt.preventDefault();
       this.open(newUrl);
     });
+
+    // For now, any navigation off the SPA is unneeded
+    this.window.webContents.on('will-navigate', (evt) => {
+      evt.preventDefault();
+    });
+
     loadDevToolsExtensions();
   }
 


### PR DESCRIPTION
While there is no intended mechanism to navigate away from the app URL within the app, this prevents any other (unexpected/untrusted) URLs from loading in the main window.