### PR TITLE
Add support for confirmation messages

### DIFF
--- a/src/main/MainApp.js
+++ b/src/main/MainApp.js
@@ -11,6 +11,7 @@ const dialog = require('./dialog');
 
 // TODO: move/centralize
 const FileImportUpdated = 'FILE_IMPORT_UPDATED';
+const PROTOCOL_IMPORT_SUCCEEDED = 'PROTOCOL_IMPORT_SUCCEEDED';
 
 const userDataDir = app.getPath('userData');
 const adminService = new AdminService({ dataDir: userDataDir });
@@ -41,11 +42,7 @@ const createApp = () => {
       .then((filename) => {
         // If filename is empty, user cancelled
         if (filename) {
-          dialog.showMessageBox(mainWindow.window, {
-            title: 'Success',
-            message: 'Successfully Imported:',
-            detail: filename,
-          });
+          mainWindow.send(PROTOCOL_IMPORT_SUCCEEDED, filename);
         }
       })
       .then(() => mainWindow.send(FileImportUpdated))

--- a/src/renderer/components/AppMessage.js
+++ b/src/renderer/components/AppMessage.js
@@ -4,17 +4,19 @@ import PropTypes from 'prop-types';
 import { Icon } from '../ui/components';
 import Fade from './transitions/Fade';
 import { messageTypes } from '../ducks/modules/appMessages';
+import { isFrameless } from '../utils/environment';
 
 const baseCssClass = 'app-message';
 
 const modifierClass = (messageType) => {
+  const frameClass = isFrameless() ? `${baseCssClass}--frameless` : '';
   switch (messageType) {
     case messageTypes.Confirmation:
-      return `${baseCssClass}--confirmation`;
+      return `${baseCssClass}--confirmation ${frameClass}`;
     case messageTypes.Error:
-      return `${baseCssClass}--error`;
+      return `${baseCssClass}--error ${frameClass}`;
     default:
-      return '';
+      return frameClass;
   }
 };
 

--- a/src/renderer/components/AppMessage.js
+++ b/src/renderer/components/AppMessage.js
@@ -1,12 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { Icon } from '../ui/components';
-
 import Fade from './transitions/Fade';
+import { messageTypes } from '../ducks/modules/appMessages';
 
-const AppMessage = ({ text }) => (
+const baseCssClass = 'app-message';
+
+const modifierClass = (messageType) => {
+  switch (messageType) {
+    case messageTypes.Confirmation:
+      return `${baseCssClass}--confirmation`;
+    case messageTypes.Error:
+      return `${baseCssClass}--error`;
+    default:
+      return '';
+  }
+};
+
+const AppMessage = ({ text, type }) => (
   <Fade transitionIn>
-    <div className="app-message">
+    <div className={`${baseCssClass} ${modifierClass(type)}`}>
       <Icon name="close" size="small" color="red" className="app-message__close" />
       <div className="app-message__text">
         {text}
@@ -16,7 +30,12 @@ const AppMessage = ({ text }) => (
 );
 
 AppMessage.propTypes = {
+  type: PropTypes.any,
   text: PropTypes.string.isRequired,
+};
+
+AppMessage.defaultProps = {
+  type: null,
 };
 
 export default AppMessage;

--- a/src/renderer/components/AppMessage.js
+++ b/src/renderer/components/AppMessage.js
@@ -18,10 +18,17 @@ const modifierClass = (messageType) => {
   }
 };
 
-const AppMessage = ({ text, type, isExpired }) => (
+const AppMessage = ({ text, type, isExpired, timestamp, handleDismissal }) => (
   <Fade transitionIn={!isExpired}>
     <div className={`${baseCssClass} ${modifierClass(type)}`}>
-      <Icon name="close" size="small" color="red" className="app-message__close" />
+      <button onClick={() => handleDismissal(timestamp)} className="app-message__button">
+        <Icon
+          className="app-message__close"
+          name="close"
+          size="small"
+          color="red"
+        />
+      </button>
       <div className="app-message__text">
         {text}
       </div>
@@ -33,6 +40,8 @@ AppMessage.propTypes = {
   type: PropTypes.any,
   text: PropTypes.string.isRequired,
   isExpired: PropTypes.bool,
+  timestamp: PropTypes.number.isRequired,
+  handleDismissal: PropTypes.func.isRequired,
 };
 
 AppMessage.defaultProps = {

--- a/src/renderer/components/AppMessage.js
+++ b/src/renderer/components/AppMessage.js
@@ -20,6 +20,8 @@ const modifierClass = (messageType) => {
   }
 };
 
+const iconName = type => (type === messageTypes.Error ? 'error' : 'info');
+
 const AppMessage = ({ text, type, isExpired, timestamp, handleDismissal }) => (
   <Fade transitionIn={!isExpired}>
     <div className={`${baseCssClass} ${modifierClass(type)}`}>
@@ -32,7 +34,8 @@ const AppMessage = ({ text, type, isExpired, timestamp, handleDismissal }) => (
         />
       </button>
       <div className="app-message__text">
-        {text}
+        <Icon className="app-message__icon" name={iconName(type)} size="small" />
+        <span>{text}</span>
       </div>
     </div>
   </Fade>

--- a/src/renderer/components/AppMessage.js
+++ b/src/renderer/components/AppMessage.js
@@ -18,8 +18,8 @@ const modifierClass = (messageType) => {
   }
 };
 
-const AppMessage = ({ text, type }) => (
-  <Fade transitionIn>
+const AppMessage = ({ text, type, isExpired }) => (
+  <Fade transitionIn={!isExpired}>
     <div className={`${baseCssClass} ${modifierClass(type)}`}>
       <Icon name="close" size="small" color="red" className="app-message__close" />
       <div className="app-message__text">
@@ -32,9 +32,11 @@ const AppMessage = ({ text, type }) => (
 AppMessage.propTypes = {
   type: PropTypes.any,
   text: PropTypes.string.isRequired,
+  isExpired: PropTypes.bool,
 };
 
 AppMessage.defaultProps = {
+  isExpired: false,
   type: null,
 };
 

--- a/src/renderer/components/__tests__/AppMessage-test.js
+++ b/src/renderer/components/__tests__/AppMessage-test.js
@@ -1,12 +1,24 @@
 /* eslint-env jest */
 import React from 'react';
-import { mount } from 'enzyme';
+import { render, shallow } from 'enzyme';
 import AppMessage from '../AppMessage';
 
 describe('<AppMessage />', () => {
+  const text = 'Mock notification';
+  const handleDismissal = jest.fn();
+  let component;
+
+  beforeEach(() => {
+    component = <AppMessage text={text} timestamp={1} handleDismissal={handleDismissal} />;
+  });
+
   it('renders the given text', () => {
-    const text = 'Error notification';
-    const wrapper = mount(<AppMessage text={text} />);
-    expect(wrapper.text()).toContain(text);
+    expect(render(component).text()).toContain(text);
+  });
+
+  it('can be dismissed', () => {
+    const wrapper = shallow(component);
+    wrapper.find('button').simulate('click');
+    expect(handleDismissal).toHaveBeenCalled();
   });
 });

--- a/src/renderer/components/transitions/Fade.js
+++ b/src/renderer/components/transitions/Fade.js
@@ -12,7 +12,7 @@ const transitionStyles = {
 };
 
 const Fade = ({ children, transitionIn }) => (
-  <Transition appear in={transitionIn} timeout={0}>
+  <Transition appear in={transitionIn} timeout={duration} unmountOnExit>
     {status => (
       <div
         style={{

--- a/src/renderer/containers/App.js
+++ b/src/renderer/containers/App.js
@@ -88,7 +88,7 @@ class App extends Component {
   render() {
     const {
       ackPairingRequest,
-      dismissAppMessages,
+      dismissAppMessage,
       dismissPairingRequest,
       appMessages,
       pairingRequest,
@@ -101,10 +101,14 @@ class App extends Component {
     const appClass = isFrameless() ? 'app app--frameless' : 'app';
     const versionParts = appVersion.split('-');
 
+    const handleDismissal = timestamp => dismissAppMessage(timestamp);
+
     return (
       <div className={appClass}>
-        <div role="Button" tabIndex="0" className="app__flash" onClick={dismissAppMessages}>
-          { appMessages.map(msg => <AppMessage key={msg.timestamp} {...msg} />) }
+        <div className="app__flash">
+          { appMessages.map(msg => (
+            <AppMessage key={msg.timestamp} {...msg} handleDismissal={handleDismissal} />
+          )) }
         </div>
         {
           <AnimatedPairPrompt
@@ -146,7 +150,7 @@ App.propTypes = {
   ackPairingRequest: PropTypes.func.isRequired,
   appMessages: PropTypes.array,
   completedPairingRequest: PropTypes.func.isRequired,
-  dismissAppMessages: PropTypes.func.isRequired,
+  dismissAppMessage: PropTypes.func.isRequired,
   dismissPairingRequest: PropTypes.func.isRequired,
   loadDevices: PropTypes.func.isRequired,
   newPairingRequest: PropTypes.func.isRequired,
@@ -175,6 +179,7 @@ function mapDispatchToProps(dispatch) {
     showConfirmationMessage:
       bindActionCreators(messageActionCreators.showConfirmationMessage, dispatch),
     dismissPairingRequest: bindActionCreators(actionCreators.dismissPairingRequest, dispatch),
+    dismissAppMessage: bindActionCreators(messageActionCreators.dismissAppMessage, dispatch),
     dismissAppMessages: bindActionCreators(messageActionCreators.dismissAppMessages, dispatch),
     setConnectionInfo: bindActionCreators(connectionInfoActionCreators.setConnectionInfo, dispatch),
   };

--- a/src/renderer/containers/App.js
+++ b/src/renderer/containers/App.js
@@ -15,7 +15,7 @@ import { AnimatedPairPrompt } from '../components/pairing/PairPrompt';
 import { actionCreators, PairingStatus } from '../ducks/modules/pairingRequest';
 import { actionCreators as connectionInfoActionCreators } from '../ducks/modules/connectionInfo';
 import { actionCreators as deviceActionCreators } from '../ducks/modules/devices';
-import { actionCreators as messageActionCreators } from '../ducks/modules/appMessages';
+import { actionCreators as messageActionCreators, messages } from '../ducks/modules/appMessages';
 import { isFrameless } from '../utils/environment';
 
 const IPC = {
@@ -24,6 +24,7 @@ const IPC = {
   PAIRING_CODE_AVAILABLE: 'PAIRING_CODE_AVAILABLE',
   PAIRING_TIMED_OUT: 'PAIRING_TIMED_OUT',
   PAIRING_COMPLETE: 'PAIRING_COMPLETE',
+  PROTOCOL_IMPORT_SUCCEEDED: 'PROTOCOL_IMPORT_SUCCEEDED',
 };
 
 // This prevents user from being able to drop a file anywhere on the app
@@ -75,6 +76,10 @@ class App extends Component {
     ipcRenderer.on(IPC.PAIRING_COMPLETE, () => {
       props.completedPairingRequest();
       props.loadDevices();
+    });
+
+    ipcRenderer.on(IPC.PROTOCOL_IMPORT_SUCCEEDED, () => {
+      props.showConfirmationMessage(messages.protocolImportSuccess);
     });
 
     this.props.dismissAppMessages();
@@ -167,6 +172,8 @@ function mapDispatchToProps(dispatch) {
     completedPairingRequest: bindActionCreators(actionCreators.completedPairingRequest, dispatch),
     loadDevices: bindActionCreators(deviceActionCreators.loadDevices, dispatch),
     newPairingRequest: bindActionCreators(actionCreators.newPairingRequest, dispatch),
+    showConfirmationMessage:
+      bindActionCreators(messageActionCreators.showConfirmationMessage, dispatch),
     dismissPairingRequest: bindActionCreators(actionCreators.dismissPairingRequest, dispatch),
     dismissAppMessages: bindActionCreators(messageActionCreators.dismissAppMessages, dispatch),
     setConnectionInfo: bindActionCreators(connectionInfoActionCreators.setConnectionInfo, dispatch),

--- a/src/renderer/containers/FileDropTarget.js
+++ b/src/renderer/containers/FileDropTarget.js
@@ -6,7 +6,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 import AdminApiClient from '../utils/adminApiClient';
-import { actionCreators as messageActionCreators } from '../ducks/modules/appMessages';
+import { actionCreators as messageActionCreators, messages } from '../ducks/modules/appMessages';
 import { actionCreators as protocolActionCreators } from '../ducks/modules/protocols';
 
 const onDragOver = (evt) => {
@@ -52,7 +52,7 @@ class FileDropTarget extends Component {
     this.apiClient
       .post('/protocols', { files })
       .then(resp => resp.protocols)
-      .then(() => showConfirmationMessage('File imported successfully'))
+      .then(() => showConfirmationMessage(messages.protocolImportSuccess))
       .then(() => loadProtocols())
       .catch(err => showErrorMessage(err.message || 'Could not save file'));
   }

--- a/src/renderer/containers/FileDropTarget.js
+++ b/src/renderer/containers/FileDropTarget.js
@@ -47,12 +47,14 @@ class FileDropTarget extends Component {
       files.push(fileList[i].path);
     }
 
+    const { loadProtocols, showConfirmationMessage, showErrorMessage } = this.props;
     this.setState({ draggingOver: false });
     this.apiClient
       .post('/protocols', { files })
       .then(resp => resp.protocols)
-      .then(() => this.props.loadProtocols())
-      .catch(err => this.props.showMessage(err.message || 'Could not save file'));
+      .then(() => showConfirmationMessage('File imported successfully'))
+      .then(() => loadProtocols())
+      .catch(err => showErrorMessage(err.message || 'Could not save file'));
   }
 
   render() {
@@ -84,11 +86,14 @@ FileDropTarget.defaultProps = {
 FileDropTarget.propTypes = {
   children: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   loadProtocols: PropTypes.func,
-  showMessage: PropTypes.func.isRequired,
+  showConfirmationMessage: PropTypes.func.isRequired,
+  showErrorMessage: PropTypes.func.isRequired,
 };
 
 const mapDispatchToProps = dispatch => ({
-  showMessage: bindActionCreators(messageActionCreators.showMessage, dispatch),
+  showConfirmationMessage:
+    bindActionCreators(messageActionCreators.showConfirmationMessage, dispatch),
+  showErrorMessage: bindActionCreators(messageActionCreators.showErrorMessage, dispatch),
   loadProtocols: bindActionCreators(protocolActionCreators.loadProtocols, dispatch),
 });
 

--- a/src/renderer/containers/PairDevice.js
+++ b/src/renderer/containers/PairDevice.js
@@ -14,13 +14,13 @@ class PairDevice extends Component {
   componentDidUpdate() {
     if (!this.timer &&
         this.props.pairingRequest.status === PairingStatus.Acknowledged) {
-      const { apiClient, dismissPairingRequest, showMessage, pairingRequest } = this.props;
+      const { apiClient, dismissPairingRequest, showErrorMessage, pairingRequest } = this.props;
       const doCheck = () => {
         apiClient.checkPairingCodeExpired(pairingRequest.id)
           .then(({ isExpired, expiresAt }) => {
             if (isExpired) {
               dismissPairingRequest();
-              showMessage('Pairing timed out');
+              showErrorMessage('Pairing timed out');
               this.timer = null;
             } else {
               let expiresIn = new Date(expiresAt) - new Date();
@@ -81,12 +81,12 @@ PairDevice.propTypes = {
     pairingCode: PropTypes.string,
     status: PropTypes.string,
   }).isRequired,
-  showMessage: PropTypes.func.isRequired,
+  showErrorMessage: PropTypes.func.isRequired,
 };
 
 const mapDispatchToProps = dispatch => ({
   dismissPairingRequest: bindActionCreators(actionCreators.dismissPairingRequest, dispatch),
-  showMessage: bindActionCreators(messageActionCreators.showMessage, dispatch),
+  showErrorMessage: bindActionCreators(messageActionCreators.showErrorMessage, dispatch),
 });
 
 const mapStateToProps = ({ pairingRequest }) => ({

--- a/src/renderer/containers/__tests__/App-test.js
+++ b/src/renderer/containers/__tests__/App-test.js
@@ -19,6 +19,7 @@ const mockDispatched = {
   completedPairingRequest: jest.fn(),
   newPairingRequest: jest.fn(),
   dismissPairingRequest: jest.fn(),
+  dismissAppMessage: jest.fn(),
   dismissAppMessages: jest.fn(),
   loadDevices: jest.fn(),
   setConnectionInfo: jest.fn(),
@@ -170,7 +171,7 @@ describe('<App />', () => {
 
     it('provides message dismissal', () => {
       const wrapper = shallow(<ConnectedApp store={mockStore} />);
-      expect(wrapper.prop('dismissAppMessages')).toBeInstanceOf(Function);
+      expect(wrapper.prop('dismissAppMessage')).toBeInstanceOf(Function);
     });
   });
 });

--- a/src/renderer/containers/__tests__/PairDevice-test.js
+++ b/src/renderer/containers/__tests__/PairDevice-test.js
@@ -12,7 +12,7 @@ const makeProps = status => ({
   apiClient: {
     checkPairingCodeExpired: jest.fn().mockResolvedValue({}),
   },
-  showMessage: jest.fn(),
+  showErrorMessage: jest.fn(),
   dismissPairingRequest: jest.fn(),
   pairingRequest: {
     pairingCode: status ? mockPin : null,

--- a/src/renderer/ducks/modules/__tests__/appMessages-test.js
+++ b/src/renderer/ducks/modules/__tests__/appMessages-test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import reducer, { actionCreators, actionTypes } from '../appMessages';
+import reducer, { actionCreators, actionTypes, messageTypes } from '../appMessages';
 
 jest.mock('../../../utils/adminApiClient');
 
@@ -28,11 +28,32 @@ describe('the appMessages module', () => {
       });
     });
 
-    it('exports a show creator', () => {
-      expect(actionCreators.showMessage('testing')).toMatchObject({
+    it('exports a showErrorMessage thunk', () => {
+      expect(actionCreators.showErrorMessage('testing')).toBeInstanceOf(Function);
+    });
+
+    it('exports a showConfirmationMessage thunk', () => {
+      expect(actionCreators.showConfirmationMessage('testing')).toBeInstanceOf(Function);
+    });
+
+    it('dispatches an error message to show', () => {
+      const dispatch = jest.fn();
+      actionCreators.showErrorMessage('testing')(dispatch);
+      expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+        messageType: messageTypes.Error,
         type: actionTypes.SHOW_MESSAGE,
         text: 'testing',
-      });
+      }));
+    });
+
+    it('dispatches a confirmation message to show', () => {
+      const dispatch = jest.fn();
+      actionCreators.showConfirmationMessage('testing')(dispatch);
+      expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+        messageType: messageTypes.Confirmation,
+        type: actionTypes.SHOW_MESSAGE,
+        text: 'testing',
+      }));
     });
   });
 });

--- a/src/renderer/ducks/modules/appMessages.js
+++ b/src/renderer/ducks/modules/appMessages.js
@@ -9,6 +9,10 @@ const messageTypes = {
   Error: Symbol('Error'),
 };
 
+const messages = {
+  protocolImportSuccess: 'Protocol imported successfully',
+};
+
 const newMessage = (text, messageType) => ({
   messageType,
   timestamp: Date.now(),
@@ -68,4 +72,5 @@ export {
   actionCreators,
   actionTypes,
   messageTypes,
+  messages,
 };

--- a/src/renderer/ducks/modules/appMessages.js
+++ b/src/renderer/ducks/modules/appMessages.js
@@ -1,3 +1,4 @@
+const DISMISS_MESSAGE = 'DISMISS_MESSAGE';
 const DISMISS_MESSAGES = 'DISMISS_MESSAGES';
 const SHOW_MESSAGE = 'SHOW_MESSAGE';
 const UPDATE_MESSAGE_STATE = 'UPDATE_MESSAGE_STATE';
@@ -26,6 +27,8 @@ const reducer = (state = initialState, action = {}) => {
   switch (action.type) {
     case DISMISS_MESSAGES:
       return initialState;
+    case DISMISS_MESSAGE:
+      return state.filter(msg => msg.timestamp !== action.messageTimestamp);
     case UPDATE_MESSAGE_STATE:
       return state
         .filter(msg => !msg.isExpired)
@@ -55,6 +58,11 @@ const dismissAppMessages = () => ({
   type: DISMISS_MESSAGES,
 });
 
+const dismissAppMessage = messageTimestamp => ({
+  type: DISMISS_MESSAGE,
+  messageTimestamp,
+});
+
 const showMessage = (text, messageType = messageTypes.Error) => (dispatch) => {
   dispatch({
     type: SHOW_MESSAGE,
@@ -68,6 +76,7 @@ const showConfirmationMessage = text => showMessage(text, messageTypes.Confirmat
 const showErrorMessage = showMessage;
 
 const actionCreators = {
+  dismissAppMessage,
   dismissAppMessages,
   showConfirmationMessage,
   showErrorMessage,

--- a/src/renderer/ducks/modules/appMessages.js
+++ b/src/renderer/ducks/modules/appMessages.js
@@ -5,6 +5,7 @@ const messageLifetimeMillis = 3 * 1000;
 const initialState = [];
 
 const messageTypes = {
+  Confirmation: Symbol('Confirmation'),
   Error: Symbol('Error'),
 };
 
@@ -45,8 +46,14 @@ const showMessage = (text, messageType = messageTypes.Error) => ({
   ...newMessage(text, messageType),
 });
 
+const showConfirmationMessage = text => showMessage(text, messageTypes.Confirmation);
+
+const showErrorMessage = showMessage;
+
 const actionCreators = {
   dismissAppMessages,
+  showConfirmationMessage,
+  showErrorMessage,
   showMessage,
 };
 

--- a/src/renderer/ducks/modules/devices.js
+++ b/src/renderer/ducks/modules/devices.js
@@ -42,7 +42,7 @@ const loadDevices = () => (dispatch) => {
   return getApiClient().get('/devices')
     .then(resp => resp.devices)
     .then(devices => dispatch(devicesLoadedAction(devices)))
-    .catch(err => dispatch(messageActionCreators.showMessage(err.message)));
+    .catch(err => messageActionCreators.showErrorMessage(err.message)(dispatch));
 };
 
 const deleteDeviceAction = deviceId => ({
@@ -54,7 +54,7 @@ const deleteDevice = deviceId => (dispatch) => {
   dispatch(deleteDeviceAction(deviceId));
   return getApiClient().delete(`devices/${deviceId}`)
     .then(() => loadDevices()(dispatch))
-    .catch(err => dispatch(messageActionCreators.showMessage(err.message)));
+    .catch(err => messageActionCreators.showErrorMessage(err.message)(dispatch));
 };
 
 const actionCreators = {

--- a/src/renderer/ducks/modules/protocols.js
+++ b/src/renderer/ducks/modules/protocols.js
@@ -64,14 +64,14 @@ const loadProtocols = () => (dispatch) => {
   return getApiClient().get('/protocols')
     .then(resp => resp.protocols)
     .then(protocols => dispatch(protocolsLoadedDispatch(protocols)))
-    .catch(err => dispatch(messageActionCreators.showMessage(err.message)));
+    .catch(err => messageActionCreators.showErrorMessage(err.message)(dispatch));
 };
 
 const deleteProtocol = id => (dispatch) => {
   dispatch(deleteProtocolDispatch(id));
   return getApiClient().delete(`/protocols/${id}`)
     .then(() => dispatch(protocolDeletedDispatch(id)))
-    .catch(err => dispatch(messageActionCreators.showMessage(err.message)));
+    .catch(err => messageActionCreators.showErrorMessage(err.message)(dispatch));
 };
 
 const actionCreators = {

--- a/src/renderer/styles/_variables.scss
+++ b/src/renderer/styles/_variables.scss
@@ -5,8 +5,10 @@
   --inverse-background-color: var(--color-navy-taupe);
   --inverse-text-color: var(--color-white);
   --message-background-color: var(--color-sea-green--dark);
+  --message-border-color: var(--color-sea-green);
   --message-color: var(--color-white);
   --error-message-background-color: var(--color-tomato--dark);
+  --error-message-border-color: var(--color-tomato);
   --error-message-color: var(--message-color);
   --recessed-background-color: var(--color-platinum--dark);
   --recessed-border-color: var(--color-platinum);

--- a/src/renderer/styles/_variables.scss
+++ b/src/renderer/styles/_variables.scss
@@ -4,7 +4,7 @@
   --base-border-color: var(--color-platinum--dark);
   --inverse-background-color: var(--color-navy-taupe);
   --inverse-text-color: var(--color-white);
-  --message-background-color: var(--color-kiwi--dark);
+  --message-background-color: var(--color-sea-green--dark);
   --message-color: var(--color-white);
   --error-message-background-color: var(--color-tomato--dark);
   --error-message-color: var(--message-color);

--- a/src/renderer/styles/_variables.scss
+++ b/src/renderer/styles/_variables.scss
@@ -4,8 +4,10 @@
   --base-border-color: var(--color-platinum--dark);
   --inverse-background-color: var(--color-navy-taupe);
   --inverse-text-color: var(--color-white);
-  --message-background-color: var(--color-tomato--dark);
+  --message-background-color: var(--color-kiwi--dark);
   --message-color: var(--color-white);
+  --error-message-background-color: var(--color-tomato--dark);
+  --error-message-color: var(--message-color);
   --recessed-background-color: var(--color-platinum--dark);
   --recessed-border-color: var(--color-platinum);
 

--- a/src/renderer/styles/components/_app-message.scss
+++ b/src/renderer/styles/components/_app-message.scss
@@ -8,6 +8,11 @@
   width: 100%;
   z-index: var(--z-index-app-messages);
 
+  @include modifier(error) {
+    background-color: var(--error-message-background-color);
+    color: var(--error-message-color);
+  }
+
   @include element(close) {
     color: var(--message-color);
 

--- a/src/renderer/styles/components/_app-message.scss
+++ b/src/renderer/styles/components/_app-message.scss
@@ -1,8 +1,9 @@
 .app-message {
   background-color: var(--message-background-color);
   color: var(--message-color);
-  cursor: pointer;
+  // cursor: pointer;
   padding: spacing(small);
+  padding-top: var(--app-titlebar-height);
   position: fixed;
   text-align: center;
   width: 100%;
@@ -13,10 +14,14 @@
     color: var(--error-message-color);
   }
 
+  @include element(button) {
+    @include reset-button;
+    cursor: pointer;
+    float: right;
+  }
+
   @include element(close) {
     color: var(--message-color);
-
-    float: right;
 
     &[name='close'] { // Specificity needed to match UI lib
       height: 1rem;

--- a/src/renderer/styles/components/_app-message.scss
+++ b/src/renderer/styles/components/_app-message.scss
@@ -1,13 +1,17 @@
 .app-message {
   background-color: var(--message-background-color);
   color: var(--message-color);
-  // cursor: pointer;
   padding: spacing(small);
-  padding-top: var(--app-titlebar-height);
   position: fixed;
   text-align: center;
   width: 100%;
   z-index: var(--z-index-app-messages);
+
+  @include modifier(frameless) {
+    // For frameless windows, ensure button is clickable below the titlebar area
+    padding-bottom: var(--app-titlebar-height);
+    padding-top: var(--app-titlebar-height);
+  }
 
   @include modifier(error) {
     background-color: var(--error-message-background-color);

--- a/src/renderer/styles/components/_app-message.scss
+++ b/src/renderer/styles/components/_app-message.scss
@@ -1,21 +1,39 @@
 .app-message {
+  --margin: #{spacing(medium)};
   background-color: var(--message-background-color);
+  border-color: var(--message-border-color);
+  border-style: solid;
+  border-width: 4px;
+  border-radius: 1rem;
+  bottom: 0;
   color: var(--message-color);
-  padding: spacing(small);
+  font-size: 1.2rem;
+  margin: spacing(medium);
+  padding: spacing(medium);
   position: fixed;
   text-align: center;
-  width: 100%;
+  width: calc(100% - 2 * var(--margin));
   z-index: var(--z-index-app-messages);
-
-  @include modifier(frameless) {
-    // For frameless windows, ensure button is clickable below the titlebar area
-    padding-bottom: var(--app-titlebar-height);
-    padding-top: var(--app-titlebar-height);
-  }
 
   @include modifier(error) {
     background-color: var(--error-message-background-color);
+    border-color: var(--error-message-border-color);
     color: var(--error-message-color);
+  }
+
+  @include element(icon) {
+    margin-right: 1rem;
+
+    &[name] { // needed to match NC-UI specificity
+      height: 35px;
+      width: 35px;
+    }
+  }
+
+  @include element(text) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   @include element(button) {
@@ -27,7 +45,7 @@
   @include element(close) {
     color: var(--message-color);
 
-    &[name='close'] { // Specificity needed to match UI lib
+    &[name] { // needed to match NC-UI specificity
       height: 1rem;
     }
   }


### PR DESCRIPTION
Fixes #193 and provides a mechanism for general feedback, useful for export/download as well.

- Messages now auto-hide after a time
- Multiple messages may be queued
- Native protocol import uses these messages instead of native dialogs to be consistent with file drag/drop