### PR TITLE
Implement filter & query backend

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 src/renderer/ui
 src/main/utils/shared-api/node_modules
+src/main/utils/network-query

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/main/utils/shared-api"]
 	path = src/main/utils/shared-api
 	url = https://github.com/codaco/secure-comms-api.git
+[submodule "src/main/utils/network-query"]
+	path = src/main/utils/network-query
+	url = https://github.com/codaco/networkQuery.git

--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -1,7 +1,7 @@
 {
   "source": {
     "includePattern": ".+\\.js$",
-    "excludePattern": "__tests__"
+    "excludePattern": "__tests__|utils\/network-query"
   },
   "plugins": ["plugins/markdown"]
 }

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "setupTestFrameworkScriptFile": "<rootDir>/config/jest/setupTestFramework.js",
     "testPathIgnorePatterns": [
       "<rootDir>[/\\\\](build|docs|node_modules|scripts|release-builds)[/\\\\]",
+      "<rootDir>/src/main/utils/network-query",
       "<rootDir>/src/renderer/ui"
     ],
     "testEnvironment": "node",

--- a/src/main/utils/formatters/__tests__/network-test.js
+++ b/src/main/utils/formatters/__tests__/network-test.js
@@ -1,7 +1,45 @@
 /* eslint-env jest */
-const { getNodeAttributes, nodeAttributesProperty, unionOfNetworks } = require('../network');
+const {
+  filterNetworkEntities,
+  filterNetworksWithQuery,
+  getNodeAttributes,
+  nodeAttributesProperty,
+  unionOfNetworks,
+} = require('../network');
 
 describe('network format helpers', () => {
+  describe('filtering & querying', () => {
+    const ruleConfig = {
+      rules: [
+        {
+          type: 'alter',
+          options: { type: 'person', operator: 'EXACTLY', attribute: 'age', value: 20 },
+          assert: { operator: 'GREATER_THAN', value: 0 }, // for query only
+        },
+      ],
+      join: 'OR',
+    };
+
+    describe('filterNetworksWithQuery()', () => {
+      it('includes nodes from attribute query', () => {
+        const a = { nodes: [{ type: 'person', [nodeAttributesProperty]: { age: 20 } }], edges: [] };
+        const b = { nodes: [{ type: 'person', [nodeAttributesProperty]: { age: 20 } }], edges: [] };
+        const c = { nodes: [{ type: 'person', [nodeAttributesProperty]: { age: 21 } }], edges: [] };
+        const networks = [a, b, c];
+        expect(filterNetworksWithQuery(networks, ruleConfig)).toEqual([a, b]);
+      });
+    });
+
+    describe('filterNetworkEntities()', () => {
+      it('includes nodes matching attributes', () => {
+        const alice = { type: 'person', [nodeAttributesProperty]: { age: 20 } };
+        const bob = { type: 'person', [nodeAttributesProperty]: { age: 21 } };
+        const networks = [{ nodes: [alice, bob], edges: [] }];
+        expect(filterNetworkEntities(networks, ruleConfig)[0].nodes).toEqual([alice]);
+      });
+    });
+  });
+
   describe('unionOfNetworks', () => {
     it('joins nodes of two networks', () => {
       const a = { nodes: [{ id: 1 }], edges: [] };

--- a/src/main/utils/formatters/network.js
+++ b/src/main/utils/formatters/network.js
@@ -1,3 +1,6 @@
+const getQuery = require('../network-query/query').default;
+const getFilter = require('../network-query/filter').default;
+
 // TODO: share with other places this is defined
 const nodePrimaryKeyProperty = '_uid';
 
@@ -12,7 +15,33 @@ const unionOfNetworks = networks =>
     return union;
   }, { nodes: [], edges: [] });
 
+/**
+ * Run the query on each network; filter for those which meet the criteria (i.e., where the query
+ * evaluates to `true`).
+ * @param  {Object[]} networks An array of NC networks
+ * @param  {Object} inclusionQueryConfig a query definition with asserting rules
+ * @return {Object[]} a subset of the networks
+ */
+const filterNetworksWithQuery = (networks, inclusionQueryConfig) =>
+  (inclusionQueryConfig ? networks.filter(getQuery(inclusionQueryConfig)) : networks);
+
+/**
+ * Filter each network based on the filter config.
+ * @param  {Object[]} networks An array of NC networks
+ * @param  {Object} filterConfig a filter definition with rules
+ * @return {Object[]} a copy of `networks`, each possibly containing a subset of the original
+ */
+const filterNetworkEntities = (networks, filterConfig) => {
+  if (!filterConfig) {
+    return networks;
+  }
+  const filter = getFilter(filterConfig);
+  return networks.map(network => filter(network));
+};
+
 module.exports = {
+  filterNetworkEntities,
+  filterNetworksWithQuery,
   getNodeAttributes,
   nodeAttributesProperty,
   nodePrimaryKeyProperty,

--- a/src/main/utils/formatters/network.js
+++ b/src/main/utils/formatters/network.js
@@ -32,7 +32,7 @@ const filterNetworksWithQuery = (networks, inclusionQueryConfig) =>
  * @return {Object[]} a copy of `networks`, each possibly containing a subset of the original
  */
 const filterNetworkEntities = (networks, filterConfig) => {
-  if (!filterConfig) {
+  if (!filterConfig || !filterConfig.rules || !filterConfig.rules.length) {
     return networks;
   }
   const filter = getFilter(filterConfig);

--- a/src/renderer/components/Filter/Rule/AddButton.js
+++ b/src/renderer/components/Filter/Rule/AddButton.js
@@ -23,6 +23,7 @@ class AddButton extends PureComponent {
       >
         <button
           className="rule-add-button__open"
+          type="button"
           disabled
         >
           +

--- a/src/renderer/components/Filter/Rule/AlterRule.js
+++ b/src/renderer/components/Filter/Rule/AlterRule.js
@@ -117,7 +117,7 @@ class AlterRule extends PureComponent {
             </div>
           )}
         </div>
-        <button className="rule__delete" onClick={() => onDeleteRule(id)} />
+        <button type="button" className="rule__delete" onClick={() => onDeleteRule(id)} />
       </div>
     );
   }

--- a/src/renderer/components/Filter/Rule/EdgeRule.js
+++ b/src/renderer/components/Filter/Rule/EdgeRule.js
@@ -117,7 +117,7 @@ class EdgeRule extends PureComponent {
             </div>
           )}
         </div>
-        <button className="rule__delete" onClick={() => onDeleteRule(id)} />
+        <button type="button" className="rule__delete" onClick={() => onDeleteRule(id)} />
       </div>
     );
   }

--- a/src/renderer/components/Filter/Rule/EgoRule.js
+++ b/src/renderer/components/Filter/Rule/EgoRule.js
@@ -104,7 +104,7 @@ class EgoRule extends PureComponent {
           </div>
         }
         { !hasPersonType && <div>No &quot;Person&quot; node type found!</div> }
-        <button className="rule__delete" onClick={() => onDeleteRule(id)} />
+        <button type="button" className="rule__delete" onClick={() => onDeleteRule(id)} />
       </div>
     );
   }

--- a/src/renderer/containers/ExportScreen.js
+++ b/src/renderer/containers/ExportScreen.js
@@ -35,13 +35,13 @@ class ExportScreen extends Component {
       exportFormat: 'graphml',
       exportNetworkUnion: false,
       csvTypes: new Set(Object.keys(availableCsvTypes)),
-      filter: defaultFilter,
+      entityFilter: defaultFilter,
       useDirectedEdges: true,
     };
   }
 
-  handleFilterChange = (filter) => {
-    this.setState({ filter });
+  handleFilterChange = (entityFilter) => {
+    this.setState({ entityFilter });
   }
 
   handleFormatChange = (evt) => {
@@ -114,7 +114,7 @@ class ExportScreen extends Component {
       exportFormat,
       exportNetworkUnion,
       csvTypes,
-      filter,
+      entityFilter,
       useDirectedEdges,
     } = this.state;
 
@@ -123,7 +123,7 @@ class ExportScreen extends Component {
         exportFormats: (exportFormat === 'csv' && [...csvTypes]) || [exportFormat],
         exportNetworkUnion,
         destinationFilepath,
-        filter,
+        entityFilter,
         useDirectedEdges,
       })
       .then(() => showConfirmation('Export complete'))
@@ -248,9 +248,9 @@ class ExportScreen extends Component {
         </div>
         <div className="export__section">
           <h3>Filtering</h3>
-          <p>Optionally filter the network(s) before export.</p>
+          <p>Include nodes and edges that meet the following criteria:</p>
           <Filter
-            filter={this.state.filter}
+            filter={this.state.entityFilter}
             onChange={this.handleFilterChange}
             variableRegistry={variableRegistry}
           />

--- a/src/renderer/containers/ExportScreen.js
+++ b/src/renderer/containers/ExportScreen.js
@@ -132,7 +132,7 @@ class ExportScreen extends Component {
   }
 
   render() {
-    const { protocol, protocolsHaveLoaded } = this.props;
+    const { protocol, protocolsHaveLoaded, variableRegistry } = this.props;
 
     if (protocolsHaveLoaded && !protocol) { // This protocol doesn't exist
       return <Redirect to="/" />;
@@ -252,7 +252,7 @@ class ExportScreen extends Component {
           <Filter
             filter={this.state.filter}
             onChange={this.handleFilterChange}
-            variableRegistry={protocol.variableRegistry}
+            variableRegistry={variableRegistry}
           />
         </div>
         <Button type="submit" disabled={exportInProgress}>Export</Button>
@@ -267,16 +267,19 @@ ExportScreen.propTypes = {
   protocolsHaveLoaded: PropTypes.bool.isRequired,
   showConfirmation: PropTypes.func.isRequired,
   showError: PropTypes.func.isRequired,
+  variableRegistry: PropTypes.object,
 };
 
 ExportScreen.defaultProps = {
   apiClient: null,
   protocol: null,
+  variableRegistry: null,
 };
 
 const mapStateToProps = (state, ownProps) => ({
   protocolsHaveLoaded: selectors.protocolsHaveLoaded(state),
   protocol: selectors.currentProtocol(state, ownProps),
+  variableRegistry: selectors.transposedRegistry(state, ownProps),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/renderer/containers/__tests__/ExportScreen-test.js
+++ b/src/renderer/containers/__tests__/ExportScreen-test.js
@@ -107,7 +107,7 @@ describe('<ExportScreen />', () => {
       const filterInstance = subject.find('Connect(FilterGroup)');
       const mockFilter = { join: null, rules: [{ mock: true }] };
       filterInstance.simulate('change', mockFilter);
-      expect(subject.state('filter')).toEqual(mockFilter);
+      expect(subject.state('entityFilter')).toEqual(mockFilter);
     });
   });
 });

--- a/src/renderer/ducks/modules/__tests__/protocols-test.js
+++ b/src/renderer/ducks/modules/__tests__/protocols-test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import reducer, { actionCreators, actionTypes } from '../protocols';
+import reducer, { actionCreators, actionTypes, selectors } from '../protocols';
 import AdminApiClient from '../../../utils/adminApiClient';
 
 jest.mock('../../../utils/adminApiClient');
@@ -92,6 +92,36 @@ describe('the protocols module', () => {
         mockApiClient.delete.mockRejectedValue(err);
         await actionCreators.deleteProtocol('1')(dispatcher);
         expect(dispatcher).toHaveBeenCalledWith(expect.objectContaining({ text: err.message }));
+      });
+    });
+  });
+
+  describe('selectors', () => {
+    const { currentProtocol, protocolsHaveLoaded, transposedRegistry } = selectors;
+
+    describe('currentProtocol', () => {
+      it('returns the current protocol object', () => {
+        const state = { protocols: [{ id: '1' }] };
+        const props = { match: { params: { id: '1' } } };
+        expect(currentProtocol(state, props)).toEqual(state.protocols[0]);
+      });
+    });
+
+    describe('protocolsHaveLoaded', () => {
+      it('indicates protocols have loaded', () => {
+        expect(protocolsHaveLoaded({ protocols: null })).toBe(false);
+        expect(protocolsHaveLoaded({ protocols: [{ id: '1' }] })).toBe(true);
+      });
+    });
+
+    describe('transposedRegistry', () => {
+      it('returns a modified registry', () => {
+        const variableRegistry = { node: { 'node-type-id': { name: 'person', variables: {} } } };
+        const state = { protocols: [{ id: '1', variableRegistry }] };
+        const props = { match: { params: { id: '1' } } };
+        const transposed = transposedRegistry(state, props);
+        expect(transposed).toHaveProperty('node');
+        expect(transposed.node).toHaveProperty('person');
       });
     });
   });

--- a/src/renderer/ducks/modules/__tests__/protocols-test.js
+++ b/src/renderer/ducks/modules/__tests__/protocols-test.js
@@ -123,6 +123,14 @@ describe('the protocols module', () => {
         expect(transposed).toHaveProperty('node');
         expect(transposed.node).toHaveProperty('person');
       });
+
+      it('does not require edge variables', () => {
+        const variableRegistry = { node: { 'node-type-id': { name: 'person', variables: {} } }, edge: { 'edge-type-id': {} } };
+        const state = { protocols: [{ id: '1', variableRegistry }] };
+        const props = { match: { params: { id: '1' } } };
+        const transposed = transposedRegistry(state, props);
+        expect(transposed.edge).toEqual({});
+      });
     });
   });
 });

--- a/src/renderer/ducks/modules/protocols.js
+++ b/src/renderer/ducks/modules/protocols.js
@@ -38,6 +38,38 @@ const currentProtocol = (state, props) => {
   return protocols && id && protocols.find(p => p.id === id);
 };
 
+// Transpose one section of the registry ('node' or 'edge') from IDs to names
+const transposedRegistrySection = (section = {}) =>
+  Object.values(section).reduce((sectionRegistry, definition) => {
+    const displayVariable = definition.variables[definition.displayVariable];
+
+    const variables = Object.values(definition.variables).reduce((acc, variable) => {
+      acc[variable.name] = variable;
+      return acc;
+    }, {});
+    sectionRegistry[definition.name] = { // eslint-disable-line no-param-reassign
+      ...definition,
+      displayVariable: displayVariable && displayVariable.name,
+      variables,
+    };
+    return sectionRegistry;
+  }, {});
+
+// Transpose all types & variable IDs to names
+// Imported data is transposed; this allows utility components from Architect to work as-is.
+const transposedRegistry = (state, props) => {
+  const protocol = currentProtocol(state, props);
+  if (!protocol) {
+    return null;
+  }
+
+  const registry = protocol.variableRegistry || {};
+  return {
+    edge: transposedRegistrySection(registry.edge),
+    node: transposedRegistrySection(registry.node),
+  };
+};
+
 const protocolsHaveLoaded = state => state.protocols !== initialState;
 
 const loadProtocolsDispatch = () => ({
@@ -89,6 +121,7 @@ const actionTypes = {
 const selectors = {
   currentProtocol,
   protocolsHaveLoaded,
+  transposedRegistry,
 };
 
 export {

--- a/src/renderer/ducks/modules/protocols.js
+++ b/src/renderer/ducks/modules/protocols.js
@@ -41,6 +41,10 @@ const currentProtocol = (state, props) => {
 // Transpose one section of the registry ('node' or 'edge') from IDs to names
 const transposedRegistrySection = (section = {}) =>
   Object.values(section).reduce((sectionRegistry, definition) => {
+    if (!definition.variables) { // not required for edges
+      return sectionRegistry;
+    }
+
     const displayVariable = definition.variables[definition.displayVariable];
 
     const variables = Object.values(definition.variables).reduce((acc, variable) => {


### PR DESCRIPTION
Depends on #205. Resolves #208 and #209.

This adds the main process scaffolding to support queries and filters. During the export flow, it runs a supplied user query to include only a subset of networks in export. It subsequently (after optionally merging all networks) filters all network nodes & edges before exporting.

It also wires up the temporary filter UI for network filtering; the UI may change as part of #200, but the interface should stay the same. (There is no querying UI yet.)

To test the filtering, you'll need to export fresh data from NC and ensure that your NC build includes https://github.com/codaco/Network-Canvas/pull/811.