### PR TITLE
Replace attribute list with edge list

### DIFF
--- a/scripts/export-tests.js
+++ b/scripts/export-tests.js
@@ -5,9 +5,9 @@ const fs = require('fs');
 const { buildMockData, variableRegistry } = require('./db-size');
 const {
   AdjacencyMatrixFormatter,
-  AdjacencyListFormatter,
   AttributeListFormatter,
   GraphMLFormatter,
+  EdgeListFormatter,
 } = require('../src/main/utils/formatters');
 
 const mockdata = buildMockData({ sessionCount: 1 });
@@ -38,10 +38,10 @@ const write = async (formatter, outFile) => new Promise((resolve, reject) => {
   await write(formatter, 'test-export-attrs.csv');
   console.timeEnd('attr-list-csv');
 
-  console.time('adjacency-list');
-  formatter = new AdjacencyListFormatter(merged);
-  await write(formatter, 'test-export-adjacency.csv');
-  console.timeEnd('adjacency-list');
+  console.time('edge-list');
+  formatter = new EdgeListFormatter(merged);
+  await write(formatter, 'test-export-edge.csv');
+  console.timeEnd('edge-list');
 
   console.time('matrix');
   formatter = new AdjacencyMatrixFormatter(merged);

--- a/src/main/data-managers/ExportManager.js
+++ b/src/main/data-managers/ExportManager.js
@@ -92,7 +92,7 @@ class ExportManager {
    * @param {string} options.destinationFilepath local FS path to output the final file
    * @param {string} options.exportFormat "csv" or "graphml"
    * @param {Array} options.csvTypes if `exportFormat` is "csv", then include these types in output.
-   *                                 Options: ["adjacencyMatrix", "adjacencyList", "attributeList"]
+   *                                 Options: ["adjacencyMatrix", "attributeList", "edgeList"]
    * @param {boolean} options.exportNetworkUnion true if all interview networks should be merged
    *                                             false if each interview network should be exported
    *                                             individually

--- a/src/main/utils/formatters/__tests__/edge-list-test.js
+++ b/src/main/utils/formatters/__tests__/edge-list-test.js
@@ -1,27 +1,27 @@
 /* eslint-env jest */
 import { makeWriteableStream } from '../../../../../config/jest/setupTestEnv';
-import { asAdjacencyList, toCSVStream } from '../adjacency-list';
+import { asEdgeList, toCSVStream } from '../edge-list';
 
-const adjacencyListFromEdges = (edges, directed) => asAdjacencyList({ edges }, directed);
+const listFromEdges = (edges, directed) => asEdgeList({ edges }, directed);
 
-describe('asAdjacencyList', () => {
+describe('asEdgeList', () => {
   it('takes a network as input', () => {
     const network = { nodes: [], edges: [{ from: 'nodeA', to: 'nodeB' }] };
-    expect(asAdjacencyList(network)).toHaveProperty('nodeA');
+    expect(asEdgeList(network)).toHaveProperty('nodeA');
   });
 
   it('represents an edgeless network', () => {
-    expect(adjacencyListFromEdges([])).toEqual({});
+    expect(listFromEdges([])).toEqual({});
   });
 
   it('represents a single undirected edge', () => {
     expect(
-      adjacencyListFromEdges([{ from: 1, to: 2 }])).toEqual({ 1: new Set([2]), 2: new Set([1]) },
+      listFromEdges([{ from: 1, to: 2 }])).toEqual({ 1: new Set([2]), 2: new Set([1]) },
     );
   });
 
   it('represents a single directed edge', () => {
-    expect(adjacencyListFromEdges([{ from: 1, to: 2 }], true)).toEqual({ 1: new Set([2]) });
+    expect(listFromEdges([{ from: 1, to: 2 }], true)).toEqual({ 1: new Set([2]) });
   });
 });
 
@@ -33,35 +33,35 @@ describe('toCSVStream', () => {
   });
 
   it('Writes a simple csv', async () => {
-    const list = adjacencyListFromEdges([{ from: 1, to: 2 }]);
+    const list = listFromEdges([{ from: 1, to: 2 }]);
     toCSVStream(list, writable);
     const csv = await writable.asString();
     expect(csv).toEqual('1,2\r\n2,1\r\n');
   });
 
   it('Writes multiple edges', async () => {
-    const list = adjacencyListFromEdges([{ from: 1, to: 2 }, { from: 1, to: 3 }]);
+    const list = listFromEdges([{ from: 1, to: 2 }, { from: 1, to: 3 }]);
     toCSVStream(list, writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('1,2,3\r\n2,1\r\n3,1\r\n');
+    expect(csv).toEqual('1,2\r\n1,3\r\n2,1\r\n3,1\r\n');
   });
 
   it('Writes a csv for directed edges', async () => {
-    const list = adjacencyListFromEdges([{ from: 1, to: 2 }, { from: 1, to: 3 }], true);
+    const list = listFromEdges([{ from: 1, to: 2 }, { from: 1, to: 3 }], true);
     toCSVStream(list, writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('1,2,3\r\n');
+    expect(csv).toEqual('1,2\r\n1,3\r\n');
   });
 
   it('Writes a csv for directed edges (inverse)', async () => {
-    const list = adjacencyListFromEdges([{ from: 1, to: 2 }, { from: 3, to: 1 }], true);
+    const list = listFromEdges([{ from: 1, to: 2 }, { from: 3, to: 1 }], true);
     toCSVStream(list, writable);
     const csv = await writable.asString();
     expect(csv).toEqual('1,2\r\n3,1\r\n');
   });
 
   it('Ignores duplicate edges', async () => {
-    const list = adjacencyListFromEdges([{ from: 1, to: 2 }, { from: 1, to: 2 }]);
+    const list = listFromEdges([{ from: 1, to: 2 }, { from: 1, to: 2 }]);
     toCSVStream(list, writable);
     const csv = await writable.asString();
     expect(csv).toEqual('1,2\r\n2,1\r\n');

--- a/src/main/utils/formatters/__tests__/utils-test.js
+++ b/src/main/utils/formatters/__tests__/utils-test.js
@@ -7,7 +7,7 @@ describe('formatter utilities', () => {
   describe('getFileExtension', () => {
     it('maps CSV types', () => {
       expect(getFileExtension(formats.adjacencyMatrix)).toEqual('.csv');
-      expect(getFileExtension(formats.adjacencyList)).toEqual('.csv');
+      expect(getFileExtension(formats.edgeList)).toEqual('.csv');
       expect(getFileExtension(formats.attributeList)).toEqual('.csv');
     });
   });

--- a/src/main/utils/formatters/index.js
+++ b/src/main/utils/formatters/index.js
@@ -1,11 +1,11 @@
 const GraphMLFormatter = require('./graphml/GraphMLFormatter');
 const { AdjacencyMatrixFormatter } = require('./matrix');
-const { AdjacencyListFormatter } = require('./adjacency-list');
 const { AttributeListFormatter } = require('./attribute-list');
+const { EdgeListFormatter } = require('./edge-list');
 
 module.exports = {
   AdjacencyMatrixFormatter,
-  AdjacencyListFormatter,
   AttributeListFormatter,
+  EdgeListFormatter,
   GraphMLFormatter,
 };

--- a/src/main/utils/formatters/utils.js
+++ b/src/main/utils/formatters/utils.js
@@ -4,8 +4,8 @@
 
 const {
   AdjacencyMatrixFormatter,
-  AdjacencyListFormatter,
   AttributeListFormatter,
+  EdgeListFormatter,
   GraphMLFormatter,
 } = require('./index');
 
@@ -17,8 +17,8 @@ const formats = {
   graphml: 'graphml',
   // CSV:
   adjacencyMatrix: 'adjacencyMatrix',
-  adjacencyList: 'adjacencyList',
   attributeList: 'attributeList',
+  edgeList: 'edgeList',
 };
 
 const extensions = {
@@ -45,7 +45,7 @@ const getFileExtension = (formatterType) => {
     case formats.graphml:
       return extensions.graphml;
     case formats.adjacencyMatrix:
-    case formats.adjacencyList:
+    case formats.edgeList:
     case formats.attributeList:
       return extensions.csv;
     default:
@@ -64,8 +64,8 @@ const getFormatterClass = (formatterType) => {
       return GraphMLFormatter;
     case formats.adjacencyMatrix:
       return AdjacencyMatrixFormatter;
-    case formats.adjacencyList:
-      return AdjacencyListFormatter;
+    case formats.edgeList:
+      return EdgeListFormatter;
     case formats.attributeList:
       return AttributeListFormatter;
     default:

--- a/src/renderer/containers/ExportScreen.js
+++ b/src/renderer/containers/ExportScreen.js
@@ -24,8 +24,8 @@ const defaultFilter = {
 
 const availableCsvTypes = {
   adjacencyMatrix: 'Adjacency Matrix',
-  adjacencyList: 'Adjacency List',
   attributeList: 'Attribute List',
+  edgeList: 'Edge List',
 };
 
 class ExportScreen extends Component {


### PR DESCRIPTION
The edge list outputs CSV in the format:

```
a,b
a,c
b,c
```

rather than the previously-available adjacency list:
```
a,b,c
b,c
```
