### PR TITLE
Fix docs

### DIFF
--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -3,13 +3,5 @@
     "includePattern": ".+\\.js$",
     "excludePattern": "__tests__"
   },
-  "plugins": ["node_modules/jsdoc-babel", "plugins/markdown"],
-  "babel": {
-    "plugins": [
-      "transform-class-properties",
-      "transform-react-jsx",
-      "transform-object-rest-spread"
-    ],
-    "babelrc": false
-  }
+  "plugins": ["plugins/markdown"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16191,22 +16191,6 @@
         }
       }
     },
-    "jsdoc-babel": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-babel/-/jsdoc-babel-0.4.0.tgz",
-      "integrity": "sha512-KF3WTPvoPYc8ZyXzC1m+vvwi+2VCKkqZX/NkqcE1tFephp8RnZAxG52QB/wvz/zoDS6XU28aM8NItMPMad50PA==",
-      "dev": true,
-      "requires": {
-        "jsdoc-regex": "^1.0.1",
-        "lodash": "^4.13.1"
-      }
-    },
-    "jsdoc-regex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-regex/-/jsdoc-regex-1.0.1.tgz",
-      "integrity": "sha1-hCRCjVtWOtjFx/vsB5uaiwnI3Po=",
-      "dev": true
-    },
     "jsdom": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "jest": "^23.4.0",
     "jest-fetch-mock": "^1.6.5",
     "jsdoc": "^3.4.3",
-    "jsdoc-babel": "^0.4.0",
     "json-loader": "^0.5.7",
     "mini-css-extract-plugin": "^0.4.1",
     "node-sass": "^4.9.3",

--- a/src/main/components/mainWindow.js
+++ b/src/main/components/mainWindow.js
@@ -48,7 +48,6 @@ const getAppUrl = (route) => {
 };
 
 /**
- * @class
  * Manages the sole instance of the app's BrowserWindow (electron).
  */
 class MainWindow {

--- a/src/main/data-managers/DatabaseAdapter.js
+++ b/src/main/data-managers/DatabaseAdapter.js
@@ -9,7 +9,10 @@ const DbConfig = {
 };
 
 /**
- * @class An abstract class wrapping NeDB instances.
+ * An abstract class wrapping NeDB instances.
+ *
+ * Methods return promises.
+ *
  * If a name is given (for either on-disk or in-mem DBs), this ensures DB
  * access uses the same underlying DB instance, as NeDB does not support concurrent
  * client initialization.

--- a/src/main/data-managers/DeviceDB.js
+++ b/src/main/data-managers/DeviceDB.js
@@ -12,7 +12,6 @@ const withDefaultName = dbDevice => ({
 });
 
 /**
- * @class
  * @extends DatabaseAdapter
  */
 class DeviceDB extends DatabaseAdapter {

--- a/src/main/data-managers/ProtocolDB.js
+++ b/src/main/data-managers/ProtocolDB.js
@@ -21,7 +21,6 @@ const validatedModifyTime = (protocol) => {
 };
 
 /**
- * @class
  * @extends DatabaseAdapter
  */
 class ProtocolDB extends DatabaseAdapter {

--- a/src/main/data-managers/ProtocolManager.js
+++ b/src/main/data-managers/ProtocolManager.js
@@ -19,7 +19,7 @@ const ProtocolDataFile = 'protocol.json';
 const hasValidExtension = filepath => validFileExts.includes(path.extname(filepath).replace(/^\./, ''));
 
 /**
- * @class ProtocolManager
+ * Interface to protocol data (higher-level than DB)
  */
 class ProtocolManager {
   constructor(dataDir) {

--- a/src/main/data-managers/SessionDB.js
+++ b/src/main/data-managers/SessionDB.js
@@ -9,7 +9,6 @@ const sessionUidField = 'uuid';
 const sessionDataField = 'data';
 
 /**
- * @class
  * @extends DatabaseAdapter
  */
 class SessionDB extends Reportable(DatabaseAdapter) {

--- a/src/main/errors/IncompletePairingError.js
+++ b/src/main/errors/IncompletePairingError.js
@@ -1,12 +1,7 @@
 /**
- * @class IncompletePairingError
+ * Used to indicate an error specific to the pairing process with a client.
  *
- * @description
- * Used to indicate an error with a request to a data manager; for example,
- * an incorrect, missing, or malformed filename when importing a protocol.
- *
- * API services can use this to distinguish between client input errors and
- * unexpected (server) errors.
+ * Error messages are assumed to be user-facing.
  */
 class IncompletePairingError extends Error {
   constructor(message) {

--- a/src/main/errors/RequestError.js
+++ b/src/main/errors/RequestError.js
@@ -1,7 +1,4 @@
 /**
- * @class RequestError
- *
- * @description
  * Used to indicate an error with a request to a data manager; for example,
  * an incorrect, missing, or malformed filename when importing a protocol.
  *

--- a/src/renderer/containers/App.js
+++ b/src/renderer/containers/App.js
@@ -41,9 +41,7 @@ const preventGlobalDragDrop = () => {
 };
 
 /**
- * @class App
  * Main app container.
- * @param props {object} - children
  */
 class App extends Component {
   constructor(props) {

--- a/src/renderer/utils/adminApiClient.js
+++ b/src/renderer/utils/adminApiClient.js
@@ -11,9 +11,6 @@ const consumeResponse = resp => (
 );
 
 /**
- * @class AdminApiClient
- *
- * @description
  * Restful API client for desktop (GUI) services.
  *
  * `post()` and `get()` methods each return a Promise.


### PR DESCRIPTION
Babel isn't needed for JSDoc. This allows JSDoc to infer more from source (e.g., classes) and runs faster.