### PR TITLE
Export files from UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The electron app (and server components) are served out of the /www folder. Chan
 ### Development workflow
 
 1. `npm run start:electron`: to start the webpack dev server
-  - Note: must be running on port 3000.
+  - Note: must be running on port 4000.
 2. `npm run electron:dev` (in another terminal session)
   1. Copies the electron source to `./electron-dev`
   2. Runs the electron app from there, including background services.

--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -28,10 +28,12 @@ const app = {
 const dialog = {
   showMessageBox: jest.fn(),
   showOpenDialog: jest.fn(),
+  showSaveDialog: jest.fn(),
 };
 
 const remote = {
   app,
+  dialog,
   process: {
     platform: '',
   },

--- a/config/jest/setupTestFramework.js
+++ b/config/jest/setupTestFramework.js
@@ -6,6 +6,15 @@
  * Relies on jest utils, and so must be called within an `it()` function.
  */
 expect.extend({
+  toAlwaysPass() {
+    // This is useful for asserting that a promise resolves, but we don't care what it resolves to,
+    // as `.resolves` by itself adds no assertions.
+    // Example: `expect(fn).resolves.toAlwaysPass()`
+    return {
+      message: 'expected anything or nothing',
+      pass: true,
+    };
+  },
   toMatchErrorMessage(receivedObj, expectedMessage) {
     const {
       matcherHint,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3897,6 +3897,120 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
+    "archiver": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
+      "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
+      "requires": {
+        "archiver-utils": "^1.3.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "zip-stream": "^1.2.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "archiver-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+      "requires": {
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.8.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
@@ -6081,8 +6195,7 @@
     "base64-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
-      "dev": true
+      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
     },
     "batch": {
       "version": "0.6.1",
@@ -6144,6 +6257,54 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
       "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+    },
+    "bl": {
+      "version": "1.2.2",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "block-stream": {
       "version": "0.0.9",
@@ -6487,7 +6648,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "dev": true,
       "requires": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -6496,14 +6656,17 @@
     "buffer-alloc-unsafe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "dev": true
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-      "dev": true
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "buffer-from": {
       "version": "1.1.0",
@@ -7515,6 +7678,56 @@
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
     },
+    "compress-commons": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+      "requires": {
+        "buffer-crc32": "^0.2.1",
+        "crc32-stream": "^2.0.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "compressible": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
@@ -7783,6 +7996,73 @@
           "requires": {
             "error-ex": "^1.3.1",
             "json-parse-better-errors": "^1.0.1"
+          }
+        }
+      }
+    },
+    "crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "requires": {
+        "buffer": "^5.1.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        }
+      }
+    },
+    "crc32-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+      "requires": {
+        "crc": "^3.4.4",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -9511,7 +9791,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -11683,6 +11962,11 @@
         "js-yaml": "^3.4.6"
       }
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "fs-extra": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
@@ -11740,8 +12024,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.4",
@@ -12569,7 +12852,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -12715,8 +12997,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graphql": {
       "version": "0.13.2",
@@ -13998,8 +14279,7 @@
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
-      "dev": true
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "iferr": {
       "version": "0.1.5",
@@ -16566,6 +16846,53 @@
       "integrity": "sha512-pjCf3BYk+uv3ZcPzEVM0BFvO9Uw58TmlrU0oG5tTrr9Kcid3+kdKxapH8CjdYmVa2nO5wOoZn2rdvZx2PKj/xg==",
       "dev": true
     },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "requires": {
+        "readable-stream": "^2.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -18062,7 +18389,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -24820,8 +25146,7 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "renderkid": {
       "version": "2.0.1",
@@ -27438,6 +27763,59 @@
         "inherits": "2"
       }
     },
+    "tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "requires": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "temp-file": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.1.3.tgz",
@@ -27570,6 +27948,11 @@
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -31022,6 +31405,56 @@
         "lodash.get": "^4.0.0",
         "lodash.isequal": "^4.0.0",
         "validator": "^10.0.0"
+      }
+    },
+    "zip-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+      "requires": {
+        "archiver-utils": "^1.3.0",
+        "compress-commons": "^1.2.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
   },
   "dependencies": {
     "animejs": "^2.2.0",
+    "archiver": "^2.1.1",
     "classnames": "^2.2.6",
     "detect-port": "^1.2.3",
     "jszip": "^3.1.5",

--- a/src/main/data-managers/ExportManager.js
+++ b/src/main/data-managers/ExportManager.js
@@ -48,7 +48,7 @@ const exportFile = (
 
   // Temporary support for graphml string interface
   if (exportFormat === formats.graphml) {
-    const formatter = new Formatter(network, variableRegistry); // TODO: unify interface
+    const formatter = new Formatter(network, useDirectedEdges, variableRegistry);
     const filepath = path.join(outDir, `${namePrefix}${extension}`);
     return writeFile(filepath, formatter.toString()).then(() => filepath);
   }

--- a/src/main/data-managers/ExportManager.js
+++ b/src/main/data-managers/ExportManager.js
@@ -1,0 +1,95 @@
+const fs = require('fs');
+const path = require('path');
+const uuid = require('uuid');
+
+const SessionDB = require('./SessionDB');
+const {
+  AdjacencyMatrixFormatter,
+  AdjacencyListFormatter,
+  AttributeListFormatter,
+  GraphMLFormatter,
+} = require('../utils/formatters');
+
+const formats = {
+  graphml: 'graphml',
+  // CSV:
+  adjacencyMatrix: 'adjacencyMatrix',
+  adjacencyList: 'adjacencyList',
+  attributeList: 'attributeList',
+};
+
+const unionOfNetworks = networks =>
+  networks.reduce((union, network) => {
+    union.nodes.push(...network.nodes);
+    union.edges.push(...network.edges);
+    return union;
+  }, { nodes: [], edges: [] });
+
+const getFormatterClass = (formatterType) => {
+  switch (formatterType) {
+    case formats.graphml:
+      return GraphMLFormatter;
+    case formats.adjacencyMatrix:
+      return AdjacencyMatrixFormatter;
+    case formats.adjacencyList:
+      return AdjacencyListFormatter;
+    case formats.attributeList:
+      return AttributeListFormatter;
+    default:
+      return null;
+  }
+};
+
+const exportFile = (exportFormat, network, forceDirectedEdges) => {
+  const Formatter = getFormatterClass(exportFormat);
+  if (!Formatter) {
+    // TODO: throw?
+    return;
+  }
+  const formatter = new Formatter(network, forceDirectedEdges);
+  // TODO: tmpfile, naming, promis resolution, etc.
+  formatter.writeToStream(fs.createWriteStream(`${uuid()}.csv`));
+};
+
+class ExportManager {
+  constructor(sessionDataDir) {
+    // TODO: path is duplicated in ProtocolManager
+    const sessionDbFile = path.join(sessionDataDir, 'db', 'sessions.db');
+    this.sessionDB = new SessionDB(sessionDbFile);
+  }
+
+  /**
+   * Produces one or more export files, zips them up if needed, writes the results to a
+   * temporary location, and returns [a promise resolving to] the filepath.
+   *
+   * @async
+   * @param {string} options.exportFormat "csv" or "graphml"
+   * @param {Array} options.csvTypes if `exportFormat` is "csv", then include these types in output.
+   *                                 Options: ["adjacencyMatrix", "adjacencyList", "attributeList"]
+   * @param {boolean} options.exportNetworkUnion true if all interview networks should be merged
+   *                                             false if each interview network should be exported
+   *                                             individually
+   * @param {Object} options.filter before formatting, apply this filter to each network (if
+   *                                `exportNetworkUnion` is false) or the merged network (if
+   *                                `exportNetworkUnion` is true)
+   * @param {boolean} options.useDirectedEdges used by the formatters. May be removed in the future
+   *                                           if information is encapsulated in network.
+   * @return {string} filepath of written file
+   */
+  createExportFile(
+    protocolId,
+    { exportFormats, exportNetworkUnion, useDirectedEdges/* , filter */ } = {},
+  ) {
+    // if (!exportFormat) {
+    //   return Promise.reject(new Error('exportFormat required'));
+    // }
+    const exportFormat = exportFormats[0];
+    return this.sessionDB.findAll(protocolId, null, null)
+      .then(sessions => sessions.map(session => session.data))
+      .then(sessions => (exportNetworkUnion ? [unionOfNetworks(sessions)] : sessions))
+      .then(networks => Promise.all(networks.map(network =>
+        exportFile(exportFormat, network, useDirectedEdges))));
+  }
+}
+
+module.exports = ExportManager;

--- a/src/main/data-managers/ExportManager.js
+++ b/src/main/data-managers/ExportManager.js
@@ -10,7 +10,7 @@ const { archive } = require('../utils/archive');
 const { writeFile } = require('../utils/promised-fs');
 const { RequestError, ErrorMessages } = require('../errors/RequestError');
 const { unionOfNetworks } = require('../utils/formatters/network');
-const { makeTempDir } = require('../utils/formatters/dir');
+const { makeTempDir, removeTempDir } = require('../utils/formatters/dir');
 const {
   formats,
   formatsAreValid,
@@ -117,15 +117,7 @@ class ExportManager {
     }
 
     let tmpDir;
-    const cleanUp = () => {
-      try {
-        // TODO: clean up all our temp files
-        // const outDirPrefix = tmpDir.substring(0, tmpDir.length - 6);
-        // if (tmpDir && (new RegExp(`${tmpDirPrefix}$`).test(outDirPrefix))) {
-        // fs.rmdirSync(tmpDir);
-        // }
-      } catch (err) { /* don't throw; cleanUp is called after catching */ }
-    };
+    const cleanUp = () => removeTempDir(tmpDir);
 
     let promisedExports;
     const exportOpts = {
@@ -166,6 +158,7 @@ class ExportManager {
       if (promisedExports) {
         promisedExports.forEach(promise => promise.abort());
       }
+      cleanUp();
     };
 
     return exportPromise;

--- a/src/main/data-managers/SessionDB.js
+++ b/src/main/data-managers/SessionDB.js
@@ -54,13 +54,13 @@ class SessionDB extends Reportable(DatabaseAdapter) {
   }
 
   /**
-   * Find all sessions for a protocol
+   * Find all sessions for a protocol.
+   * The default projection returns only limited data to speed up query.
    */
-  findAll(protocolId, limit = null) {
-    // For now, return only limited data to speed query
-    const projection = { updatedAt: 1 };
+  findAll(protocolId, limit = null, projection = { updatedAt: 1 }) {
     return new Promise((resolve, reject) => {
-      let cursor = this.db.find({ protocolId }, projection).sort(mostRecent);
+      let cursor = this.db.find({ protocolId }, projection || undefined);
+      cursor = cursor.sort(mostRecent);
       if (limit) { cursor = cursor.limit(limit); }
       cursor.exec((err, docs) => {
         if (err) {

--- a/src/main/data-managers/__tests__/ExportManager-test.js
+++ b/src/main/data-managers/__tests__/ExportManager-test.js
@@ -11,7 +11,10 @@ jest.mock('../../utils/archive', () => ({
   archive: jest.fn().mockResolvedValue({}),
 }));
 
-jest.mock('../../utils/formatters/dir');
+jest.mock('../../utils/formatters/dir', () => ({
+  makeTempDir: jest.fn().mockResolvedValue('temp'),
+  removeTempDir: jest.fn(),
+}));
 
 describe('ExportManager', () => {
   let protocol;

--- a/src/main/data-managers/__tests__/ExportManager-test.js
+++ b/src/main/data-managers/__tests__/ExportManager-test.js
@@ -1,0 +1,70 @@
+/* eslint-env jest */
+
+import ExportManager from '../ExportManager';
+import { ErrorMessages } from '../../errors/RequestError';
+
+jest.mock('../../utils/promised-fs', () => ({
+  writeFile: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../utils/archive', () => ({
+  archive: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../../utils/formatters/dir');
+
+describe('ExportManager', () => {
+  let protocol;
+  let validOpts;
+  let manager;
+
+  beforeEach(() => {
+    manager = new ExportManager('.');
+    protocol = { id: '1', name: '1', createdAt: new Date() };
+    validOpts = {
+      destinationFilepath: '.',
+      exportFormats: ['graphml'],
+      exportNetworkUnion: false,
+      useDirectedEdges: false,
+    };
+  });
+
+  it('returns a promise', async () => {
+    await expect(manager.createExportFile(protocol, validOpts)).resolves.toAlwaysPass();
+  });
+
+  it('rejects if protocol missing', async () => {
+    await expect(manager.createExportFile(null, validOpts)).rejects.toMatchErrorMessage('Not found');
+  });
+
+  it('rejects if path missing', async () => {
+    const opts = { ...validOpts, destinationFilepath: null };
+    const message = ErrorMessages.InvalidExportOptions;
+    await expect(manager.createExportFile(protocol, opts)).rejects.toMatchErrorMessage(message);
+  });
+
+  it('rejects if formats missing', async () => {
+    const opts = { ...validOpts, exportFormats: null };
+    const message = ErrorMessages.InvalidExportOptions;
+    await expect(manager.createExportFile(protocol, opts)).rejects.toMatchErrorMessage(message);
+  });
+
+  it('rejects if type is invalid', async () => {
+    const opts = { ...validOpts, exportFormats: ['not-a-format'] };
+    const message = ErrorMessages.InvalidExportOptions;
+    await expect(manager.createExportFile(protocol, opts)).rejects.toMatchErrorMessage(message);
+  });
+
+  fdescribe('with data', () => {
+    beforeEach(() => {
+      protocol.variableRegistry = {};
+      manager.sessionDB = {
+        findAll: jest.fn().mockResolvedValue([{ data: { nodes: [], edges: [] } }]),
+      };
+    });
+
+    it('exports a graphml file', async () => {
+      await expect(manager.createExportFile(protocol, validOpts)).resolves.toAlwaysPass();
+    });
+  });
+});

--- a/src/main/errors/RequestError.js
+++ b/src/main/errors/RequestError.js
@@ -21,6 +21,7 @@ const ErrorMessages = {
   InvalidProtocolFormat: 'Invalid protocol format',
   InvalidRequestBody: 'Could not parse request data',
   InvalidZip: 'Invalid ZIP file',
+  InvalidExportOptions: 'Invalid export options',
   MissingProtocolFile: 'Missing protocol file',
   NotFound: 'Not found',
   ProtocolNotFoundForSession: 'The associated protocol does not exist on this server',

--- a/src/main/server/AdminService.js
+++ b/src/main/server/AdminService.js
@@ -205,12 +205,7 @@ class AdminService {
     // See ExportManager#createExportFile for possible req body params
     api.post('/protocols/:protocolId/export_requests', (req, res, next) => {
       this.protocolManager.getProtocol(req.params.protocolId)
-        .then((protocol) => {
-          if (!protocol) {
-            throw new RequestError(ErrorMessages.NotFound);
-          }
-          return this.exportManager.createExportFile(protocol, req.body);
-        })
+        .then(protocol => this.exportManager.createExportFile(protocol, req.body))
         .then(filepath => res.send({ status: 'ok', filepath }))
         .catch((err) => {
           logger.error(err);

--- a/src/main/utils/__tests__/promised-fs-test.js
+++ b/src/main/utils/__tests__/promised-fs-test.js
@@ -12,6 +12,8 @@ describe('promisified fs', () => {
     const mockFileContents = Buffer.from([0x01]);
     beforeAll(() => {
       fs.mkdir.mockImplementation((p, opts, cb) => (cb || opts)(undefined));
+      fs.readdir.mockImplementation((d, opts, cb) => (cb || opts)(undefined, []));
+      fs.rmdir.mockImplementation((p, cb) => cb(undefined));
       fs.readFile.mockImplementation((f, opts, cb) => (cb || opts)(undefined, mockFileContents));
       fs.rename.mockImplementation((a, b, cb) => cb(undefined));
       fs.unlink.mockImplementation((f, cb) => cb(undefined));
@@ -21,20 +23,20 @@ describe('promisified fs', () => {
     helpers.forEach((helper) => {
       it('resolves successful callback', async () => {
         expect.hasAssertions();
-        await expect(pfs[helper]('.')).resolves.toAlwaysPass();
+        await expect(pfs[helper]('__mocks__')).resolves.toAlwaysPass();
       });
     });
 
     it('accepts options for readFile', async () => {
-      await expect(pfs.readFile('.', {})).resolves.toEqual(mockFileContents);
+      await expect(pfs.readFile('foo.txt', {})).resolves.toEqual(mockFileContents);
     });
 
     it('accepts options for writeFile', async () => {
-      await expect(pfs.writeFile('.', Buffer.from([]), {})).resolves.toBe(undefined);
+      await expect(pfs.writeFile('foo.txt', Buffer.from([]), {})).resolves.toBe(undefined);
     });
 
     it('accepts mode for mkdir', async () => {
-      await expect(pfs.mkdir('.', 0o777)).resolves.toBe(undefined);
+      await expect(pfs.mkdir('foo', 0o777)).resolves.toBe(undefined);
     });
   });
 
@@ -43,6 +45,8 @@ describe('promisified fs', () => {
     mockErr.code = 'ENOENT';
     beforeAll(() => {
       fs.mkdir.mockImplementation((p, cb) => cb(mockErr));
+      fs.readdir.mockImplementation((d, opts, cb) => (cb || opts)(mockErr));
+      fs.rmdir.mockImplementation((p, cb) => cb(mockErr));
       fs.readFile.mockImplementation((f, cb) => cb(mockErr));
       fs.rename.mockImplementation((a, b, cb) => cb(mockErr));
       fs.unlink.mockImplementation((f, cb) => cb(mockErr));
@@ -65,11 +69,14 @@ describe('promisified fs', () => {
   describe('on synchronous error (invalid args)', () => {
     const mockErr = new Error('mock');
     beforeAll(() => {
-      fs.mkdir.mockImplementation(() => { throw mockErr; });
-      fs.readFile.mockImplementation(() => { throw mockErr; });
-      fs.rename.mockImplementation(() => { throw mockErr; });
-      fs.unlink.mockImplementation(() => { throw mockErr; });
-      fs.writeFile.mockImplementation(() => { throw mockErr; });
+      const throwErr = () => { throw mockErr; };
+      fs.mkdir.mockImplementation(throwErr);
+      fs.readdir.mockImplementation(throwErr);
+      fs.rmdir.mockImplementation(throwErr);
+      fs.readFile.mockImplementation(throwErr);
+      fs.rename.mockImplementation(throwErr);
+      fs.unlink.mockImplementation(throwErr);
+      fs.writeFile.mockImplementation(throwErr);
     });
 
     // fs methods throw (rather than calling back with error) on invalid input

--- a/src/main/utils/__tests__/promised-fs-test.js
+++ b/src/main/utils/__tests__/promised-fs-test.js
@@ -20,7 +20,8 @@ describe('promisified fs', () => {
 
     helpers.forEach((helper) => {
       it('resolves successful callback', async () => {
-        await expect(pfs[helper]('.')).resolves;
+        expect.hasAssertions();
+        await expect(pfs[helper]('.')).resolves.toAlwaysPass();
       });
     });
 

--- a/src/main/utils/archive.js
+++ b/src/main/utils/archive.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const archiver = require('archiver');
+
+// const zlibFastestCompression = 1;
+// const zlibBestCompression = 9;
+const zlibDefaultCompression = -1;
+
+// Use zlib default: compromise speed & size
+// archiver overrides zlib's default (with 'best speed'), so we need to provide it
+const archiveOptions = {
+  zlib: { level: zlibDefaultCompression },
+  store: true,
+};
+
+/**
+ * Write a bundled (zip) from source files
+ * @param {string} destinationPath full FS path to write
+ * @param {string[]} sourcePaths
+ * @return Returns a promise that resolves to (sourcePath, destinationPath)
+ */
+const archive = (sourcePaths, destinationPath) =>
+  new Promise((resolve, reject) => {
+    const output = fs.createWriteStream(destinationPath);
+    const zip = archiver('zip', archiveOptions);
+
+    output.on('close', () => {
+      resolve(destinationPath);
+    });
+
+    output.on('warning', reject);
+    output.on('error', reject);
+
+    zip.pipe(output);
+
+    zip.on('warning', reject);
+    zip.on('error', reject);
+
+    sourcePaths.forEach((sourcePath) => {
+      zip.file(sourcePath, { name: path.basename(sourcePath) });
+    });
+
+    zip.finalize();
+  });
+
+// This is adapted from Architect; consider using `extract` as well
+module.exports = {
+  archive,
+};

--- a/src/main/utils/formatters/__mocks__/dir.js
+++ b/src/main/utils/formatters/__mocks__/dir.js
@@ -1,0 +1,5 @@
+/* eslint-env jest */
+
+module.exports = {
+  makeTempDir: jest.fn().mockResolvedValue('.'),
+};

--- a/src/main/utils/formatters/__tests__/adjacency-list-test.js
+++ b/src/main/utils/formatters/__tests__/adjacency-list-test.js
@@ -2,17 +2,26 @@
 import { makeWriteableStream } from '../../../../../config/jest/setupTestEnv';
 import { asAdjacencyList, toCSVStream } from '../adjacency-list';
 
+const adjacencyListFromEdges = (edges, directed) => asAdjacencyList({ edges }, directed);
+
 describe('asAdjacencyList', () => {
+  it('takes a network as input', () => {
+    const network = { nodes: [], edges: [{ from: 'nodeA', to: 'nodeB' }] };
+    expect(asAdjacencyList(network)).toHaveProperty('nodeA');
+  });
+
   it('represents an edgeless network', () => {
-    expect(asAdjacencyList([])).toEqual({});
+    expect(adjacencyListFromEdges([])).toEqual({});
   });
 
   it('represents a single undirected edge', () => {
-    expect(asAdjacencyList([{ from: 1, to: 2 }])).toEqual({ 1: new Set([2]), 2: new Set([1]) });
+    expect(
+      adjacencyListFromEdges([{ from: 1, to: 2 }])).toEqual({ 1: new Set([2]), 2: new Set([1]) },
+    );
   });
 
   it('represents a single directed edge', () => {
-    expect(asAdjacencyList([{ from: 1, to: 2 }], true)).toEqual({ 1: new Set([2]) });
+    expect(adjacencyListFromEdges([{ from: 1, to: 2 }], true)).toEqual({ 1: new Set([2]) });
   });
 });
 
@@ -24,35 +33,35 @@ describe('toCSVStream', () => {
   });
 
   it('Writes a simple csv', async () => {
-    const list = asAdjacencyList([{ from: 1, to: 2 }]);
+    const list = adjacencyListFromEdges([{ from: 1, to: 2 }]);
     toCSVStream(list, writable);
     const csv = await writable.asString();
     expect(csv).toEqual('1,2\r\n2,1\r\n');
   });
 
   it('Writes multiple edges', async () => {
-    const list = asAdjacencyList([{ from: 1, to: 2 }, { from: 1, to: 3 }]);
+    const list = adjacencyListFromEdges([{ from: 1, to: 2 }, { from: 1, to: 3 }]);
     toCSVStream(list, writable);
     const csv = await writable.asString();
     expect(csv).toEqual('1,2,3\r\n2,1\r\n3,1\r\n');
   });
 
   it('Writes a csv for directed edges', async () => {
-    const list = asAdjacencyList([{ from: 1, to: 2 }, { from: 1, to: 3 }], true);
+    const list = adjacencyListFromEdges([{ from: 1, to: 2 }, { from: 1, to: 3 }], true);
     toCSVStream(list, writable);
     const csv = await writable.asString();
     expect(csv).toEqual('1,2,3\r\n');
   });
 
   it('Writes a csv for directed edges (inverse)', async () => {
-    const list = asAdjacencyList([{ from: 1, to: 2 }, { from: 3, to: 1 }], true);
+    const list = adjacencyListFromEdges([{ from: 1, to: 2 }, { from: 3, to: 1 }], true);
     toCSVStream(list, writable);
     const csv = await writable.asString();
     expect(csv).toEqual('1,2\r\n3,1\r\n');
   });
 
   it('Ignores duplicate edges', async () => {
-    const list = asAdjacencyList([{ from: 1, to: 2 }, { from: 1, to: 2 }]);
+    const list = adjacencyListFromEdges([{ from: 1, to: 2 }, { from: 1, to: 2 }]);
     toCSVStream(list, writable);
     const csv = await writable.asString();
     expect(csv).toEqual('1,2\r\n2,1\r\n');

--- a/src/main/utils/formatters/__tests__/attribute-list-test.js
+++ b/src/main/utils/formatters/__tests__/attribute-list-test.js
@@ -1,7 +1,14 @@
 /* eslint-env jest */
 
 import { makeWriteableStream } from '../../../../../config/jest/setupTestEnv';
-import { toCSVStream } from '../attribute-list';
+import { asAttributeList, toCSVStream } from '../attribute-list';
+
+describe('asAttributeList', () => {
+  it('transforms a network to nodes', () => {
+    const network = { nodes: [{ id: 1 }], edges: [] };
+    expect(asAttributeList(network)).toEqual(network.nodes);
+  });
+});
 
 describe('toCSVStream', () => {
   let writable;

--- a/src/main/utils/formatters/__tests__/dir-test.js
+++ b/src/main/utils/formatters/__tests__/dir-test.js
@@ -1,19 +1,22 @@
 /* eslint-env jest */
 /* eslint-disable no-console */
 const fs = require('fs');
+const path = require('path');
 
-const { makeTempDir, tmpDirPrefix } = require('../dir');
+const { makeTempDir, removeTempDir, tmpDirPrefix } = require('../dir');
 
+// Note: mocking fs.mkdtemp breaks the test runner
 describe('makeTempDir', () => {
-  it('makes a temp dir', async () => {
+  it('makes and removes a temp dir', async () => {
+    expect.assertions(2);
     const tempDir = await makeTempDir();
     expect(tempDir).toMatch(tmpDirPrefix);
-    try {
-      if ((tempDir).indexOf('org.codaco.server') > 0) {
-        fs.rmdirSync(tempDir);
-      } else {
-        console.warn('Invalid tempDir:', tempDir);
-      }
-    } catch (err) { console.log(err); }
+    if ((tempDir).indexOf('org.codaco.server') > 0) {
+      fs.writeFileSync(path.join(tempDir, 'foo.csv'), 'test');
+      await removeTempDir(tempDir);
+      expect(fs.existsSync(tempDir)).toBe(false);
+    } else {
+      console.warn('Invalid tempDir:', tempDir);
+    }
   });
 });

--- a/src/main/utils/formatters/__tests__/dir-test.js
+++ b/src/main/utils/formatters/__tests__/dir-test.js
@@ -1,0 +1,19 @@
+/* eslint-env jest */
+/* eslint-disable no-console */
+const fs = require('fs');
+
+const { makeTempDir, tmpDirPrefix } = require('../dir');
+
+describe('makeTempDir', () => {
+  it('makes a temp dir', async () => {
+    const tempDir = await makeTempDir();
+    expect(tempDir).toMatch(tmpDirPrefix);
+    try {
+      if ((tempDir).indexOf('org.codaco.server') > 0) {
+        fs.rmdirSync(tempDir);
+      } else {
+        console.warn('Invalid tempDir:', tempDir);
+      }
+    } catch (err) { console.log(err); }
+  });
+});

--- a/src/main/utils/formatters/__tests__/graphml-test.js
+++ b/src/main/utils/formatters/__tests__/graphml-test.js
@@ -4,13 +4,13 @@ import { DOMParser } from 'xmldom';
 import createGraphML from '../graphml';
 
 describe('createGraphML', () => {
+  const buildXML = (...args) => (new DOMParser()).parseFromString(createGraphML(...args));
   const edgeType = 'peer';
   let network;
   let variableRegistry;
   let xml;
 
   beforeEach(() => {
-    const buildXML = (...args) => (new DOMParser()).parseFromString(createGraphML(...args));
     network = {
       nodes: [
         { _uid: '1', type: 'person', attributes: { 'mock-uuid-1': 'Dee', 'mock-uuid-2': 40 } },
@@ -42,6 +42,10 @@ describe('createGraphML', () => {
     expect(xml.getElementsByTagName('graphml')).toHaveLength(1);
   });
 
+  it('defaults to undirected edges', () => {
+    expect(xml.getElementsByTagName('graph')[0].getAttribute('edgedefault')).toEqual('undirected');
+  });
+
   it('adds nodes', () => {
     expect(xml.getElementsByTagName('node')).toHaveLength(2);
   });
@@ -57,5 +61,15 @@ describe('createGraphML', () => {
   it('exports edge labels', () => { // This indicates that [non-]transposition worked for edges
     const edge = xml.getElementsByTagName('edge')[0];
     expect(edge.getElementsByTagName('data')[0].textContent).toEqual(edgeType);
+  });
+
+  describe('with directed edge option', () => {
+    beforeEach(() => {
+      xml = buildXML(network, variableRegistry, null, true);
+    });
+
+    it('specifies directed edges', () => {
+      expect(xml.getElementsByTagName('graph')[0].getAttribute('edgedefault')).toEqual('directed');
+    });
   });
 });

--- a/src/main/utils/formatters/__tests__/network-test.js
+++ b/src/main/utils/formatters/__tests__/network-test.js
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+const { getNodeAttributes, nodeAttributesProperty, unionOfNetworks } = require('../network');
+
+describe('network format helpers', () => {
+  describe('unionOfNetworks', () => {
+    it('joins nodes of two networks', () => {
+      const a = { nodes: [{ id: 1 }], edges: [] };
+      const b = { nodes: [{ id: 2 }], edges: [] };
+      expect(unionOfNetworks([a, b]).nodes).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+
+    it('joins edges of two networks', () => {
+      const a = { nodes: [], edges: [{ id: 1 }] };
+      const b = { nodes: [], edges: [{ id: 2 }] };
+      expect(unionOfNetworks([a, b]).edges).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+  });
+
+  describe('getNodeAttributes', () => {
+    it('gets nested attributes', () => {
+      const node = { id: 1, [nodeAttributesProperty]: { attr: 1 } };
+      expect(getNodeAttributes(node)).toEqual({ attr: 1 });
+    });
+  });
+});

--- a/src/main/utils/formatters/__tests__/utils-test.js
+++ b/src/main/utils/formatters/__tests__/utils-test.js
@@ -1,0 +1,40 @@
+/* eslint-env jest */
+
+const { formats, formatsAreValid, getFileExtension, getFormatterClass } = require('../utils');
+const { GraphMLFormatter } = require('../index');
+
+describe('formatter utilities', () => {
+  describe('getFileExtension', () => {
+    it('maps CSV types', () => {
+      expect(getFileExtension(formats.adjacencyMatrix)).toEqual('.csv');
+      expect(getFileExtension(formats.adjacencyList)).toEqual('.csv');
+      expect(getFileExtension(formats.attributeList)).toEqual('.csv');
+    });
+  });
+
+  describe('getFormatterClass', () => {
+    it('maps graphml to its formatter', () => {
+      expect(getFormatterClass(formats.graphml)).toEqual(GraphMLFormatter);
+    });
+
+    it('maps each format to a class', () => {
+      Object.keys(formats).forEach((format) => {
+        expect(getFormatterClass(format)).toBeDefined();
+      });
+    });
+  });
+
+  describe('formatsAreValid', () => {
+    it('recognizes formats', () => {
+      expect(formatsAreValid(['graphml'])).toBe(true);
+    });
+
+    it('requires an array', () => {
+      expect(formatsAreValid()).toBe(false);
+    });
+
+    it('checks for invalid formats', () => {
+      expect(formatsAreValid(['graphml', 'not-a-format'])).toBe(false);
+    });
+  });
+});

--- a/src/main/utils/formatters/adjacency-list.js
+++ b/src/main/utils/formatters/adjacency-list.js
@@ -42,6 +42,8 @@ const asAdjacencyList = (network, directed = false) =>
  * b,a
  * c,a
  * ```
+ *
+ * @return {Object} an abort controller; call the attached abort() method as needed.
  */
 // TODO: quoting/escaping (not needed while we're only using UUIDs)
 const toCSVStream = (adjancencyList, outStream) => {
@@ -65,6 +67,10 @@ const toCSVStream = (adjancencyList, outStream) => {
 
   // TODO: handle teardown. Use pipeline() API in Node 10?
   inStream.pipe(outStream);
+
+  return {
+    abort: () => { inStream.destroy(); },
+  };
 };
 
 class AdjacencyListFormatter {

--- a/src/main/utils/formatters/adjacency-list.js
+++ b/src/main/utils/formatters/adjacency-list.js
@@ -66,7 +66,17 @@ const toCSVStream = (adjancencyList, outStream) => {
   inStream.pipe(outStream);
 };
 
+class AdjacencyListFormatter {
+  constructor(data, directed = false) {
+    this.list = asAdjacencyList(data, directed);
+  }
+  writeToStream(outStream) {
+    toCSVStream(outStream, this.list);
+  }
+}
+
 module.exports = {
+  AdjacencyListFormatter,
   asAdjacencyList,
   toCSVStream,
 };

--- a/src/main/utils/formatters/adjacency-list.js
+++ b/src/main/utils/formatters/adjacency-list.js
@@ -16,13 +16,14 @@ const { csvEOL } = require('./csv');
  * | c    | a        |
  * ```
  *
- * @param  {Array}  edges from the NC network
+ * @param  {Object} network NC network containing edges
+ * @param  {Array} network.edges
  * @param  {Boolean} directed if false, adjacencies are represented in both directions
  *                            default: false
  * @return {Object.<string, Set>} the adjacency list
  */
-const asAdjacencyList = (edges, directed = false) =>
-  edges.reduce((acc, val) => {
+const asAdjacencyList = (network, directed = false) =>
+  (network.edges || []).reduce((acc, val) => {
     acc[val.from] = acc[val.from] || new Set();
     acc[val.from].add(val.to);
     if (directed === false) {
@@ -71,7 +72,7 @@ class AdjacencyListFormatter {
     this.list = asAdjacencyList(data, directed);
   }
   writeToStream(outStream) {
-    toCSVStream(outStream, this.list);
+    toCSVStream(this.list, outStream);
   }
 }
 

--- a/src/main/utils/formatters/attribute-list.js
+++ b/src/main/utils/formatters/attribute-list.js
@@ -57,7 +57,18 @@ const toCSVStream = (nodes, outStream) => {
   inStream.pipe(outStream);
 };
 
+class AttributeListFormatter {
+  constructor(data, directed = false) {
+    this.list = asAttributeList(data, directed);
+  }
+  writeToStream(outStream) {
+    toCSVStream(outStream, this.list);
+  }
+}
+
+
 module.exports = {
+  AttributeListFormatter,
   asAttributeList,
   toCSVStream,
 };

--- a/src/main/utils/formatters/attribute-list.js
+++ b/src/main/utils/formatters/attribute-list.js
@@ -19,6 +19,9 @@ const attributeHeaders = (nodes) => {
   return [...headerSet];
 };
 
+/**
+ * @return {Object} an abort controller; call the attached abort() method as needed.
+ */
 const toCSVStream = (nodes, outStream) => {
   const totalRows = nodes.length;
   const attrNames = attributeHeaders(nodes);
@@ -55,6 +58,10 @@ const toCSVStream = (nodes, outStream) => {
 
   // TODO: handle teardown. Use pipeline() API in Node 10?
   inStream.pipe(outStream);
+
+  return {
+    abort: () => { inStream.destroy(); },
+  };
 };
 
 class AttributeListFormatter {

--- a/src/main/utils/formatters/attribute-list.js
+++ b/src/main/utils/formatters/attribute-list.js
@@ -3,7 +3,7 @@ const { Readable } = require('stream');
 const { nodePrimaryKeyProperty } = require('./network');
 const { cellValue, csvEOL } = require('./csv');
 
-const asAttributeList = nodes => nodes;
+const asAttributeList = network => network.nodes;
 
 /**
  * The output of this formatter will contain the primary key (_uid)
@@ -62,7 +62,7 @@ class AttributeListFormatter {
     this.list = asAttributeList(data, directed);
   }
   writeToStream(outStream) {
-    toCSVStream(outStream, this.list);
+    toCSVStream(this.list, outStream);
   }
 }
 

--- a/src/main/utils/formatters/dir.js
+++ b/src/main/utils/formatters/dir.js
@@ -1,8 +1,16 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { readdir, rmdir, tryUnlink } = require('../promised-fs');
+const { extensions } = require('./utils');
 
 const tmpDirPrefix = 'org.codaco.server.exporting.';
+
+/**
+ * Create a new temp directory to hold intermediate export files
+ * @async
+ * @return {string} the directory (path) created
+ */
 const makeTempDir = () =>
   new Promise((resolve, reject) => {
     fs.mkdtemp(path.join(os.tmpdir(), tmpDirPrefix), (err, dir) => {
@@ -14,7 +22,30 @@ const makeTempDir = () =>
     });
   });
 
+const extensionPattern = new RegExp(`${Object.values(extensions).join('|')}$`);
+
+/**
+ * Best-effort clean up of the temp directory. Should not throw/reject.
+ * @async
+ */
+const removeTempDir = (tmpDir) => {
+  const ignoreError = () => {};
+  const removeFile = (name) => {
+    if (extensionPattern.test(name)) {
+      return tryUnlink(path.join(tmpDir, name)).catch(ignoreError);
+    }
+    return Promise.resolve();
+  };
+
+  return readdir(tmpDir, { withFileTypes: true })
+    .then(fileNames => Promise.all(fileNames.map(removeFile)))
+    .then(() => rmdir(tmpDir))
+    .catch(ignoreError);
+};
+
+
 module.exports = {
+  removeTempDir,
   makeTempDir,
   tmpDirPrefix,
 };

--- a/src/main/utils/formatters/dir.js
+++ b/src/main/utils/formatters/dir.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const tmpDirPrefix = 'org.codaco.server.exporting.';
+const makeTempDir = () =>
+  new Promise((resolve, reject) => {
+    fs.mkdtemp(path.join(os.tmpdir(), tmpDirPrefix), (err, dir) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(dir);
+      }
+    });
+  });
+
+module.exports = {
+  makeTempDir,
+  tmpDirPrefix,
+};

--- a/src/main/utils/formatters/graphml.js
+++ b/src/main/utils/formatters/graphml.js
@@ -2,7 +2,7 @@
 // - [ ] APIs (string output vs streaming); see saveFile()
 // - [ ] need to abstract DOMParser
 // - [ ] need to abstract XMLSerializer (see xmlToString())
-// - [ ] need directed as an option (until network encapsulates this)
+// - [x] need directed as an option (until network encapsulates this)
 // - [x] updated export (default/named)
 // - [x] source data differs (we're working with resolved names in Server)
 //    - this affects variable type lookup for nodes and labels for edges
@@ -30,13 +30,14 @@ const VariableTypeValues = Object.freeze(Object.values(VariableType));
 // TODO: different API needed for server
 const saveFile = xml => xml;
 
-const setUpXml = () => {
+const setUpXml = (useDirectedEdges) => {
+  const edgeDefault = useDirectedEdges ? 'directed' : 'undirected';
   const graphMLOutline = '<?xml version="1.0" encoding="UTF-8"?>\n' +
     '<graphml xmlns="http://graphml.graphdrawing.org/xmlns"\n' +
     'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n' +
     'xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns\n' +
     'http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">\n' +
-    '  <graph edgedefault="undirected">\n' +
+    `  <graph edgedefault="${edgeDefault}">\n` +
     ' </graph>\n' +
     ' </graphml>\n';
 
@@ -303,9 +304,9 @@ const xmlToString = xmlData => new XMLSerializer().serializeToString(xmlData);
 //   return xmlString;
 // };
 
-const createGraphML = (networkData, variableRegistry, onError) => {
+const createGraphML = (networkData, variableRegistry, onError, useDirectedEdges = false) => {
   // default graph structure
-  const xml = setUpXml();
+  const xml = setUpXml(useDirectedEdges);
   const graph = xml.getElementsByTagName('graph')[0];
   const graphML = xml.getElementsByTagName('graphml')[0];
 
@@ -353,12 +354,13 @@ const createGraphML = (networkData, variableRegistry, onError) => {
 };
 
 class GraphMLFormatter {
-  constructor(data, variableRegistry) {
+  constructor(data, useDirectedEdges, variableRegistry) {
     this.network = data;
     this.variableRegistry = variableRegistry;
+    this.useDirectedEdges = useDirectedEdges;
   }
   toString() {
-    return createGraphML(this.network, this.variableRegistry);
+    return createGraphML(this.network, this.variableRegistry, null, this.useDirectedEdges);
   }
 }
 

--- a/src/main/utils/formatters/graphml.js
+++ b/src/main/utils/formatters/graphml.js
@@ -2,6 +2,8 @@
 // - [ ] APIs (string output vs streaming); see saveFile()
 // - [ ] need to abstract DOMParser
 // - [ ] need to abstract XMLSerializer (see xmlToString())
+// - [ ] need directed as an option (until network encapsulates this)
+// - [x] updated export (default/named)
 // - [x] source data differs (we're working with resolved names in Server)
 //    - this affects variable type lookup for nodes and labels for edges
 // - [x] document is not global
@@ -350,4 +352,21 @@ const createGraphML = (networkData, variableRegistry, onError) => {
     { message: 'Your network canvas graphml file.', subject: 'network canvas export' });
 };
 
-module.exports = createGraphML;
+class GraphMLFormatter {
+  constructor(data) {
+    this.network = data;
+  }
+  toString() {
+    return createGraphML(this.network);
+  }
+}
+
+// Provides ES6 named + default imports via babel
+Object.defineProperty(exports, '__esModule', {
+  value: true,
+});
+
+exports.default = createGraphML;
+
+exports.GraphMLFormatter = GraphMLFormatter;
+exports.createGraphML = createGraphML;

--- a/src/main/utils/formatters/graphml.js
+++ b/src/main/utils/formatters/graphml.js
@@ -353,11 +353,12 @@ const createGraphML = (networkData, variableRegistry, onError) => {
 };
 
 class GraphMLFormatter {
-  constructor(data) {
+  constructor(data, variableRegistry) {
     this.network = data;
+    this.variableRegistry = variableRegistry;
   }
   toString() {
-    return createGraphML(this.network);
+    return createGraphML(this.network, this.variableRegistry);
   }
 }
 

--- a/src/main/utils/formatters/index.js
+++ b/src/main/utils/formatters/index.js
@@ -1,0 +1,11 @@
+const { AdjacencyMatrixFormatter } = require('./matrix');
+const { AdjacencyListFormatter } = require('./adjacency-list');
+const { AttributeListFormatter } = require('./attribute-list');
+const { GraphMLFormatter } = require('./graphml');
+
+module.exports = {
+  AdjacencyMatrixFormatter,
+  AdjacencyListFormatter,
+  AttributeListFormatter,
+  GraphMLFormatter,
+};

--- a/src/main/utils/formatters/matrix.js
+++ b/src/main/utils/formatters/matrix.js
@@ -236,6 +236,16 @@ const asAdjacencyMatrix = (network, directed = false) => {
   return adjacencyMatrix;
 };
 
+class AdjacencyMatrixFormatter {
+  constructor(data, directed = false) {
+    this.matrix = asAdjacencyMatrix(data, directed);
+  }
+  writeToStream(outStream) {
+    this.matrix.toCSVStream(outStream);
+  }
+}
+
 module.exports = {
+  AdjacencyMatrixFormatter,
   asAdjacencyMatrix,
 };

--- a/src/main/utils/formatters/matrix.js
+++ b/src/main/utils/formatters/matrix.js
@@ -113,8 +113,8 @@ class AdjacencyMatrix {
 
   /**
    * @param {Stream.Writable} outStream A writable stream for CSV output
+   * @return {Object} an abort controller; call the attached abort() method as needed.
    */
-  // TODO: support cancellation
   toCSVStream(outStream) {
     const uniqueNodeIds = this.uniqueNodeIds;
     const dataColumnCount = uniqueNodeIds.length;
@@ -202,6 +202,10 @@ class AdjacencyMatrix {
 
     // TODO: handle teardown. Use pipeline() API in Node 10?
     inStream.pipe(outStream);
+
+    return {
+      abort: () => { inStream.destroy(); },
+    };
   }
 
   toArray(matrixView = this.arrayView) {
@@ -241,7 +245,7 @@ class AdjacencyMatrixFormatter {
     this.matrix = asAdjacencyMatrix(data, directed);
   }
   writeToStream(outStream) {
-    this.matrix.toCSVStream(outStream);
+    return this.matrix.toCSVStream(outStream);
   }
 }
 

--- a/src/main/utils/formatters/network.js
+++ b/src/main/utils/formatters/network.js
@@ -5,8 +5,16 @@ const nodeAttributesProperty = 'attributes';
 
 const getNodeAttributes = node => node[nodeAttributesProperty] || {};
 
+const unionOfNetworks = networks =>
+  networks.reduce((union, network) => {
+    union.nodes.push(...network.nodes);
+    union.edges.push(...network.edges);
+    return union;
+  }, { nodes: [], edges: [] });
+
 module.exports = {
   getNodeAttributes,
   nodeAttributesProperty,
   nodePrimaryKeyProperty,
+  unionOfNetworks,
 };

--- a/src/main/utils/formatters/utils.js
+++ b/src/main/utils/formatters/utils.js
@@ -21,6 +21,11 @@ const formats = {
   attributeList: 'attributeList',
 };
 
+const extensions = {
+  graphml: '.graphml',
+  csv: '.csv',
+};
+
 /**
  * Check validity of supplied formats
  * @param  {string[]} suppliedFormats
@@ -38,11 +43,11 @@ const formatsAreValid = suppliedFormats =>
 const getFileExtension = (formatterType) => {
   switch (formatterType) {
     case formats.graphml:
-      return '.graphml';
+      return extensions.graphml;
     case formats.adjacencyMatrix:
     case formats.adjacencyList:
     case formats.attributeList:
-      return '.csv';
+      return extensions.csv;
     default:
       return null;
   }
@@ -69,6 +74,7 @@ const getFormatterClass = (formatterType) => {
 };
 
 module.exports = {
+  extensions,
   formats,
   formatsAreValid,
   getFileExtension,

--- a/src/main/utils/formatters/utils.js
+++ b/src/main/utils/formatters/utils.js
@@ -1,0 +1,52 @@
+const {
+  AdjacencyMatrixFormatter,
+  AdjacencyListFormatter,
+  AttributeListFormatter,
+  GraphMLFormatter,
+} = require('./index');
+
+const formats = {
+  graphml: 'graphml',
+  // CSV:
+  adjacencyMatrix: 'adjacencyMatrix',
+  adjacencyList: 'adjacencyList',
+  attributeList: 'attributeList',
+};
+
+const formatsAreValid = suppliedFormats =>
+  (suppliedFormats && suppliedFormats.every(format => formats[format])) || false;
+
+const getFileExtension = (formatterType) => {
+  switch (formatterType) {
+    case formats.graphml:
+      return '.graphml';
+    case formats.adjacencyMatrix:
+    case formats.adjacencyList:
+    case formats.attributeList:
+      return '.csv';
+    default:
+      return null;
+  }
+};
+
+const getFormatterClass = (formatterType) => {
+  switch (formatterType) {
+    case formats.graphml:
+      return GraphMLFormatter;
+    case formats.adjacencyMatrix:
+      return AdjacencyMatrixFormatter;
+    case formats.adjacencyList:
+      return AdjacencyListFormatter;
+    case formats.attributeList:
+      return AttributeListFormatter;
+    default:
+      return null;
+  }
+};
+
+module.exports = {
+  formats,
+  formatsAreValid,
+  getFileExtension,
+  getFormatterClass,
+};

--- a/src/main/utils/formatters/utils.js
+++ b/src/main/utils/formatters/utils.js
@@ -1,3 +1,7 @@
+/**
+ * @module ExportUtils
+ */
+
 const {
   AdjacencyMatrixFormatter,
   AdjacencyListFormatter,
@@ -5,6 +9,10 @@ const {
   GraphMLFormatter,
 } = require('./index');
 
+/**
+ * Possible values for data export
+ * @enum {string}
+ */
 const formats = {
   graphml: 'graphml',
   // CSV:
@@ -13,9 +21,20 @@ const formats = {
   attributeList: 'attributeList',
 };
 
+/**
+ * Check validity of supplied formats
+ * @param  {string[]} suppliedFormats
+ * @return {boolean} `true` if every supplied format is a valid type (or suppliedFormats is empty);
+ *                   `false` if suppliedFormats is falsy or contains an invalid format.
+ */
 const formatsAreValid = suppliedFormats =>
   (suppliedFormats && suppliedFormats.every(format => formats[format])) || false;
 
+/**
+ * Provide the appropriate file extension for the export type
+ * @param  {string} formatterType one of the `format`s
+ * @return {string}
+ */
 const getFileExtension = (formatterType) => {
   switch (formatterType) {
     case formats.graphml:
@@ -29,6 +48,11 @@ const getFileExtension = (formatterType) => {
   }
 };
 
+/**
+ * Formatter factory
+ * @param  {string} formatterType one of the `format`s
+ * @return {class}
+ */
 const getFormatterClass = (formatterType) => {
   switch (formatterType) {
     case formats.graphml:

--- a/src/main/utils/promised-fs.js
+++ b/src/main/utils/promised-fs.js
@@ -1,10 +1,10 @@
 const fs = require('fs');
 
-const resolveOrRejectWith = (resolve, reject) => (err) => {
+const resolveOrRejectWith = (resolve, reject) => (err, ...args) => {
   if (err) {
     reject(err);
   } else {
-    resolve();
+    resolve(...args);
   }
 };
 
@@ -17,6 +17,21 @@ const mkdir = (path, mode) => (new Promise((resolve, reject) => {
   try {
     fs.mkdir.apply(null, args);
   } catch (err) { reject(err); }
+}));
+
+const readdir = (path, options) => (new Promise((resolve, reject) => {
+  const args = [path];
+  if (options) {
+    args.push(options);
+  }
+  args.push(resolveOrRejectWith(resolve, reject));
+  try {
+    fs.readdir.apply(null, args);
+  } catch (err) { reject(err); }
+}));
+
+const rmdir = path => (new Promise((resolve, reject) => {
+  fs.rmdir(path, resolveOrRejectWith(resolve, reject));
 }));
 
 const writeFile = (file, data, options) => (new Promise((resolve, reject) => {
@@ -35,13 +50,7 @@ const readFile = (path, options) => (new Promise((resolve, reject) => {
   if (options) {
     args.push(options);
   }
-  args.push((err, data) => {
-    if (err) {
-      reject(err);
-    } else {
-      resolve(data);
-    }
-  });
+  args.push(resolveOrRejectWith(resolve, reject));
   try {
     fs.readFile.apply(null, args);
   } catch (err) { reject(err); }
@@ -65,6 +74,8 @@ const tryUnlink = path => unlink(path).catch((err) => {
 
 module.exports = {
   mkdir,
+  readdir,
+  rmdir,
   readFile,
   rename,
   tryUnlink,

--- a/src/renderer/components/ExportModal.js
+++ b/src/renderer/components/ExportModal.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Modal from './Modal';
+import { Spinner } from '../ui/components';
+
+const ExportModal = ({ className, handleCancel, show }) => (
+  <Modal className={className} title="Exporting..." show={show} onCancel={handleCancel}>
+    <div className="export-modal__progress">
+      <div className="export-modal__progress">
+        {/* TODO: progress */}
+        <Spinner small />
+      </div>
+    </div>
+  </Modal>
+);
+
+ExportModal.propTypes = {
+  className: PropTypes.string,
+  handleCancel: PropTypes.func.isRequired,
+  show: PropTypes.bool,
+};
+
+ExportModal.defaultProps = {
+  className: null,
+  show: false,
+};
+
+export default ExportModal;

--- a/src/renderer/components/SessionPanel.js
+++ b/src/renderer/components/SessionPanel.js
@@ -13,7 +13,7 @@ class SessionPanel extends Component {
     return (
       <div className="session-panel__header">
         <h4 className="session-panel__header-text">
-          Imported Sessions
+          Imported Interviews
           <small className="session-panel__header-count">
             {countText}
           </small>

--- a/src/renderer/components/__tests__/SessionPanel-test.js
+++ b/src/renderer/components/__tests__/SessionPanel-test.js
@@ -19,7 +19,7 @@ const props = {
 describe('<SessionPanel />', () => {
   it('renders a title', () => {
     const subject = mount(<SessionPanel {...props} />);
-    expect(subject.text()).toMatch('Sessions');
+    expect(subject.text()).toMatch('Interviews');
   });
 
   it('renders sessions', () => {

--- a/src/renderer/containers/ExportScreen.js
+++ b/src/renderer/containers/ExportScreen.js
@@ -58,7 +58,7 @@ class ExportScreen extends Component {
     this.setState({ exportNetworkUnion: evt.target.value === 'true' });
   }
 
-  useDandleDirectedEdgesChange = (evt) => {
+  handleDirectedEdgesChange = (evt) => {
     this.setState({ useDirectedEdges: evt.target.checked });
   }
 
@@ -120,7 +120,7 @@ class ExportScreen extends Component {
                     label="Treat edges as directed"
                     input={{
                       name: 'export_use_directed_edges',
-                      onChange: this.useDandleDirectedEdgesChange,
+                      onChange: this.handleDirectedEdgesChange,
                       value: this.state.useDirectedEdges,
                     }}
                   />

--- a/src/renderer/containers/ExportScreen.js
+++ b/src/renderer/containers/ExportScreen.js
@@ -31,7 +31,7 @@ class ExportScreen extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      exportFormat: null,
+      exportFormat: 'graphml',
       exportNetworkUnion: null,
       csvTypes: new Set(Object.keys(availableCsvTypes)),
       filter: defaultFilter,
@@ -136,6 +136,17 @@ class ExportScreen extends Component {
           </p>
           <div>
             <Radio
+              label="GraphML"
+              input={{
+                name: 'export_format',
+                checked: this.state.exportFormat === 'graphml',
+                value: 'graphml',
+                onChange: this.handleFormatChange,
+              }}
+            />
+          </div>
+          <div>
+            <Radio
               label="CSV"
               input={{
                 name: 'export_format',
@@ -177,17 +188,6 @@ class ExportScreen extends Component {
                 </div>
               </div>
             </DrawerTransition>
-          </div>
-          <div>
-            <Radio
-              label="GraphML"
-              input={{
-                name: 'export_format',
-                checked: this.state.exportFormat === 'graphml',
-                value: 'graphml',
-                onChange: this.handleFormatChange,
-              }}
-            />
           </div>
         </div>
         <div className="export__section">

--- a/src/renderer/containers/ExportScreen.js
+++ b/src/renderer/containers/ExportScreen.js
@@ -33,7 +33,7 @@ class ExportScreen extends Component {
     super(props);
     this.state = {
       exportFormat: 'graphml',
-      exportNetworkUnion: null,
+      exportNetworkUnion: false,
       csvTypes: new Set(Object.keys(availableCsvTypes)),
       filter: defaultFilter,
       useDirectedEdges: true,

--- a/src/renderer/containers/ExportScreen.js
+++ b/src/renderer/containers/ExportScreen.js
@@ -89,8 +89,10 @@ class ExportScreen extends Component {
   }
 
   handleCancel = () => {
-    // TODO: cancel underlying requests
-    this.setState({ exportInProgress: false });
+    // this.setState({ exportInProgress: false });
+    // TODO: cancel underlying requests with an AbortController (requires Electron 3+)
+    // Temporary workaround:
+    remote.getCurrentWindow().reload();
   }
 
   exportToFile = (destinationFilepath) => {

--- a/src/renderer/containers/ExportScreen.js
+++ b/src/renderer/containers/ExportScreen.js
@@ -68,6 +68,11 @@ class ExportScreen extends Component {
   }
 
   handleExport = () => {
+    if (!this.formatsAreValid()) {
+      this.props.showError('Please select at least one file type to export');
+      return;
+    }
+
     const defaultName = this.props.protocol.name || 'network-canvas-data';
     const exportDialog = {
       title: 'Export ',
@@ -93,6 +98,10 @@ class ExportScreen extends Component {
     // TODO: cancel underlying requests with an AbortController (requires Electron 3+)
     // Temporary workaround:
     remote.getCurrentWindow().reload();
+  }
+
+  formatsAreValid() {
+    return this.state.exportFormat === 'graphml' || this.state.csvTypes.size > 0;
   }
 
   exportToFile = (destinationFilepath) => {

--- a/src/renderer/containers/ExportScreen.js
+++ b/src/renderer/containers/ExportScreen.js
@@ -193,20 +193,20 @@ class ExportScreen extends Component {
                     ))
                   }
                 </div>
-                <div className="export__subpanel-content">
-                  <h4>Directed Edges</h4>
-                  <Toggle
-                    label="Treat edges as directed"
-                    input={{
-                      name: 'export_use_directed_edges',
-                      onChange: this.handleDirectedEdgesChange,
-                      value: this.state.useDirectedEdges,
-                    }}
-                  />
-                </div>
               </div>
             </DrawerTransition>
           </div>
+        </div>
+        <div className="export__section">
+          <h4>Directed Edges</h4>
+          <Toggle
+            label="Treat edges as directed"
+            input={{
+              name: 'export_use_directed_edges',
+              onChange: this.handleDirectedEdgesChange,
+              value: this.state.useDirectedEdges,
+            }}
+          />
         </div>
         <div className="export__section">
           <h3>Interview Networks</h3>

--- a/src/renderer/containers/ExportScreen.js
+++ b/src/renderer/containers/ExportScreen.js
@@ -11,6 +11,7 @@ import DrawerTransition from '../components/Transitions/Drawer';
 import Checkbox from '../ui/components/Fields/Checkbox';
 import Radio from '../ui/components/Fields/Radio';
 import Toggle from '../ui/components/Fields/Toggle';
+import ExportModal from '../components/ExportModal';
 import withApiClient from '../components/withApiClient';
 import { selectors } from '../ducks/modules/protocols';
 import { Button, Spinner } from '../ui';
@@ -79,9 +80,17 @@ class ExportScreen extends Component {
 
     remote.dialog.showSaveDialog(exportDialog, (filepath) => {
       if (filepath) {
-        this.setState({ exportInProgress: true }, () => this.exportToFile(filepath));
+        this.setState(
+          { exportInProgress: true },
+          () => this.exportToFile(filepath),
+        );
       }
     });
+  }
+
+  handleCancel = () => {
+    // TODO: cancel underlying requests
+    this.setState({ exportInProgress: false });
   }
 
   exportToFile = (destinationFilepath) => {
@@ -127,6 +136,13 @@ class ExportScreen extends Component {
 
     return (
       <form className="export" onSubmit={this.handleExport}>
+        {
+          <ExportModal
+            className="modal--export"
+            show={exportInProgress}
+            handleCancel={this.handleCancel}
+          />
+        }
         <h1>{protocol.name}</h1>
         <div className="export__section">
           <h3>File Type</h3>

--- a/src/renderer/styles/_field_focus_fixes.scss
+++ b/src/renderer/styles/_field_focus_fixes.scss
@@ -1,0 +1,73 @@
+//
+// Fix focus styling on fields & make keyboard-controllable
+//
+
+// NC-UI doesn't style focus colors; fix for keyboard accessibility
+$focused-accent-border: var(--color-cerulean-blue);
+$focused-accent-background: var(--color-sea-green--dark);
+@mixin input-focus-style {
+  &::before {
+    border-color: $focused-accent-border;
+  }
+
+  &::after {
+    background-color: $focused-accent-background;
+  }
+}
+
+@mixin fix-input-border-color {
+  border-color: var(--input-accent); // NC-UI hardcodes to white; override
+}
+
+// sass-lint:disable force-pseudo-nesting force-element-nesting
+.form-field-radio:hover {
+  .form-field-radio__radio::before {
+    @include fix-input-border-color;
+  }
+}
+
+.form-field-checkbox__input,
+.form-field-checkbox__input:checked {
+  ~ .form-field-checkbox__checkbox::before {
+    @include fix-input-border-color;
+  }
+
+  &:focus ~ .form-field-checkbox__checkbox {
+    @include input-focus-style;
+  }
+}
+
+.form-field-toggle__input {
+  $border-width: 2px;
+
+  // replace 'display: none' (which prevents focus)
+  display: block;
+  position: absolute;
+  opacity: 0;
+
+  // Toggle borders work a little differently than other inputs
+  ~ .form-field-toggle__toggle .form-field-toggle__button {
+    // always use a border so knob positioning is consistent
+    border: $border-width solid transparent;
+
+    &::before {
+      width: -$border-width;
+      top: -$border-width;
+    }
+  }
+
+  &:focus ~ .form-field-toggle__toggle .form-field-toggle__button {
+    border-color: $focused-accent-border;
+  }
+}
+
+.form-field-radio__input {
+  ~ .form-field-radio__radio::before {
+    @include fix-input-border-color;
+  }
+
+  &:focus ~ .form-field-radio__radio {
+    @include input-focus-style
+  }
+}
+// sass-lint:enable force-pseudo-nesting

--- a/src/renderer/styles/_reset.scss
+++ b/src/renderer/styles/_reset.scss
@@ -23,49 +23,10 @@ body {
   background-color: var(--color-platinum--dark);
 }
 
-@mixin input-focus-style {
-  // NC-UI doesn't style focus colors; fix for keyboard accessibility
-  $focused-accent-border: var(--color-cerulean-blue);
-  $focused-accent-background: var(--color-sea-green--dark);
-
-  &::before {
-    border-color: $focused-accent-border;
-  }
-
-  &::after {
-    background-color: $focused-accent-background;
+.form-field {
+  &.form-field-toggle {
+    margin-bottom: 0; // other NC field types don't have a margin; reset for consistency
   }
 }
 
-@mixin fix-input-border-color {
-  border-color: var(--input-accent); // NC-UI hardcodes to white; override
-}
-
-// sass-lint:disable force-pseudo-nesting
-.form-field-radio:hover {
-  .form-field-radio__radio::before {
-    @include fix-input-border-color;
-  }
-}
-
-.form-field-checkbox__input,
-.form-field-checkbox__input:checked {
-  ~ .form-field-checkbox__checkbox::before {
-    @include fix-input-border-color;
-  }
-
-  &:focus ~ .form-field-checkbox__checkbox {
-    @include input-focus-style;
-  }
-}
-
-.form-field-radio__input {
-  ~ .form-field-radio__radio::before {
-    @include fix-input-border-color;
-  }
-
-  &:focus ~ .form-field-radio__radio {
-    @include input-focus-style
-  }
-}
-// sass-lint:enable force-pseudo-nesting
+@import 'field_focus_fixes';

--- a/src/renderer/styles/components/_all.scss
+++ b/src/renderer/styles/components/_all.scss
@@ -4,6 +4,7 @@
 @import './device';
 @import './device-list';
 @import './dismiss-button';
+@import './export-modal';
 @import './get-started';
 @import './header';
 @import './instructions';

--- a/src/renderer/styles/components/_export-modal.scss
+++ b/src/renderer/styles/components/_export-modal.scss
@@ -1,0 +1,8 @@
+.modal {
+  @include modifier(export) {
+
+    .modal__window {
+      min-width: 80vw;
+    }
+  }
+}


### PR DESCRIPTION
Resolves #22. Depends on #198, #201, #203.

The following export options are supported:

- [x] multiple file or single network export
- [x] directed / undirected edges
- [x] CSV & graphML types

Known issues:
- ~creates temp files that should be manually cleaned up~
- graphml export is string-based: #210  
- filtering is not wired up (displays old UI): #208, #209
- ~cancellation not yet implemented~
  - will be improved in #206
- progress not yet implemented: #207 
- ~graphML doesn't respect directed edge setting~
- ~error messages could be better~
- multi-step UI flow: #200
- ego-specific interface: #199