### PR TITLE
Add basic CSV list formats

### DIFF
--- a/scripts/db-size.js
+++ b/scripts/db-size.js
@@ -32,6 +32,7 @@ const printResult = (taskDesc, result, hrtimeDiff) => {
 }
 
 const nodePrimaryKeyProperty = '_uid';
+const nodeAttributesProperty = 'attributes';
 
 const dbFile = 'perf-test-sessions.db';
 let db;
@@ -67,7 +68,21 @@ function buildMockData({ sessionCount = SessionCount, edgesPerSession = EdgesPer
    *
    * Normal dist: 18 nodes, 180 edges per interview
    */
-  const mockNode = {[nodePrimaryKeyProperty]:"person_3","type":"person","name":"Carlito","nickname":"Carl","age":"25","itemType":"NEW_NODE","stageId":"namegen1","promptId":"6cl","school_important":true,"id":2,"closenessLayout":{"x":0.35625,"y":0.6988888888888889}};
+  const mockNode = {
+    [nodePrimaryKeyProperty]: 'person_3',
+    type: 'person',
+    [nodeAttributesProperty]: {
+      name: 'Carlito',
+      nickname: 'Carl',
+      age: '25',
+      itemType: 'NEW_NODE',
+      prop1: 'example1',
+      prop2: 22,
+      school_important: true,
+      id:2,
+      closenessLayout: {"x":0.35625,"y":0.6988888888888889},
+    }
+  };
   const mockEdge = {"from":12,"to":11,"type":"friends"};
 
   const makeNetwork = (includeEgo = false) => {
@@ -77,7 +92,7 @@ function buildMockData({ sessionCount = SessionCount, edgesPerSession = EdgesPer
     edges.fill(mockEdge);
 
     // Change last edge's property so we can search for it
-    edges[edges.length - 1].from = 13;
+    if (edges.length) { edges[edges.length - 1].from = 13; }
 
     if (useRealIds) {
       const pickNodeUid = () => nodes[~~(Math.random() * nodes.length)][nodePrimaryKeyProperty];

--- a/scripts/export-matrix.js
+++ b/scripts/export-matrix.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const { buildMockData } = require('./db-size');
 const { asAdjacencyMatrix } = require('../src/main/utils/formatters/matrix');
 const { asAdjacencyList, toCSVStream } = require('../src/main/utils/formatters/adjacency-list');
+const { toCSVStream: toAttributeCSV } = require('../src/main/utils/formatters/attribute-list');
 
 
 const mockdata = buildMockData({ sessionCount: 4500 });
@@ -14,13 +15,17 @@ mockdata.forEach((session) => {
   merged.edges.push(...session.data.edges);
 });
 
-console.time('list');
-const list = asAdjacencyList(merged.edges, false);
-console.timeEnd('list');
+console.time('attr-list-csv');
+toAttributeCSV(merged.nodes, fs.createWriteStream('test-export-attrs.csv'));
+console.timeEnd('attr-list-csv');
 
-console.time('list-csv');
+console.time('adjacency-list');
+const list = asAdjacencyList(merged.edges, false);
+console.timeEnd('adjacency-list');
+
+console.time('adjacency-list-csv');
 toCSVStream(list, fs.createWriteStream('test-export-list.csv'));
-console.timeEnd('list-csv');
+console.timeEnd('adjacency-list-csv');
 
 console.time('list-directed');
 asAdjacencyList(merged.edges, true);
@@ -34,7 +39,6 @@ console.time('matrix-directed');
 const matrix = asAdjacencyMatrix(merged, true);
 console.timeEnd('matrix-directed');
 
-// Test CSV output
-console.time('csv');
+console.time('matrix-csv');
 matrix.toCSVStream(fs.createWriteStream('test-export-matrix.csv'));
-console.timeEnd('csv');
+console.timeEnd('matrix-csv');

--- a/scripts/export-matrix.js
+++ b/scripts/export-matrix.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const { buildMockData } = require('./db-size');
 const { asAdjacencyMatrix } = require('../src/main/utils/formatters/matrix');
-const { asAdjacencyList } = require('../src/main/utils/formatters/adjacency-list');
+const { asAdjacencyList, toCSVStream } = require('../src/main/utils/formatters/adjacency-list');
 
 
 const mockdata = buildMockData({ sessionCount: 4500 });
@@ -15,8 +15,12 @@ mockdata.forEach((session) => {
 });
 
 console.time('list');
-asAdjacencyList(merged.edges, false);
+const list = asAdjacencyList(merged.edges, false);
 console.timeEnd('list');
+
+console.time('list-csv');
+toCSVStream(list, fs.createWriteStream('test-export-list.csv'));
+console.timeEnd('list-csv');
 
 console.time('list-directed');
 asAdjacencyList(merged.edges, true);
@@ -32,5 +36,5 @@ console.timeEnd('matrix-directed');
 
 // Test CSV output
 console.time('csv');
-matrix.toCSVStream(fs.createWriteStream('test-export.csv'));
+matrix.toCSVStream(fs.createWriteStream('test-export-matrix.csv'));
 console.timeEnd('csv');

--- a/src/main/utils/formatters/__tests__/adjacency-list-test.js
+++ b/src/main/utils/formatters/__tests__/adjacency-list-test.js
@@ -1,5 +1,6 @@
 /* eslint-env jest */
-import { asAdjacencyList } from '../adjacency-list';
+import { Writable } from 'stream';
+import { asAdjacencyList, toCSVStream } from '../adjacency-list';
 
 describe('asAdjacencyList', () => {
   it('represents an edgeless network', () => {
@@ -12,5 +13,60 @@ describe('asAdjacencyList', () => {
 
   it('represents a single directed edge', () => {
     expect(asAdjacencyList([{ from: 1, to: 2 }], true)).toEqual({ 1: new Set([2]) });
+  });
+});
+
+describe('toCSVStream', () => {
+  let chunks;
+  let streamToString;
+  let writable;
+
+  beforeEach(() => {
+    chunks = [];
+    streamToString = async stream => new Promise((resolve, reject) => {
+      stream.on('finish', () => { resolve(chunks.join('')); });
+      stream.on('error', (err) => { reject(err); });
+    });
+    writable = new Writable({
+      write(chunk, encoding, next) {
+        chunks.push(chunk.toString());
+        next(null);
+      },
+    });
+  });
+
+  it('Writes a simple csv', async () => {
+    const list = asAdjacencyList([{ from: 1, to: 2 }]);
+    toCSVStream(list, writable);
+    const csv = await streamToString(writable);
+    expect(csv).toEqual('1,2\r\n2,1\r\n');
+  });
+
+  it('Writes multiple edges', async () => {
+    const list = asAdjacencyList([{ from: 1, to: 2 }, { from: 1, to: 3 }]);
+    toCSVStream(list, writable);
+    const csv = await streamToString(writable);
+    expect(csv).toEqual('1,2,3\r\n2,1\r\n3,1\r\n');
+  });
+
+  it('Writes a csv for directed edges', async () => {
+    const list = asAdjacencyList([{ from: 1, to: 2 }, { from: 1, to: 3 }], true);
+    toCSVStream(list, writable);
+    const csv = await streamToString(writable);
+    expect(csv).toEqual('1,2,3\r\n');
+  });
+
+  it('Writes a csv for directed edges (inverse)', async () => {
+    const list = asAdjacencyList([{ from: 1, to: 2 }, { from: 3, to: 1 }], true);
+    toCSVStream(list, writable);
+    const csv = await streamToString(writable);
+    expect(csv).toEqual('1,2\r\n3,1\r\n');
+  });
+
+  it('Ignores duplicate edges', async () => {
+    const list = asAdjacencyList([{ from: 1, to: 2 }, { from: 1, to: 2 }]);
+    toCSVStream(list, writable);
+    const csv = await streamToString(writable);
+    expect(csv).toEqual('1,2\r\n2,1\r\n');
   });
 });

--- a/src/main/utils/formatters/__tests__/adjacency-list-test.js
+++ b/src/main/utils/formatters/__tests__/adjacency-list-test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { Writable } from 'stream';
+import { makeWriteableStream } from '../../../../../config/jest/setupTestEnv';
 import { asAdjacencyList, toCSVStream } from '../adjacency-list';
 
 describe('asAdjacencyList', () => {
@@ -17,56 +17,44 @@ describe('asAdjacencyList', () => {
 });
 
 describe('toCSVStream', () => {
-  let chunks;
-  let streamToString;
   let writable;
 
   beforeEach(() => {
-    chunks = [];
-    streamToString = async stream => new Promise((resolve, reject) => {
-      stream.on('finish', () => { resolve(chunks.join('')); });
-      stream.on('error', (err) => { reject(err); });
-    });
-    writable = new Writable({
-      write(chunk, encoding, next) {
-        chunks.push(chunk.toString());
-        next(null);
-      },
-    });
+    writable = makeWriteableStream();
   });
 
   it('Writes a simple csv', async () => {
     const list = asAdjacencyList([{ from: 1, to: 2 }]);
     toCSVStream(list, writable);
-    const csv = await streamToString(writable);
+    const csv = await writable.asString();
     expect(csv).toEqual('1,2\r\n2,1\r\n');
   });
 
   it('Writes multiple edges', async () => {
     const list = asAdjacencyList([{ from: 1, to: 2 }, { from: 1, to: 3 }]);
     toCSVStream(list, writable);
-    const csv = await streamToString(writable);
+    const csv = await writable.asString();
     expect(csv).toEqual('1,2,3\r\n2,1\r\n3,1\r\n');
   });
 
   it('Writes a csv for directed edges', async () => {
     const list = asAdjacencyList([{ from: 1, to: 2 }, { from: 1, to: 3 }], true);
     toCSVStream(list, writable);
-    const csv = await streamToString(writable);
+    const csv = await writable.asString();
     expect(csv).toEqual('1,2,3\r\n');
   });
 
   it('Writes a csv for directed edges (inverse)', async () => {
     const list = asAdjacencyList([{ from: 1, to: 2 }, { from: 3, to: 1 }], true);
     toCSVStream(list, writable);
-    const csv = await streamToString(writable);
+    const csv = await writable.asString();
     expect(csv).toEqual('1,2\r\n3,1\r\n');
   });
 
   it('Ignores duplicate edges', async () => {
     const list = asAdjacencyList([{ from: 1, to: 2 }, { from: 1, to: 2 }]);
     toCSVStream(list, writable);
-    const csv = await streamToString(writable);
+    const csv = await writable.asString();
     expect(csv).toEqual('1,2\r\n2,1\r\n');
   });
 });

--- a/src/main/utils/formatters/__tests__/attribute-list-test.js
+++ b/src/main/utils/formatters/__tests__/attribute-list-test.js
@@ -1,0 +1,54 @@
+/* eslint-env jest */
+
+import { makeWriteableStream } from '../../../../../config/jest/setupTestEnv';
+import { toCSVStream } from '../attribute-list';
+
+describe('toCSVStream', () => {
+  let writable;
+
+  beforeEach(() => {
+    writable = makeWriteableStream();
+  });
+
+  it('writes a simple CSV', async () => {
+    toCSVStream([{ _uid: 1, attributes: { name: 'Jane' } }], writable);
+    const csv = await writable.asString();
+    expect(csv).toEqual('_uid,name\r\n1,Jane\r\n');
+  });
+
+  it('escapes quotes', async () => {
+    toCSVStream([{ _uid: 1, attributes: { nickname: '"Nicky"' } }], writable);
+    const csv = await writable.asString();
+    expect(csv).toEqual('_uid,nickname\r\n1,"""Nicky"""\r\n');
+  });
+
+  it('escapes quotes in attr names', async () => {
+    toCSVStream([{ _uid: 1, attributes: { '"quoted"': 1 } }], writable);
+    const csv = await writable.asString();
+    expect(csv).toEqual('_uid,"""quoted"""\r\n1,1\r\n');
+  });
+
+  it('stringifies and quotes objects', async () => {
+    toCSVStream([{ _uid: 1, attributes: { location: { x: 1, y: 1 } } }], writable);
+    const csv = await writable.asString();
+    expect(csv).toEqual('_uid,location\r\n1,"{""x"":1,""y"":1}"\r\n');
+  });
+
+  it('exports undefined values as blank', async () => {
+    toCSVStream([{ _uid: 1, attributes: { prop: undefined } }], writable);
+    const csv = await writable.asString();
+    expect(csv).toEqual('_uid,prop\r\n1,\r\n');
+  });
+
+  it('exports null values as blank', async () => {
+    toCSVStream([{ _uid: 1, attributes: { prop: null } }], writable);
+    const csv = await writable.asString();
+    expect(csv).toEqual('_uid,prop\r\n1,\r\n');
+  });
+
+  it('exports `false` values as "false"', async () => {
+    toCSVStream([{ _uid: 1, attributes: { prop: false } }], writable);
+    const csv = await writable.asString();
+    expect(csv).toEqual('_uid,prop\r\n1,false\r\n');
+  });
+});

--- a/src/main/utils/formatters/adjacency-list.js
+++ b/src/main/utils/formatters/adjacency-list.js
@@ -1,5 +1,22 @@
-// Need not contain all nodes
-// TODO: I'm assuming only one edge per vertex pair; others are filtered out...
+/**
+ * Builds an adjacency list for a network, based only on its edges (it need
+ * not contain all nodes).
+ *
+ * Note that duplicate edges (e.g., of different types) are not conveyed in the output.
+ *
+ * @example:
+ * ```
+ * | node | adjacent |
+ * | a    | b,c      |
+ * | b    | a        |
+ * | c    | a        |
+ * ```
+ *
+ * @param  {Array}  edges from the NC network
+ * @param  {Boolean} directed if false, adjacencies are represented in both directions
+ *                            default: false
+ * @return {Object.<string, Set>} the adjacency list
+ */
 const asAdjacencyList = (edges, directed = false) =>
   edges.reduce((acc, val) => {
     acc[val.from] = acc[val.from] || new Set();
@@ -11,6 +28,17 @@ const asAdjacencyList = (edges, directed = false) =>
     return acc;
   }, {});
 
+// TODO: quoting/escaping (not needed while we're only using UUIDs)
+const toCSVStream = (adjancencyList, outStream) => {
+  const csvEOL = '\r\n';
+  Object.entries(adjancencyList).forEach(([source, destinations]) => {
+    const rowContent = `${source},${[...destinations].join(',')}${csvEOL}`;
+    outStream.write(rowContent);
+  });
+  outStream.end();
+};
+
 module.exports = {
   asAdjacencyList,
+  toCSVStream,
 };

--- a/src/main/utils/formatters/adjacency-list.js
+++ b/src/main/utils/formatters/adjacency-list.js
@@ -1,5 +1,7 @@
 const { Readable } = require('stream');
 
+const { csvEOL } = require('./csv');
+
 /**
  * Builds an adjacency list for a network, based only on its edges (it need
  * not contain all nodes).
@@ -42,7 +44,6 @@ const asAdjacencyList = (edges, directed = false) =>
  */
 // TODO: quoting/escaping (not needed while we're only using UUIDs)
 const toCSVStream = (adjancencyList, outStream) => {
-  const csvEOL = '\r\n';
   const adjacencies = Object.entries(adjancencyList);
   const totalRows = adjacencies.length;
   let rowContent;

--- a/src/main/utils/formatters/attribute-list.js
+++ b/src/main/utils/formatters/attribute-list.js
@@ -1,0 +1,63 @@
+const { Readable } = require('stream');
+
+const { nodePrimaryKeyProperty } = require('./network');
+const { cellValue, csvEOL } = require('./csv');
+
+const asAttributeList = nodes => nodes;
+
+/**
+ * The output of this formatter will contain the primary key (_uid)
+ * and all model data (inside the `attributes` property)
+ */
+const attributeHeaders = (nodes) => {
+  const headerSet = nodes.reduce((headers, node) => {
+    Object.keys(node.attributes).forEach((key) => {
+      headers.add(key);
+    });
+    return headers;
+  }, new Set([nodePrimaryKeyProperty]));
+  return [...headerSet];
+};
+
+const toCSVStream = (nodes, outStream) => {
+  const totalRows = nodes.length;
+  const attrNames = attributeHeaders(nodes);
+  let headerWritten = false;
+  let rowIndex = 0;
+  let rowContent;
+  let node;
+
+  const inStream = new Readable({
+    read(/* size */) {
+      if (!headerWritten) {
+        this.push(`${attrNames.map(attr => cellValue(attr)).join(',')}${csvEOL}`);
+        headerWritten = true;
+      } else if (rowIndex < totalRows) {
+        node = nodes[rowIndex];
+        const values = attrNames.map((attrName) => {
+          // The primary key exists at the top-level; all others inside `.attributes`
+          let value;
+          if (attrName === nodePrimaryKeyProperty) {
+            value = node[attrName];
+          } else {
+            value = node.attributes[attrName];
+          }
+          return cellValue(value);
+        });
+        rowContent = `${values.join(',')}${csvEOL}`;
+        this.push(rowContent);
+        rowIndex += 1;
+      } else {
+        this.push(null);
+      }
+    },
+  });
+
+  // TODO: handle teardown. Use pipeline() API in Node 10?
+  inStream.pipe(outStream);
+};
+
+module.exports = {
+  asAttributeList,
+  toCSVStream,
+};

--- a/src/main/utils/formatters/csv.js
+++ b/src/main/utils/formatters/csv.js
@@ -1,0 +1,1 @@
+module.exports.csvEOL = '\r\n'; // always this, not os-specific

--- a/src/main/utils/formatters/csv.js
+++ b/src/main/utils/formatters/csv.js
@@ -1,1 +1,40 @@
-module.exports.csvEOL = '\r\n'; // always this, not os-specific
+/**
+ * This module provides helpers for writing CSV output
+ * @module CSV
+ */
+
+const csvEOL = '\r\n'; // always this, not os-specific
+
+/**
+ * @param  {string} value a string potentially containing quotes
+ * @return {string} a quote-delimited string, with internal quotation marks escaped (as '""')
+ */
+const quoteValue = value => `"${value.replace(/"/g, '""')}"`;
+
+/**
+ * Returned strings are already quote-escaped as needed.
+ * You must not call quoteValue() on the return value of this method.
+ * @param value any value to write to a CSV cell. If an object is passed,
+ *              this will attempt to JSON.stringify, and fall back to
+ * @return {string}
+ */
+const cellValue = (value) => {
+  if (value && typeof value === 'object') {
+    let serialized;
+    try {
+      serialized = JSON.stringify(value);
+    } catch (err) {
+      serialized = value.toString(); // value will never be null here
+    }
+    return quoteValue(serialized);
+  } else if (typeof value === 'string' && value.indexOf('"') >= 0) {
+    return quoteValue(value);
+  }
+  return value;
+};
+
+module.exports = {
+  csvEOL,
+  quoteValue,
+  cellValue,
+};

--- a/src/main/utils/formatters/matrix.js
+++ b/src/main/utils/formatters/matrix.js
@@ -3,7 +3,7 @@
 
 const { Readable } = require('stream');
 
-const nodePrimaryKeyProperty = '_uid';
+const { nodePrimaryKeyProperty } = require('./network');
 const { csvEOL } = require('./csv');
 
 /**

--- a/src/main/utils/formatters/matrix.js
+++ b/src/main/utils/formatters/matrix.js
@@ -4,6 +4,7 @@
 const { Readable } = require('stream');
 
 const nodePrimaryKeyProperty = '_uid';
+const { csvEOL } = require('./csv');
 
 /**
  * An opaque reprensentation of an adjacency matrix with binary values (edge is present/absent).
@@ -115,7 +116,6 @@ class AdjacencyMatrix {
    */
   // TODO: support cancellation
   toCSVStream(outStream) {
-    const csvEOL = '\r\n'; // always this, not os-specific
     const uniqueNodeIds = this.uniqueNodeIds;
     const dataColumnCount = uniqueNodeIds.length;
     const matrixCellCount = dataColumnCount * dataColumnCount;

--- a/src/main/utils/formatters/network.js
+++ b/src/main/utils/formatters/network.js
@@ -1,0 +1,2 @@
+// TODO: share with other places this is defined
+module.exports.nodePrimaryKeyProperty = '_uid';


### PR DESCRIPTION
This adds basic formatting for CSV adjacency lists and attribute lists, in addition to the matrix formatter in #198. These were significantly simpler to implement & scale, so this should take less time to scrutinize. Note, though, that the attribute list is the sole CSV format that contains user input and so requires quoting/escaping.

As in #198, the tests convey the CSV output format. 

I'm not 100% sure of what's desired for the adjacency list. Currently it renders each adjacent node ID in a separate CSV column; that is, there is no fixed column count. So it looks something like this:

```
node1,node2
node3,node4,node5
```

and *not* a two-column layout:
```
node1,"[node2]"
node3,"[node4,node5]"
```