### PR TITLE
Display progress during export

### DIFF
--- a/src/main/server/__tests__/AdminService-test.js
+++ b/src/main/server/__tests__/AdminService-test.js
@@ -64,7 +64,7 @@ describe('the AdminService', () => {
         expect(testPortNumber).toBeLessThan(65535 - 1);
         const svc = await adminService.start(testPortNumber);
         expect(svc).toBe(adminService);
-        expect(svc.port).toEqual(testPortNumber + 1);
+        expect(svc.port).toBeGreaterThan(testPortNumber);
       });
     });
 

--- a/src/main/server/__tests__/Server-test.js
+++ b/src/main/server/__tests__/Server-test.js
@@ -18,6 +18,7 @@ jest.mock('electron-log');
 jest.mock('mdns');
 jest.mock('../../data-managers/DeviceManager');
 jest.mock('../../data-managers/ProtocolManager');
+jest.mock('../AdminService');
 
 describe('Server', () => {
   let mdnsProvider;

--- a/src/main/utils/formatters/AsyncReadable.js
+++ b/src/main/utils/formatters/AsyncReadable.js
@@ -17,7 +17,7 @@ class AsyncReadable extends Readable {
   }
 
   _read() {
-    setTimeout(this.readSync, 0);
+    setImmediate(this.readSync);
   }
 }
 

--- a/src/main/utils/formatters/AsyncReadable.js
+++ b/src/main/utils/formatters/AsyncReadable.js
@@ -1,0 +1,24 @@
+const { Readable } = require('stream');
+
+/**
+ * By wrapping read in a timeout, we allow exporters to interleave; otherwise,
+ * they'll proceed in sequence. This makes progress tracking easier;
+ * we could instead have exporters estimate their length ahead of time.
+ *
+ * Instantiate with the 'Simplified Constructor' approach in Readable:
+ * ```
+ * new AsyncReadable({ read() {} })
+ * ```
+ */
+class AsyncReadable extends Readable {
+  constructor(options) {
+    super({ ...options, read: undefined });
+    this.readSync = options.read.bind(this);
+  }
+
+  _read() {
+    setTimeout(this.readSync, 0);
+  }
+}
+
+module.exports = AsyncReadable;

--- a/src/main/utils/formatters/attribute-list.js
+++ b/src/main/utils/formatters/attribute-list.js
@@ -78,7 +78,7 @@ class AttributeListFormatter {
     this.list = asAttributeList(data, directed);
   }
   writeToStream(outStream) {
-    toCSVStream(this.list, outStream);
+    return toCSVStream(this.list, outStream);
   }
 }
 

--- a/src/main/utils/formatters/edge-list.js
+++ b/src/main/utils/formatters/edge-list.js
@@ -91,7 +91,7 @@ class EdgeListFormatter {
     this.list = asEdgeList(data, directed);
   }
   writeToStream(outStream) {
-    toCSVStream(this.list, outStream);
+    return toCSVStream(this.list, outStream);
   }
 }
 

--- a/src/main/utils/formatters/edge-list.js
+++ b/src/main/utils/formatters/edge-list.js
@@ -58,18 +58,16 @@ const toCSVStream = (edgeList, outStream) => {
 
   const inStream = new AsyncReadable({
     read() {
-      setTimeout(() => {
-        if (chunkIndex < totalChunks) {
-          const [fromId, destinations] = adjacencies[chunkIndex];
-          chunkContent = [...destinations].map(toId => `${fromId},${toId}`).join(csvEOL);
-          this.push(`${chunkContent}${csvEOL}`);
-          chunkIndex += 1;
-          outStream.emit(progressEvent, chunkIndex / totalChunks);
-        } else {
-          this.push(null);
-          outStream.emit(progressEvent, 1);
-        }
-      }, 0);
+      if (chunkIndex < totalChunks) {
+        const [fromId, destinations] = adjacencies[chunkIndex];
+        chunkContent = [...destinations].map(toId => `${fromId},${toId}`).join(csvEOL);
+        this.push(`${chunkContent}${csvEOL}`);
+        chunkIndex += 1;
+        outStream.emit(progressEvent, chunkIndex / totalChunks);
+      } else {
+        this.push(null);
+        outStream.emit(progressEvent, 1);
+      }
     },
   });
 

--- a/src/main/utils/formatters/edge-list.js
+++ b/src/main/utils/formatters/edge-list.js
@@ -1,6 +1,6 @@
 const logger = require('electron-log');
-const { Readable } = require('stream');
 
+const AsyncReadable = require('./AsyncReadable');
 const progressEvent = require('./progressEvent');
 const { csvEOL } = require('./csv');
 
@@ -56,8 +56,8 @@ const toCSVStream = (edgeList, outStream) => {
   let chunkContent;
   let chunkIndex = 0;
 
-  const inStream = new Readable({
-    read(/* size */) {
+  const inStream = new AsyncReadable({
+    read() {
       setTimeout(() => {
         if (chunkIndex < totalChunks) {
           const [fromId, destinations] = adjacencies[chunkIndex];

--- a/src/main/utils/formatters/graphml/GraphMLFormatter.js
+++ b/src/main/utils/formatters/graphml/GraphMLFormatter.js
@@ -1,6 +1,6 @@
 const logger = require('electron-log');
-const { Readable } = require('stream');
 
+const AsyncReadable = require('../AsyncReadable');
 const progressEvent = require('../progressEvent');
 const { estimatedChunkCount, graphMLGenerator } = require('./createGraphML');
 
@@ -18,19 +18,17 @@ class GraphMLFormatter {
     );
     let chunksRead = 0;
     const totalChunks = estimatedChunkCount(this.network);
-    const inStream = new Readable({
-      read(/* size */) {
-        setTimeout(() => {
-          const { done, value } = generator.next();
-          if (done) {
-            this.push(null);
-            outStream.emit(progressEvent, 1);
-          } else {
-            this.push(value);
-            chunksRead += 1;
-            outStream.emit(progressEvent, chunksRead / totalChunks);
-          }
-        }, 0);
+    const inStream = new AsyncReadable({
+      read() {
+        const { done, value } = generator.next();
+        if (done) {
+          this.push(null);
+          outStream.emit(progressEvent, 1);
+        } else {
+          this.push(value);
+          chunksRead += 1;
+          outStream.emit(progressEvent, chunksRead / totalChunks);
+        }
       },
     });
 

--- a/src/main/utils/formatters/graphml/GraphMLFormatter.js
+++ b/src/main/utils/formatters/graphml/GraphMLFormatter.js
@@ -1,6 +1,8 @@
+const logger = require('electron-log');
 const { Readable } = require('stream');
 
-const { graphMLGenerator } = require('./createGraphML');
+const progressEvent = require('../progressEvent');
+const { estimatedChunkCount, graphMLGenerator } = require('./createGraphML');
 
 class GraphMLFormatter {
   constructor(data, useDirectedEdges, variableRegistry) {
@@ -14,15 +16,27 @@ class GraphMLFormatter {
       this.variableRegistry,
       this.useDirectedEdges,
     );
+    let chunksRead = 0;
+    const totalChunks = estimatedChunkCount(this.network);
     const inStream = new Readable({
       read(/* size */) {
-        const { done, value } = generator.next();
-        if (done) {
-          this.push(null);
-        } else {
-          this.push(value);
-        }
+        setTimeout(() => {
+          const { done, value } = generator.next();
+          if (done) {
+            this.push(null);
+            outStream.emit(progressEvent, 1);
+          } else {
+            this.push(value);
+            chunksRead += 1;
+            outStream.emit(progressEvent, chunksRead / totalChunks);
+          }
+        }, 0);
       },
+    });
+
+    inStream.on('error', (err) => {
+      logger.warn('Readable error', err.message);
+      logger.debug(err);
     });
 
     // TODO: handle teardown. Use pipeline() API in Node 10?

--- a/src/main/utils/formatters/matrix.js
+++ b/src/main/utils/formatters/matrix.js
@@ -221,7 +221,6 @@ class AdjacencyMatrix {
 
     return {
       abort: () => { inStream.destroy(); },
-      estimatedProgressStepCount: dataColumnCount,
     };
   }
 

--- a/src/main/utils/formatters/progressEvent.js
+++ b/src/main/utils/formatters/progressEvent.js
@@ -1,0 +1,2 @@
+// Formatters emit this event as data is written to output streams
+module.exports = 'export-progress';

--- a/src/renderer/components/ExportModal.js
+++ b/src/renderer/components/ExportModal.js
@@ -2,14 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Modal from './Modal';
-import { Spinner } from '../ui/components';
+import Progress from '../ui/components/Progress';
 
-const ExportModal = ({ className, handleCancel, show }) => (
+const ExportModal = ({ className, handleCancel, fractionComplete, show }) => (
   <Modal className={className} title="Exporting..." show={show} onCancel={handleCancel}>
     <div className="export-modal__progress">
       <div className="export-modal__progress">
-        {/* TODO: progress */}
-        <Spinner small />
+        {
+          <Progress max={1} value={fractionComplete} />
+        }
       </div>
     </div>
   </Modal>
@@ -17,12 +18,14 @@ const ExportModal = ({ className, handleCancel, show }) => (
 
 ExportModal.propTypes = {
   className: PropTypes.string,
+  fractionComplete: PropTypes.number,
   handleCancel: PropTypes.func.isRequired,
   show: PropTypes.bool,
 };
 
 ExportModal.defaultProps = {
   className: null,
+  fractionComplete: 0,
   show: false,
 };
 

--- a/src/renderer/containers/ExportScreen.js
+++ b/src/renderer/containers/ExportScreen.js
@@ -13,6 +13,7 @@ import Radio from '../ui/components/Fields/Radio';
 import Toggle from '../ui/components/Fields/Toggle';
 import ExportModal from '../components/ExportModal';
 import withApiClient from '../components/withApiClient';
+import { makeStreamingResponseConsumer } from '../utils/adminApiClient';
 import { selectors } from '../ducks/modules/protocols';
 import { Button, Spinner } from '../ui';
 import { actionCreators as messageActionCreators } from '../ducks/modules/appMessages';
@@ -118,6 +119,10 @@ class ExportScreen extends Component {
       useDirectedEdges,
     } = this.state;
 
+    const responseConsumer = makeStreamingResponseConsumer((fractionComplete) => {
+      this.setState({ fractionComplete });
+    });
+
     apiClient
       .post(`/protocols/${protocolId}/export_requests`, {
         exportFormats: (exportFormat === 'csv' && [...csvTypes]) || [exportFormat],
@@ -125,6 +130,8 @@ class ExportScreen extends Component {
         destinationFilepath,
         entityFilter,
         useDirectedEdges,
+      }, {
+        responseConsumer,
       })
       .then(() => showConfirmation('Export complete'))
       .catch(err => showError(err.message))
@@ -152,6 +159,7 @@ class ExportScreen extends Component {
             className="modal--export"
             show={exportInProgress}
             handleCancel={this.handleCancel}
+            fractionComplete={this.state.fractionComplete}
           />
         }
         <h1>{protocol.name}</h1>

--- a/src/renderer/utils/adminApiClient.js
+++ b/src/renderer/utils/adminApiClient.js
@@ -36,12 +36,13 @@ const makeStreamingResponseConsumer = progressHandler =>
         return true;
       }
 
+      // Look for the last JSON object in the reponse stream
       const text = decoder.decode(value, { stream: true });
-      const lines = text && text.split('\n').filter(s => s.length);
-      if (lines.length) {
+      const statusMatch = text.match(/({.+})[^}]*$/);
+      if (statusMatch && statusMatch[1]) {
+        const latestStatus = statusMatch[1];
         try {
-          const lastLine = lines[lines.length - 1];
-          const json = JSON.parse(lastLine);
+          const json = JSON.parse(latestStatus);
           if (json.progress) {
             progressHandler(json.progress);
           } else if (json.status === 'error') {


### PR DESCRIPTION
Resolves #207. This includes the new Progress component from UI to report determinate progress during export.

The progress calculation is pretty naive, but should suffice for most/all cases. Basically, each stream write is considered a chunk of work, and assumed to take roughly the same amount of time. The current implementation of matrix exporting might produce skewed progress with very large networks, but that should be addressed by #218.

![export](https://user-images.githubusercontent.com/39674/50598417-ab0b0000-0e78-11e9-8f36-938f0878210c.png)