### PR TITLE
Fix unlimited opening of dialogs

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -1,7 +1,5 @@
 /* eslint-env jest */
 
-// const electron = jest.genMockFromModule('electron');
-
 const ipcRenderer = {
   on: jest.fn(),
   once: jest.fn(),

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dist:linux": "npm run build && electron-builder -l --publish=always",
     "dist:win": "npm run build && electron-builder -w --publish=always",
     "generate-icons": "node scripts/generate-app-icons.js",
-    "preflight": "npm run lint && npm run sass-lint -- --max-warnings 0 && npm run build-docs && node scripts/build-api-spec && npm test -- --coverage"
+    "preflight": "npm run lint -- --max-warnings 0 && npm run sass-lint -- --max-warnings 0 && npm run build-docs && node scripts/build-api-spec && npm test -- --coverage"
   },
   "repository": {
     "type": "git",

--- a/scripts/build-api-spec.js
+++ b/scripts/build-api-spec.js
@@ -1,10 +1,12 @@
+/* eslint-env node */
+/* eslint-disable no-console */
+
 const fs = require('fs');
 const path = require('path');
 const swaggerJSDoc = require('swagger-jsdoc');
 
 const paths = require('../config/paths');
-const { ApiVersion } = require('../src/main/server/devices/DeviceAPI');
-const { DefaultHttpsPort } = require('../src/main/server/devices/DeviceService');
+const { DeviceAPIConfig } = require('../src/main/apiConfig');
 
 const deviceApiSource = path.join(__dirname, '..', 'src', 'main', 'server', 'devices', 'DeviceAPI.js');
 
@@ -22,13 +24,13 @@ HTTPS endpoints handle communications between a paired Client & Server.
 
 const options = {
   swaggerDefinition: {
-    host: `localhost:${DefaultHttpsPort}`,
+    host: `localhost:${DeviceAPIConfig.DefaultHttpsPort}`,
     basePath: '/',
     schemes: ['http', 'https'],
     info: {
       title: 'Network Canvas Devices API',
       description,
-      version: ApiVersion,
+      version: DeviceAPIConfig.Version,
       license: {
         name: 'GNU General Public License v3.0',
         url: 'https://github.com/codaco/Server/blob/master/LICENSE',
@@ -40,7 +42,7 @@ const options = {
 };
 
 const destDir = path.join(paths.config, 'api');
-const destPath = path.join(destDir, `api-spec-${ApiVersion}.json`);
+const destPath = path.join(destDir, `api-spec-${DeviceAPIConfig.version}.json`);
 const destFile = fs.openSync(destPath, 'w');
 
 const apiSpec = swaggerJSDoc(options);

--- a/scripts/build-electron-dev.js
+++ b/scripts/build-electron-dev.js
@@ -1,3 +1,6 @@
+/* eslint-env node */
+/* eslint-disable no-console */
+
 const fs = require('fs-extra');
 const path = require('path');
 const paths = require('../config/paths');

--- a/src/main/MainApp.js
+++ b/src/main/MainApp.js
@@ -1,5 +1,4 @@
-const { app, dialog, Menu } = require('electron');
-
+const { app, Menu } = require('electron');
 const ProtocolManager = require('./data-managers/ProtocolManager');
 const MainWindow = require('./components/mainWindow');
 const { AdminService } = require('./server/AdminService');
@@ -8,6 +7,7 @@ const { createTray } = require('./components/tray');
 
 const guiProxy = require('./guiProxy');
 const updater = require('./updater');
+const dialog = require('./dialog');
 
 // TODO: move/centralize
 const FileImportUpdated = 'FILE_IMPORT_UPDATED';

--- a/src/main/MainApp.js
+++ b/src/main/MainApp.js
@@ -37,7 +37,7 @@ const createApp = () => {
   };
 
   const showImportProtocolDialog = () => {
-    protocolManager.presentImportDialog()
+    protocolManager.presentImportDialog(mainWindow.window)
       .then((filename) => {
         // If filename is empty, user cancelled
         if (filename) {

--- a/src/main/__mocks__/dialog.js
+++ b/src/main/__mocks__/dialog.js
@@ -1,0 +1,1 @@
+module.exports = require('../../../__mocks__/electron').dialog;

--- a/src/main/__tests__/dialog.js
+++ b/src/main/__tests__/dialog.js
@@ -1,0 +1,34 @@
+/* eslint-env jest */
+
+const { dialog } = require('electron');
+
+const dialogProxy = require('../dialog');
+const { globalDialogLock } = require('../dialogLock');
+
+jest.mock('../dialogLock');
+
+describe('the dialog proxy', () => {
+  beforeEach(() => {
+    globalDialogLock.isLocked = false;
+  });
+
+  it('implements methods from electron dialog', () => {
+    Object.keys(dialog).forEach((fn) => {
+      expect(dialogProxy[fn]).toBeDefined();
+    });
+  });
+
+  it('prevents consecutive dialog opens when a callback is available', () => {
+    dialog.showOpenDialog.mockClear();
+    dialogProxy.showOpenDialog({}, jest.fn());
+    dialogProxy.showOpenDialog({}, jest.fn());
+    expect(dialog.showOpenDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not prevent if no callback is available', () => {
+    dialog.showOpenDialog.mockClear();
+    dialogProxy.showOpenDialog({});
+    dialogProxy.showOpenDialog({});
+    expect(dialog.showOpenDialog).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/main/__tests__/updater-test.js
+++ b/src/main/__tests__/updater-test.js
@@ -1,10 +1,11 @@
 /* eslint-env jest */
 
-const { dialog } = require('electron');
 const updater = require('../updater');
+const dialog = require('../dialog');
 
 jest.mock('electron');
 jest.mock('electron-updater');
+jest.mock('../dialog');
 
 describe('updater', () => {
   beforeEach(() => {

--- a/src/main/apiConfig.js
+++ b/src/main/apiConfig.js
@@ -1,0 +1,7 @@
+module.exports = {
+  DeviceAPIConfig: {
+    Version: '0.0.14',
+    DefaultHttpPort: 51001,
+    DefaultHttpsPort: 51002,
+  },
+};

--- a/src/main/data-managers/ProtocolManager.js
+++ b/src/main/data-managers/ProtocolManager.js
@@ -47,7 +47,7 @@ class ProtocolManager {
    *                                     `undefined` if no files were selected
    * @throws {Error} If importing of any input file failed
    */
-  presentImportDialog() {
+  presentImportDialog(browserWindow) {
     const opts = {
       title: 'Import Protocol',
       properties: ['openFile'],
@@ -56,7 +56,7 @@ class ProtocolManager {
       ],
     };
     return new Promise((resolve, reject) => {
-      dialog.showOpenDialog(opts, (filePaths) => {
+      dialog.showOpenDialog(browserWindow, opts, (filePaths) => {
         if (!filePaths) {
           // User cancelled
           resolve();

--- a/src/main/data-managers/ProtocolManager.js
+++ b/src/main/data-managers/ProtocolManager.js
@@ -3,8 +3,8 @@ const jszip = require('jszip');
 const logger = require('electron-log');
 const path = require('path');
 const uuid = require('uuid/v4');
-const { dialog } = require('electron');
 
+const dialog = require('../dialog');
 const ProtocolDB = require('./ProtocolDB');
 const SessionDB = require('./SessionDB');
 const { ErrorMessages, RequestError } = require('../errors/RequestError');

--- a/src/main/data-managers/__tests__/ProtocolManager-test.js
+++ b/src/main/data-managers/__tests__/ProtocolManager-test.js
@@ -1,10 +1,10 @@
 /* eslint-env jest */
 import fs from 'fs';
-import { dialog } from 'electron';
 import JSZip from 'jszip';
 
 import ProtocolManager from '../ProtocolManager';
 import promisedFs from '../../utils/promised-fs';
+import dialog from '../../dialog';
 
 jest.mock('fs');
 jest.mock('electron');
@@ -13,6 +13,7 @@ jest.mock('jszip');
 jest.mock('../../utils/promised-fs');
 jest.mock('../ProtocolDB');
 jest.mock('../SessionDB');
+jest.mock('../../dialog');
 
 const anyNetcanvasFile = expect.stringMatching(/\.netcanvas$/);
 

--- a/src/main/data-managers/__tests__/ProtocolManager-test.js
+++ b/src/main/data-managers/__tests__/ProtocolManager-test.js
@@ -40,7 +40,7 @@ describe('ProtocolManager', () => {
     });
 
     it('allows an import via the open dialog', (done) => {
-      const simulateChooseFile = (opts, callback) => {
+      const simulateChooseFile = (browserWindow, opts, callback) => {
         callback(mockFileList);
         expect(manager.validateAndImport).toHaveBeenCalled();
         done();
@@ -52,7 +52,7 @@ describe('ProtocolManager', () => {
 
     it('allows dialog to be cancelled', (done) => {
       expect.assertions(1);
-      const simulateChooseNothing = (opts, callback) => {
+      const simulateChooseNothing = (browserWindow, opts, callback) => {
         callback();
         expect(manager.validateAndImport).not.toHaveBeenCalled();
         done();

--- a/src/main/dialog.js
+++ b/src/main/dialog.js
@@ -1,0 +1,50 @@
+const { dialog } = require('electron');
+
+const { globalDialogLock } = require('./dialogLock');
+
+const proxiedDialogMethod = (func) => {
+  const handler = {
+    apply: (target, thisArg, argumentsList) => {
+      if (globalDialogLock.isLocked) {
+        return undefined;
+      }
+      const callback = argumentsList[argumentsList.length - 1];
+      if (typeof callback === 'function') {
+        globalDialogLock.isLocked = true;
+        argumentsList.splice(-1, 1, (...args) => {
+          globalDialogLock.isLocked = false;
+          callback(...args);
+        });
+      }
+      return target.apply(thisArg, argumentsList);
+    },
+  };
+  return new Proxy(func, handler);
+};
+
+/**
+ * A proxy to electron's dialog.
+ *
+ * dialog is proxied in order to prevent multiple native dialogs from opening.
+ * This includes any dialog with a callback (notably, for file opening and messaging).
+ * When the callback is fired, the lock is released.
+ *
+ * This prevents issues when multiple modal dialogs are used (for example, the 'reset'
+ * message not being shown and its menu item then being disabled until app restart).
+ *
+ * All app components should use this proxy rather than including
+ * [electron's dialog]{@link https://electronjs.org/docs/api/dialog} directly.
+ *
+ * @type {Object}
+ */
+const dialogProxy = {};
+
+Object.entries(dialog).forEach(([k, v]) => {
+  if (typeof v === 'function') {
+    dialogProxy[k] = proxiedDialogMethod(v);
+  } else {
+    dialogProxy[k] = v;
+  }
+});
+
+module.exports = dialogProxy;

--- a/src/main/dialogLock.js
+++ b/src/main/dialogLock.js
@@ -1,0 +1,5 @@
+module.exports = {
+  globalDialogLock: {
+    isLocked: false,
+  },
+};

--- a/src/main/server/devices/DeviceAPI.js
+++ b/src/main/server/devices/DeviceAPI.js
@@ -12,6 +12,7 @@ const DeviceManager = require('../../data-managers/DeviceManager');
 const ProtocolManager = require('../../data-managers/ProtocolManager');
 const apiRequestLogger = require('../apiRequestLogger');
 const deviceAuthenticator = require('./deviceAuthenticator');
+const { Version } = require('../../apiConfig').DeviceAPIConfig;
 const { PairingRequestService } = require('./PairingRequestService');
 const { ErrorMessages, RequestError } = require('../../errors/RequestError');
 const { IncompletePairingError } = require('../../errors/IncompletePairingError');
@@ -45,7 +46,7 @@ const lanIP = () => {
  *       For the pairing protocol (`GET /devices/new`, `POST `/devices`), no deviceId is required (nor available).
  */
 const ApiName = 'DeviceAPI';
-const ApiVersion = '0.0.14';
+const ApiVersion = Version;
 const ApiHostName = '0.0.0.0'; // IPv4 for compatibility with Travis (& unknown installations)
 
 const Schema = {
@@ -691,7 +692,6 @@ class DeviceAPI extends EventEmitter {
 
 module.exports = {
   default: DeviceAPI,
-  ApiVersion,
   DeviceAPI,
   apiEvents: emittedEvents,
 };

--- a/src/main/server/devices/DeviceService.js
+++ b/src/main/server/devices/DeviceService.js
@@ -2,10 +2,8 @@ const { EventEmitter } = require('events');
 const logger = require('electron-log');
 
 const { DeviceAPI, apiEvents } = require('./DeviceAPI');
+const { DefaultHttpPort, DefaultHttpsPort } = require('../../apiConfig').DeviceAPIConfig;
 const { emittedEvents: pairingEvents, outOfBandDelegate } = require('./OutOfBandDelegate');
-
-const DefaultHttpPort = 51001;
-const DefaultHttpsPort = 51002;
 
 const emittedEvents = {
   ...apiEvents,

--- a/src/main/updater.js
+++ b/src/main/updater.js
@@ -1,6 +1,7 @@
 const logger = require('electron-log');
 const { autoUpdater } = require('electron-updater');
-const { app, dialog } = require('electron');
+const { app } = require('electron');
+const dialog = require('./dialog');
 
 const releasesUrl = 'https://github.com/codaco/Server/releases';
 


### PR DESCRIPTION
Fixes #169, where multiple native dialogs (e.g., file open) could be opened at once.

This makes the following changes:
- standardizes on modal dialogs, which improves the UX for opening
- centralizes dialog handling so that only a single [callback-driven] native dialog is opened at once
    - even with modals, this handling is needed on macOS
    - locking across different dialogs is required to prevent buggy behavior seen with the reset data modal
- Cleans up config/imports so that app code need not be imported by the API spec script