### PR TITLE
Fix addresses displayed in Instructions

### DIFF
--- a/src/renderer/components/Instructions.js
+++ b/src/renderer/components/Instructions.js
@@ -48,8 +48,8 @@ const Instructions = ({ compact, apiInfo, showPairingInstructions, showImportIns
               you may enter the connection information manually:</em>
             </p>
             <dl className="instructions__definition-list">
-              <dt>Address</dt>
-              <dd>{apiInfo.address}</dd>
+              <dt>Addresses</dt>
+              <dd>{apiInfo.publicAddresses.join(', ')}</dd>
               <dt>Port</dt>
               <dd>{apiInfo.httpPort}</dd>
             </dl>

--- a/src/renderer/components/__tests__/Instructions-test.js
+++ b/src/renderer/components/__tests__/Instructions-test.js
@@ -31,9 +31,9 @@ describe('<Instructions />', () => {
   });
 
   it('renders API info', () => {
-    const apiInfo = { address: '192.168.x.x', httpPort: 65531 };
+    const apiInfo = { publicAddresses: ['192.168.x.x'], httpPort: 65531 };
     const subject = shallow(<Instructions apiInfo={apiInfo} />);
-    expect(subject.text()).toMatch(apiInfo.address);
+    expect(subject.text()).toMatch(apiInfo.publicAddresses[0]);
     expect(subject.text()).toMatch(apiInfo.httpPort.toString());
   });
 });

--- a/src/renderer/containers/__tests__/OverviewScreen-test.js
+++ b/src/renderer/containers/__tests__/OverviewScreen-test.js
@@ -37,7 +37,7 @@ describe('<OverviewScreen />', () => {
     const state = {
       devices: [{ id: 'device1', name: '1', createdAt: new Date() }],
       protocols: [{ id: 'protocol1', name: '1', createdAt: new Date() }],
-      connectionInfo: { deviceService: { httpPort: 5555, address: '192.168.x.x' } },
+      connectionInfo: { deviceService: { httpPort: 5555, publicAddresses: ['192.168.x.x'] } },
     };
     let store;
     beforeEach(() => {

--- a/src/renderer/types.js
+++ b/src/renderer/types.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 
 const deviceApiInfo = PropTypes.shape({
-  address: PropTypes.string.isRequired,
+  publicAddresses: PropTypes.arrayOf(PropTypes.string).isRequired,
   httpPort: PropTypes.number.isRequired,
 });
 


### PR DESCRIPTION
With the added changes for IPv6, we also display multiple API addresses; Instructions needed to be updated to use the new array.

Fixes the propType warning, which was only readily visible with a fresh app state.
