### PR TITLE
Fix coordinate export in graphml

### DIFF
--- a/src/main/data-managers/ExportManager.js
+++ b/src/main/data-managers/ExportManager.js
@@ -12,6 +12,7 @@ const { makeTempDir, removeTempDir } = require('../utils/formatters/dir');
 const {
   filterNetworkEntities,
   filterNetworksWithQuery,
+  transposedRegistry,
   unionOfNetworks,
 } = require('../utils/formatters/network');
 const {
@@ -150,7 +151,7 @@ class ExportManager {
     let promisedExports;
     const exportOpts = {
       useDirectedEdges,
-      variableRegistry: protocol.variableRegistry,
+      variableRegistry: transposedRegistry(protocol.variableRegistry),
     };
 
     // Export flow:

--- a/src/main/utils/formatters/graphml/__tests__/createGraphML-test.js
+++ b/src/main/utils/formatters/graphml/__tests__/createGraphML-test.js
@@ -19,8 +19,8 @@ describe('buildGraphML', () => {
   beforeEach(() => {
     network = {
       nodes: [
-        { _uid: '1', type: 'person', attributes: { 'mock-uuid-1': 'Dee', 'mock-uuid-2': 40 } },
-        { _uid: '2', type: 'person', attributes: { 'mock-uuid-1': 'Carl', 'mock-uuid-2': 50 } },
+        { _uid: '1', type: 'person', attributes: { 'mock-uuid-1': 'Dee', 'mock-uuid-2': 40, 'mock-uuid-3': { x: 0, y: 0 } } },
+        { _uid: '2', type: 'person', attributes: { 'mock-uuid-1': 'Carl', 'mock-uuid-2': 50, 'mock-uuid-3': { x: 0, y: 0 } } },
       ],
       edges: [
         { from: '1', to: '2', type: 'mock-uuid-3' },
@@ -32,6 +32,7 @@ describe('buildGraphML', () => {
           variables: {
             'mock-uuid-1': { name: 'firstName', type: 'string' },
             'mock-uuid-2': { name: 'age', type: 'number' },
+            'mock-uuid-3': { name: 'layout', type: 'layout' },
           },
         },
       },
@@ -62,6 +63,11 @@ describe('buildGraphML', () => {
 
   it('infers int types', () => { // This indicates that transposition worked for nodes
     expect(xml.getElementById('age').getAttribute('attr.type')).toEqual('int');
+  });
+
+  it('converts layout types', () => {
+    expect(xml.getElementById('layoutX').getAttribute('attr.type')).toEqual('double');
+    expect(xml.getElementById('layoutY').getAttribute('attr.type')).toEqual('double');
   });
 
   it('exports edge labels', () => { // This indicates that [non-]transposition worked for edges

--- a/src/main/utils/formatters/graphml/createGraphML.js
+++ b/src/main/utils/formatters/graphml/createGraphML.js
@@ -108,7 +108,6 @@ const generateKeyElements = (
 
     Object.keys(iterableElement).forEach((key) => {
       // transpose ids to names based on registry; fall back to the raw key
-      // (Server does not need transposing.)
       const keyName = getTypeFromVariableRegistry(variableRegistry, type, element, key, 'name') || key;
       if (done.indexOf(keyName) === -1 && !excludeList.includes(keyName)) {
         const keyElement = document.createElement('key');
@@ -190,15 +189,9 @@ const generateDataElements = (
     fragment.appendChild(domElement);
 
     if (type === 'edge') {
-      let label = variableRegistry && variableRegistry[type] &&
+      const label = variableRegistry && variableRegistry[type] &&
         variableRegistry[type][dataElement.type] && (variableRegistry[type][dataElement.type].name
           || variableRegistry[type][dataElement.type].label);
-
-      // If we couldn't find a transposition, use the key directly.
-      // This will be the case on Server (and `type` will already contain the name).
-      if (!label) {
-        label = dataElement.type;
-      }
 
       domElement.appendChild(createDataElement(document, 'label', label));
 

--- a/src/main/utils/formatters/graphml/helpers.js
+++ b/src/main/utils/formatters/graphml/helpers.js
@@ -37,23 +37,11 @@ const getGraphMLTypeForKey = (data, key) => (
     return 'string';
   }, ''));
 
-const getVariableDefinition = (variables, key) => {
-  if (!variables) {
-    return null;
-  }
-  if (variables[key]) {
-    // NC: When dealing with variableIDs (not transposed), we have the match
-    return variables[key];
-  }
-  // Server: need to look up based on name (transpose name back to ID)
-  const entries = Object.entries(variables).find(([, variable]) => variable.name === key);
-  return entries && entries[1];
-};
-
 const getVariableInfo = (variableRegistry, type, element, key) => (
   variableRegistry[type] &&
   variableRegistry[type][element.type] &&
-  getVariableDefinition(variableRegistry[type][element.type].variables, key)
+  variableRegistry[type][element.type].variables &&
+  variableRegistry[type][element.type].variables[key]
 );
 
 const variableRegistryExists = (variableRegistry, type, element, key) => {

--- a/src/main/utils/formatters/network.js
+++ b/src/main/utils/formatters/network.js
@@ -39,11 +39,39 @@ const filterNetworkEntities = (networks, filterConfig) => {
   return networks.map(network => filter(network));
 };
 
+const transposedRegistrySection = (section = {}) =>
+  Object.values(section).reduce((sectionRegistry, definition) => {
+    if (!definition.variables) { // not required for edges
+      sectionRegistry[definition.name] = definition; // eslint-disable-line no-param-reassign
+      return sectionRegistry;
+    }
+
+    const displayVariable = definition.variables[definition.displayVariable];
+
+    const variables = Object.values(definition.variables).reduce((acc, variable) => {
+      acc[variable.name] = variable;
+      return acc;
+    }, {});
+    sectionRegistry[definition.name] = { // eslint-disable-line no-param-reassign
+      ...definition,
+      displayVariable: displayVariable && displayVariable.name,
+      variables,
+    };
+    return sectionRegistry;
+  }, {});
+
+const transposedRegistry = (registry = {}) => ({
+  edge: transposedRegistrySection(registry.edge),
+  node: transposedRegistrySection(registry.node),
+});
+
 module.exports = {
   filterNetworkEntities,
   filterNetworksWithQuery,
   getNodeAttributes,
   nodeAttributesProperty,
   nodePrimaryKeyProperty,
+  transposedRegistry,
+  transposedRegistrySection,
   unionOfNetworks,
 };

--- a/src/renderer/ducks/modules/__tests__/protocols-test.js
+++ b/src/renderer/ducks/modules/__tests__/protocols-test.js
@@ -125,11 +125,14 @@ describe('the protocols module', () => {
       });
 
       it('does not require edge variables', () => {
-        const variableRegistry = { node: { 'node-type-id': { name: 'person', variables: {} } }, edge: { 'edge-type-id': {} } };
+        const variableRegistry = {
+          node: { 'node-type-id': { name: 'person', variables: {} } },
+          edge: { 'edge-type-id': { name: 'edge-name' } },
+        };
         const state = { protocols: [{ id: '1', variableRegistry }] };
         const props = { match: { params: { id: '1' } } };
         const transposed = transposedRegistry(state, props);
-        expect(transposed.edge).toEqual({});
+        expect(transposed.edge).toEqual({ 'edge-name': { name: 'edge-name' } });
       });
     });
   });

--- a/src/renderer/ducks/modules/protocols.js
+++ b/src/renderer/ducks/modules/protocols.js
@@ -1,6 +1,7 @@
 import AdminApiClient from '../../utils/adminApiClient';
 import viewModelMapper from '../../utils/baseViewModelMapper';
 import { actionCreators as messageActionCreators } from './appMessages';
+import { transposedRegistrySection } from '../../../main/utils/formatters/network'; // TODO: move
 
 const LOAD_PROTOCOLS = 'LOAD_PROTOCOLS';
 const PROTOCOLS_LOADED = 'PROTOCOLS_LOADED';
@@ -37,27 +38,6 @@ const currentProtocol = (state, props) => {
   const id = props.match && props.match.params.id;
   return protocols && id && protocols.find(p => p.id === id);
 };
-
-// Transpose one section of the registry ('node' or 'edge') from IDs to names
-const transposedRegistrySection = (section = {}) =>
-  Object.values(section).reduce((sectionRegistry, definition) => {
-    if (!definition.variables) { // not required for edges
-      return sectionRegistry;
-    }
-
-    const displayVariable = definition.variables[definition.displayVariable];
-
-    const variables = Object.values(definition.variables).reduce((acc, variable) => {
-      acc[variable.name] = variable;
-      return acc;
-    }, {});
-    sectionRegistry[definition.name] = { // eslint-disable-line no-param-reassign
-      ...definition,
-      displayVariable: displayVariable && displayVariable.name,
-      variables,
-    };
-    return sectionRegistry;
-  }, {});
 
 // Transpose all types & variable IDs to names
 // Imported data is transposed; this allows utility components from Architect to work as-is.


### PR DESCRIPTION
This change removes the previous lookup fallbacks in the graphml export in favor of providing a transposed (ID->name) registry up front to the exporter. This fixes the lookup types of some variables, including the special handling of layout variables for gephi.

The transposing code itself was written for the filtering UI, and is now shared between main & render processes. I'd like to find a better approach for shared code between the two, perhaps as part of https://github.com/codaco/Network-Canvas/issues/796.