### PR TITLE
Partition edge output based on edge type

### DIFF
--- a/src/main/utils/formatters/__tests__/utils-test.js
+++ b/src/main/utils/formatters/__tests__/utils-test.js
@@ -1,7 +1,14 @@
 /* eslint-env jest */
 
-const { formats, formatsAreValid, getFileExtension, getFormatterClass } = require('../utils');
 const { GraphMLFormatter } = require('../index');
+const { nodePrimaryKeyProperty } = require('../network');
+const {
+  formats,
+  formatsAreValid,
+  getFileExtension,
+  getFormatterClass,
+  partitionByEdgeType,
+} = require('../utils');
 
 describe('formatter utilities', () => {
   describe('getFileExtension', () => {
@@ -35,6 +42,57 @@ describe('formatter utilities', () => {
 
     it('checks for invalid formats', () => {
       expect(formatsAreValid(['graphml', 'not-a-format'])).toBe(false);
+    });
+  });
+
+  describe('partitionByEdgeType', () => {
+    const alice = { [nodePrimaryKeyProperty]: 'a' };
+    const bob = { [nodePrimaryKeyProperty]: 'b' };
+    const carla = { [nodePrimaryKeyProperty]: 'c' };
+    let nodes;
+    let network;
+    beforeEach(() => {
+      nodes = [alice, bob, carla];
+      network = {
+        nodes,
+        edges: [{ from: 'a', to: 'b', type: 'knows' }, { from: 'a', to: 'b', type: 'likes' }],
+      };
+    });
+
+    it('partitions edges for matrix output', () => {
+      const partitioned = partitionByEdgeType(network, formats.adjacencyMatrix);
+      expect(partitioned[0].edges).toEqual([network.edges[0]]);
+      expect(partitioned[1].edges).toEqual([network.edges[1]]);
+    });
+
+    it('partitions edges for edge list output', () => {
+      const partitioned = partitionByEdgeType(network, formats.edgeList);
+      expect(partitioned[0].edges).toEqual([network.edges[0]]);
+      expect(partitioned[1].edges).toEqual([network.edges[1]]);
+    });
+
+    it('does not partition for other types', () => {
+      expect(partitionByEdgeType(network, formats.graphml)).toHaveLength(1);
+      expect(partitionByEdgeType(network, formats.attributeList)).toHaveLength(1);
+    });
+
+    it('decorates with an edgeType prop', () => {
+      const partitioned = partitionByEdgeType(network, formats.adjacencyMatrix);
+      expect(partitioned[0].edgeType).toEqual('knows');
+      expect(partitioned[1].edgeType).toEqual('likes');
+    });
+
+    it('maintains a reference to nodes (without copying or modifying)', () => {
+      // This is important to keep memory use low on large networks
+      const partitioned = partitionByEdgeType(network, formats.adjacencyMatrix);
+      expect(partitioned[0].nodes).toBe(nodes);
+      expect(partitioned[1].nodes).toBe(nodes);
+    });
+
+    it('returns at least 1 network, even when no edges', () => {
+      const partitioned = partitionByEdgeType({ nodes, edges: [] }, formats.adjacencyMatrix);
+      expect(partitioned).toHaveLength(1);
+      expect(partitioned[0].nodes).toBe(nodes);
     });
   });
 });


### PR DESCRIPTION
This updates the edge-oriented exports to produce one file for each edge type in the network(s). The edge type is added to the filename; the CSVs contain only edge information for that type.

For example, a network with "knows" and "likes" edge types might export the following files:

```
1.adjacencyMatrix.knows.csv
1.adjacencyMatrix.likes.csv
1.attributeList.csv
1.edgeList.knows.csv
1.edgeList.likes.csv
```

The adjacency matrix still includes information for every node, so #218 covers future handling of large matrices.