### PR TITLE
Add GraphML export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30922,8 +30922,7 @@
     "xmldom": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
-      "dev": true
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     },
     "xregexp": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16692,9 +16692,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash-es": {
       "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "detect-port": "^1.2.3",
     "jszip": "^3.1.5",
     "libsodium-wrappers": "^0.7.3",
+    "lodash": "^4.17.11",
     "mdns": "^2.4.0",
     "nedb": "^1.8.0",
     "prop-types": "^15.6.2",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
     "restify-cors-middleware": "^1.1.1",
     "selfsigned": "^1.10.3",
     "thread-loader": "^1.1.5",
-    "uuid": "^3.3.2"
+    "uuid": "^3.3.2",
+    "xmldom": "^0.1.27"
   },
   "browserslist": [
     "Chrome 61"

--- a/scripts/db-size.js
+++ b/scripts/db-size.js
@@ -67,6 +67,9 @@ function buildMockData({ sessionCount = SessionCount, edgesPerSession = EdgesPer
    * 80k nodes + 850k edges across 4,500 participant interviews.
    *
    * Normal dist: 18 nodes, 180 edges per interview
+   *
+   * This format should match that of the NC export (stored in DB).
+   * Note that variable IDs are already transposed to names.
    */
   const mockNode = {
     [nodePrimaryKeyProperty]: 'person_3',
@@ -220,19 +223,10 @@ function printDbSize() {
 
 function go() { return Promise.resolve(); }
 
+// Note that IDs are not transposed to names here; for ease of review, node variable names & IDs
+// happen to match (except for 'prop1' and 'prop2', which can be used to verify correct behavior
+// with transposition).
 const variableRegistry = {
-  // const mockNode = {
-  // [nodePrimaryKeyProperty]:"person_3",
-  // "type":"person",
-  // "name":"Carlito",
-  // "nickname":"Carl",
-  // "age":"25",
-  // "itemType":"NEW_NODE",
-  // "stageId":"namegen1",
-  // "promptId":"6cl",
-  // "school_important":true,
-  // "id":2,
-  // "closenessLayout":{"x":0.35625,"y":0.6988888888888889}};
   node: {
     person: {
       name: 'person',
@@ -280,13 +274,13 @@ const variableRegistry = {
           name: "itemType",
           type: "text",
         },
-        stageId: {
-          name: "stageId",
+        '68119732-49a4-449f-b056-f444f4e41982': {
+          name: "prop1",
           type: "text",
         },
-        promptId: {
-          name: "promptId",
-          type: "text",
+        'cb0a01eb-bc86-4e8f-afc6-4a60806a7c8d': {
+          name: "prop2",
+          type: "number",
         },
         school_important: {
           "name": "school_important",
@@ -303,7 +297,12 @@ const variableRegistry = {
       }
     }
   },
-  edge: {},
+  edge: {
+    '77199445-9d50-4646-b0bc-6d6b0c0e06bd': {
+      name: 'friend',
+      label: 'Friend',
+    }
+  },
 };
 
 if (require.main === module) {

--- a/scripts/export-matrix.js
+++ b/scripts/export-matrix.js
@@ -1,19 +1,26 @@
 /* eslint-disable no-console */
 
 const fs = require('fs');
-const { buildMockData } = require('./db-size');
+const { buildMockData, variableRegistry } = require('./db-size');
 const { asAdjacencyMatrix } = require('../src/main/utils/formatters/matrix');
 const { asAdjacencyList, toCSVStream } = require('../src/main/utils/formatters/adjacency-list');
 const { toCSVStream: toAttributeCSV } = require('../src/main/utils/formatters/attribute-list');
+const createGraphML = require('../src/main/utils/formatters/graphml');
 
-
-const mockdata = buildMockData({ sessionCount: 4500 });
+const mockdata = buildMockData({ sessionCount: 1 });
 const merged = { nodes: [], edges: [] };
 
 mockdata.forEach((session) => {
   merged.nodes.push(...session.data.nodes);
   merged.edges.push(...session.data.edges);
 });
+
+console.time('graphml');
+const xml = createGraphML(merged, variableRegistry, (err) => {
+  console.error(err);
+});
+fs.writeFileSync('test-graph.xml', xml, console.error);
+console.timeEnd('graphml');
 
 console.time('attr-list-csv');
 toAttributeCSV(merged.nodes, fs.createWriteStream('test-export-attrs.csv'));

--- a/src/main/.eslintrc.json
+++ b/src/main/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../../.eslintrc.json",
+    "env": {
+        "browser": false,
+        "commonjs": false
+    }
+}

--- a/src/main/utils/formatters/__tests__/graphml-test.js
+++ b/src/main/utils/formatters/__tests__/graphml-test.js
@@ -1,0 +1,61 @@
+/* eslint-env jest */
+import { DOMParser } from 'xmldom';
+
+import createGraphML from '../graphml';
+
+describe('createGraphML', () => {
+  const edgeType = 'peer';
+  let network;
+  let variableRegistry;
+  let xml;
+
+  beforeEach(() => {
+    const buildXML = (...args) => (new DOMParser()).parseFromString(createGraphML(...args));
+    network = {
+      nodes: [
+        { _uid: '1', type: 'person', attributes: { 'mock-uuid-1': 'Dee', 'mock-uuid-2': 40 } },
+        { _uid: '2', type: 'person', attributes: { 'mock-uuid-1': 'Carl', 'mock-uuid-2': 50 } },
+      ],
+      edges: [
+        { from: '1', to: '2', type: 'mock-uuid-3' },
+      ],
+    };
+    variableRegistry = {
+      node: {
+        person: {
+          variables: {
+            'mock-uuid-1': { name: 'firstName', type: 'string' },
+            'mock-uuid-2': { name: 'age', type: 'number' },
+          },
+        },
+      },
+      edge: {
+        'mock-uuid-3': {
+          name: edgeType,
+        },
+      },
+    };
+    xml = buildXML(network, variableRegistry);
+  });
+
+  it('produces a graphml document', () => {
+    expect(xml.getElementsByTagName('graphml')).toHaveLength(1);
+  });
+
+  it('adds nodes', () => {
+    expect(xml.getElementsByTagName('node')).toHaveLength(2);
+  });
+
+  it('adds edges', () => {
+    expect(xml.getElementsByTagName('edge')).toHaveLength(1);
+  });
+
+  it('infers integer types', () => { // This indicates that transposition worked for nodes
+    expect(xml.getElementById('age').getAttribute('attr.type')).toEqual('integer');
+  });
+
+  it('exports edge labels', () => { // This indicates that [non-]transposition worked for edges
+    const edge = xml.getElementsByTagName('edge')[0];
+    expect(edge.getElementsByTagName('data')[0].textContent).toEqual(edgeType);
+  });
+});

--- a/src/main/utils/formatters/graphml.js
+++ b/src/main/utils/formatters/graphml.js
@@ -1,8 +1,22 @@
-import { findKey, forInRight, isNil } from 'lodash';
+const { findKey, forInRight, isNil } = require('lodash');
 
-import saveFile from './SaveFile';
-import { nodePrimaryKeyProperty, nodeAttributesProperty, getNodeAttributes } from '../ducks/modules/network';
-import { VariableType, VariableTypeValues } from '../protocol-consts';
+const { nodePrimaryKeyProperty, nodeAttributesProperty, getNodeAttributes } = require('./network');
+
+// TODO: VariableType[Values] is shared with 'protocol-consts' in NC;
+const VariableType = Object.freeze({
+  boolean: 'boolean',
+  text: 'text',
+  number: 'number',
+  datetime: 'datetime',
+  ordinal: 'ordinal',
+  categorical: 'categorical',
+  layout: 'layout',
+  location: 'location',
+});
+const VariableTypeValues = Object.freeze(Object.values(VariableType));
+
+// TODO: different API needed for server
+const saveFile = xml => xml;
 
 const setUpXml = () => {
   const graphMLOutline = '<?xml version="1.0" encoding="UTF-8"?>\n' +
@@ -289,4 +303,4 @@ const createGraphML = (networkData, variableRegistry, onError) => {
     { message: 'Your network canvas graphml file.', subject: 'network canvas export' });
 };
 
-export default createGraphML;
+module.exports = createGraphML;

--- a/src/main/utils/formatters/graphml.js
+++ b/src/main/utils/formatters/graphml.js
@@ -1,0 +1,292 @@
+import { findKey, forInRight, isNil } from 'lodash';
+
+import saveFile from './SaveFile';
+import { nodePrimaryKeyProperty, nodeAttributesProperty, getNodeAttributes } from '../ducks/modules/network';
+import { VariableType, VariableTypeValues } from '../protocol-consts';
+
+const setUpXml = () => {
+  const graphMLOutline = '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    '<graphml xmlns="http://graphml.graphdrawing.org/xmlns"\n' +
+    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n' +
+    'xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns\n' +
+    'http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">\n' +
+    '  <graph edgedefault="undirected">\n' +
+    ' </graph>\n' +
+    ' </graphml>\n';
+
+  return (new DOMParser()).parseFromString(graphMLOutline, 'text/xml');
+};
+
+const getVariableInfo = (variableRegistry, type, element, key) => (
+  variableRegistry[type] && variableRegistry[type][element.type] &&
+  variableRegistry[type][element.type].variables &&
+  variableRegistry[type][element.type].variables[key]
+);
+
+const isVariableRegistryExists = (variableRegistry, type, element, key) => {
+  const variableInfo = getVariableInfo(variableRegistry, type, element, key);
+  return variableInfo && variableInfo.type && VariableTypeValues.includes(variableInfo.type);
+};
+
+const getTypeFromVariableRegistry = (variableRegistry, type, element, key, variableAttribute = 'type') => {
+  const variableInfo = getVariableInfo(variableRegistry, type, element, key);
+  return variableInfo && variableInfo[variableAttribute];
+};
+
+// returns a graphml type
+const getTypeForKey = (data, key) => (
+  data.reduce((result, value) => {
+    const attrs = getNodeAttributes(value);
+    if (isNil(attrs[key])) return result;
+    let currentType = typeof attrs[key];
+    if (currentType === 'number') {
+      currentType = Number.isInteger(attrs[key]) ? 'integer' : 'double';
+      if (result && currentType !== result) return 'double';
+    }
+    if (String(Number.parseInt(attrs[key], 10)) === attrs[key]) {
+      currentType = 'integer';
+      if (result === 'double') return 'double';
+    } else if (String(Number.parseFloat(attrs[key], 10)) === attrs[key]) {
+      currentType = 'double';
+      if (result === 'integer') return 'double';
+    }
+    if (isNil(currentType)) return result;
+    if (currentType === result || result === '') return currentType;
+    return 'string';
+  }, ''));
+
+const generateKeys = (
+  graph, // <Graph> Element
+  graphML, // <GraphML> Element
+  elements, // networkData.nodes
+  type, // 'node' - node type?
+  excludeList, // Variables to exlude
+  variableRegistry, // variable registry
+  layoutVariable, // boolean value uses for edges?
+) => {
+  // generate keys for attributes
+  const missingVariables = [];
+  const done = [];
+
+  // add keys for gephi positions
+  if (layoutVariable) {
+    const xElement = document.createElementNS(graphML.namespaceURI, 'key');
+    xElement.setAttribute('id', 'x');
+    xElement.setAttribute('attr.name', 'x');
+    xElement.setAttribute('attr.type', 'double');
+    xElement.setAttribute('for', type);
+    graphML.insertBefore(xElement, graph);
+    const yElement = document.createElementNS(graphML.namespaceURI, 'key');
+    yElement.setAttribute('id', 'y');
+    yElement.setAttribute('attr.name', 'y');
+    yElement.setAttribute('attr.type', 'double');
+    yElement.setAttribute('for', type);
+    graphML.insertBefore(yElement, graph);
+  }
+
+  if (type === 'edge') {
+    const label = document.createElementNS(graphML.namespaceURI, 'key');
+    label.setAttribute('id', 'label');
+    label.setAttribute('attr.name', 'label');
+    label.setAttribute('attr.type', 'string');
+    label.setAttribute('for', type);
+    graphML.insertBefore(label, graph);
+  }
+
+  elements.forEach((element) => {
+    let iterableElement = element;
+    if (type === 'node') {
+      iterableElement = getNodeAttributes(element);
+    }
+    // Node data model attributes are now stored under a specific propertyy
+
+    Object.keys(iterableElement).forEach((key) => {
+      // transpose ids to names based on registry
+      const keyName = getTypeFromVariableRegistry(variableRegistry, type, element, key, 'name') || key;
+      if (done.indexOf(keyName) === -1 && !excludeList.includes(keyName)) {
+        const keyElement = document.createElementNS(graphML.namespaceURI, 'key');
+        keyElement.setAttribute('id', keyName);
+        keyElement.setAttribute('attr.name', keyName);
+
+        if (!isVariableRegistryExists(variableRegistry, type, element, key)) {
+          missingVariables.push(`"${key}" in ${type}.${element.type}`);
+        }
+
+        const variableType = getTypeFromVariableRegistry(variableRegistry, type, element, key);
+        switch (variableType) {
+          case VariableType.boolean:
+            keyElement.setAttribute('attr.type', variableType);
+            break;
+          case VariableType.ordinal:
+          case VariableType.number: {
+            const keyType = getTypeForKey(elements, key);
+            keyElement.setAttribute('attr.type', keyType);
+            break;
+          }
+          case VariableType.layout: {
+            // special handling for locations
+            keyElement.setAttribute('attr.name', `${keyName}Y`);
+            keyElement.setAttribute('id', `${keyName}Y`);
+            keyElement.setAttribute('attr.type', 'double');
+            const keyElement2 = document.createElementNS(graphML.namespaceURI, 'key');
+            keyElement2.setAttribute('id', `${keyName}X`);
+            keyElement2.setAttribute('attr.name', `${keyName}X`);
+            keyElement2.setAttribute('attr.type', 'double');
+            keyElement2.setAttribute('for', type);
+            graphML.insertBefore(keyElement2, graph);
+            break;
+          }
+          case VariableType.text:
+          case VariableType.datetime:
+          case VariableType.categorical:
+          case VariableType.location: // TODO: special handling?
+          default:
+            keyElement.setAttribute('attr.type', 'string');
+        }
+        keyElement.setAttribute('for', type);
+        graphML.insertBefore(keyElement, graph);
+        done.push(keyName);
+      }
+    });
+  });
+  return missingVariables;
+};
+
+const getDataElement = (uri, key, text) => {
+  const data = document.createElementNS(uri, 'data');
+  data.setAttribute('key', key);
+  data.appendChild(document.createTextNode(text));
+  return data;
+};
+
+const addElements = (
+  graph, // <Graph> XML Element
+  uri, // the xmlns attribute from <GraphML>
+  dataList, // List of nodes or edges
+  type, // Element type to be created. "node" or "egde"
+  excludeList, // Attributes to exclude lookup of in variable registry
+  variableRegistry, // Copy of variable registry
+  layoutVariable, // Primary layout variable. Null for edges
+  extra = false, // ???
+) => {
+  dataList.forEach((dataElement, index) => {
+    const domElement = document.createElementNS(uri, type);
+    const nodeAttrs = getNodeAttributes(dataElement);
+
+    if (dataElement[nodePrimaryKeyProperty]) {
+      domElement.setAttribute('id', dataElement[nodePrimaryKeyProperty]);
+    } else {
+      domElement.setAttribute('id', index);
+    }
+    if (extra) domElement.setAttribute('source', dataElement.from);
+    if (extra) domElement.setAttribute('target', dataElement.to);
+    graph.appendChild(domElement);
+
+    if (extra) {
+      const label = variableRegistry && variableRegistry[type] &&
+        variableRegistry[type][dataElement.type] && (variableRegistry[type][dataElement.type].name
+          || variableRegistry[type][dataElement.type].label);
+      domElement.appendChild(getDataElement(uri, 'label', label));
+    }
+
+    // Add node attributes
+    if (type === 'node') {
+      Object.keys(nodeAttrs).forEach((key) => {
+        const keyName = getTypeFromVariableRegistry(variableRegistry, type, dataElement, key, 'name') || key;
+        if (!excludeList.includes(keyName)) {
+          if (typeof nodeAttrs[key] !== 'object') {
+            domElement.appendChild(
+              getDataElement(uri, keyName, nodeAttrs[key]));
+          } else if (getTypeFromVariableRegistry(variableRegistry, type, dataElement, key) === 'layout') {
+            domElement.appendChild(getDataElement(uri, `${keyName}X`, nodeAttrs[key].x));
+            domElement.appendChild(getDataElement(uri, `${keyName}Y`, nodeAttrs[key].y));
+          } else {
+            domElement.appendChild(
+              getDataElement(uri, keyName, JSON.stringify(nodeAttrs[key])));
+          }
+        }
+      });
+    } else {
+      Object.keys(dataElement).forEach((key) => {
+        const keyName = getTypeFromVariableRegistry(variableRegistry, type, dataElement, key, 'name') || key;
+        if (!excludeList.includes(keyName)) {
+          if (typeof dataElement[key] !== 'object') {
+            domElement.appendChild(getDataElement(uri, keyName, dataElement[key]));
+          } else if (getTypeFromVariableRegistry(variableRegistry, type, dataElement, key) === 'layout') {
+            domElement.appendChild(getDataElement(uri, `${keyName}X`, dataElement[key].x));
+            domElement.appendChild(getDataElement(uri, `${keyName}Y`, dataElement[key].y));
+          } else {
+            domElement.appendChild(getDataElement(uri, keyName, JSON.stringify(dataElement[key])));
+          }
+        }
+      });
+    }
+
+    // add positions for gephi
+    if (layoutVariable && nodeAttrs[layoutVariable]) {
+      domElement.appendChild(getDataElement(uri, 'x', nodeAttrs[layoutVariable].x * window.innerWidth));
+      domElement.appendChild(getDataElement(uri, 'y', (1.0 - nodeAttrs[layoutVariable].y) * window.innerHeight));
+    }
+  });
+};
+
+const xmlToString = (xmlData) => {
+  let xmlString;
+  if (window.ActiveXObject) { // IE
+    xmlString = xmlData.xml;
+  } else { // code for Mozilla, Firefox, Opera, etc.
+    xmlString = (new window.XMLSerializer()).serializeToString(xmlData);
+  }
+  return xmlString;
+};
+
+const createGraphML = (networkData, variableRegistry, onError) => {
+  // default graph structure
+  const xml = setUpXml();
+  const graph = xml.getElementsByTagName('graph')[0];
+  const graphML = xml.getElementsByTagName('graphml')[0];
+
+  // find the first variable of type layout
+  let layoutVariable;
+  forInRight(variableRegistry.node, (value) => {
+    layoutVariable = findKey(value.variables, { type: 'layout' });
+  });
+
+  // generate keys for nodes
+  let missingVariables = generateKeys(
+    graph,
+    graphML,
+    networkData.nodes,
+    'node',
+    [nodePrimaryKeyProperty],
+    variableRegistry,
+    layoutVariable,
+  );
+
+  // generate keys for edges and add to keys for nodes
+  missingVariables = missingVariables.concat(generateKeys(
+    graph,
+    graphML,
+    networkData.edges,
+    'edge',
+    ['from', 'to', 'type'],
+    variableRegistry,
+  ));
+
+  if (missingVariables.length > 0) {
+    // hard fail if checking the registry fails
+    // remove this to fall back to using "text" for unknowns
+    // onError(`The variable registry seems to be missing
+    // "type" of: ${join(missingVariables, ', ')}.`);
+    // return null;
+  }
+
+  // add nodes and edges to graph
+  addElements(graph, graphML.namespaceURI, networkData.nodes, 'node', [nodePrimaryKeyProperty, nodeAttributesProperty], variableRegistry, layoutVariable);
+  addElements(graph, graphML.namespaceURI, networkData.edges, 'edge', ['from', 'to', 'type'], variableRegistry, null, true);
+
+  return saveFile(xmlToString(xml), onError, 'graphml', ['graphml'], 'networkcanvas.graphml', 'text/xml',
+    { message: 'Your network canvas graphml file.', subject: 'network canvas export' });
+};
+
+export default createGraphML;

--- a/src/main/utils/formatters/graphml.js
+++ b/src/main/utils/formatters/graphml.js
@@ -3,7 +3,7 @@
 // - need to abstract DOMParser
 // - need to abstract XMLSerializer (see xmlToString())
 // - source data differs (we're working with resolved names in Server)
-//    - could inject the transform dependencies (no-ops for server)
+//    - this affects variable type lookup for nodes and labels for edges
 
 const { DOMParser, XMLSerializer } = require('xmldom'); // TODO: these are globals in browser
 
@@ -127,6 +127,7 @@ const generateKeys = (
 
     Object.keys(iterableElement).forEach((key) => {
       // transpose ids to names based on registry
+      // FIXME: Server should not be transposing
       const keyName = getTypeFromVariableRegistry(variableRegistry, type, element, key, 'name') || key;
       if (done.indexOf(keyName) === -1 && !excludeList.includes(keyName)) {
         const keyElement = document.createElementNS(graphML.namespaceURI, 'key');
@@ -212,6 +213,7 @@ const addElements = (
     graph.appendChild(domElement);
 
     if (type === 'edge') {
+      // FIXME: ID/name transposition for Server
       const label = variableRegistry && variableRegistry[type] &&
         variableRegistry[type][dataElement.type] && (variableRegistry[type][dataElement.type].name
           || variableRegistry[type][dataElement.type].label);

--- a/src/main/utils/formatters/network.js
+++ b/src/main/utils/formatters/network.js
@@ -1,2 +1,12 @@
 // TODO: share with other places this is defined
-module.exports.nodePrimaryKeyProperty = '_uid';
+const nodePrimaryKeyProperty = '_uid';
+
+const nodeAttributesProperty = 'attributes';
+
+const getNodeAttributes = node => node[nodeAttributesProperty] || {};
+
+module.exports = {
+  getNodeAttributes,
+  nodeAttributesProperty,
+  nodePrimaryKeyProperty,
+};


### PR DESCRIPTION
This builds on the mock network changes in #201 and adds graphML exporting. Currently, this retains the string-based interface of the NC original (ExportData.js), so it won't scale to very large consolidated networks. https://github.com/codaco/Network-Canvas/issues/796 describes some issues related to that.

- There are a couple of tests relevant to variable transposition, but in general output format should match Network Canvas.
- I added two direct dependencies:
    - This runs in the main process; [xmldom](https://www.npmjs.com/package/xmldom) is used for parsing & serializing present natively in the NC browser
    - lodash (at the version used by NC)
- More work will be needed to be able to actually share this between Server & NC and resolve https://github.com/codaco/Network-Canvas/issues/796; ~my goal for this first PR is to get a streaming version working so that~ UI integration can begin with the various formatters.

Edit: I'll follow up with a separate streaming API PR; this is enough to integrate into the UI and support moderately-sized networks.