### PR TITLE
Add real metadata panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}",
       "!src/renderer/ui/**",
+      "!src/main/utils/network-query/**",
       "!src/renderer/components/Filter/**",
       "!src/renderer/components/Transitions/(Appear|Drawer)*",
       "!**/dummy_data.js"

--- a/src/main/data-managers/Reportable.js
+++ b/src/main/data-managers/Reportable.js
@@ -6,10 +6,37 @@ const { resolveOrReject } = require('../utils/db');
 // an empty dummy field instead of full objects speeds up counting significantly.
 const pseudoField = 'nc_pseudo_field';
 
+// Map document results to a count of contained edges *for each interview*
+const edgeCounts = docs => docs.map(doc => doc.data.edges[pseudoField].length);
+
+// As above, but for nodes
+const nodeCounts = docs => docs.map(doc => doc.data.nodes[pseudoField].length);
+
+// Return min/mean/max based on entityCounts (# of nodes or edges per interview)
+const summaryStats = (entityCounts) => {
+  const stats = entityCounts.reduce((acc, count) => {
+    acc.sum += count;
+    acc.min = Math.min(acc.min, count);
+    acc.max = Math.max(acc.max, count);
+    return acc;
+  }, { min: Infinity, max: 0, sum: 0 });
+  stats.mean = stats.sum / entityCounts.length;
+  return stats;
+};
+
 /**
  * Mixin for report queries on a SessionDB.
  */
 const Reportable = Super => class extends Super {
+  summaryStats(protocolId) {
+    return Promise.all(
+      [
+        this.nodeStats(protocolId).catch(() => {}),
+        this.edgeStats(protocolId).catch(() => {}),
+      ])
+      .then(([nodes, edges]) => ({ nodes, edges }));
+  }
+
   totalCounts(protocolId) {
     return Promise.all(
       [
@@ -24,6 +51,24 @@ const Reportable = Super => class extends Super {
       })));
   }
 
+  nodeStats(protocolId) {
+    return new Promise((resolve, reject) => {
+      this.db
+        .find({ protocolId, 'data.nodes': { $exists: true } })
+        .projection({ [`data.nodes.${[pseudoField]}`]: 1, _id: 0 })
+        .exec(resolveOrReject(docs => resolve(summaryStats(nodeCounts(docs))), reject));
+    });
+  }
+
+  edgeStats(protocolId) {
+    return new Promise((resolve, reject) => {
+      this.db
+        .find({ protocolId, 'data.edges': { $exists: true } })
+        .projection({ [`data.edges.${[pseudoField]}`]: 1, _id: 0 })
+        .exec(resolveOrReject(docs => resolve(summaryStats(edgeCounts(docs))), reject));
+    });
+  }
+
   countSessions(protocolId) {
     return new Promise((resolve, reject) => {
       this.db.count({ protocolId }, resolveOrReject(resolve, reject));
@@ -31,27 +76,11 @@ const Reportable = Super => class extends Super {
   }
 
   countNodes(protocolId) {
-    return new Promise((resolve, reject) => {
-      this.db
-        .find({ protocolId, 'data.nodes': { $exists: true } })
-        .projection({ [`data.nodes.${[pseudoField]}`]: 1, _id: 0 })
-        .exec(resolveOrReject(docs => resolve(docs.reduce((sum, doc) => {
-          sum += doc.data.nodes[pseudoField].length;
-          return sum;
-        }, 0)), reject));
-    });
+    return this.nodeStats(protocolId).then(stats => stats && stats.sum);
   }
 
   countEdges(protocolId) {
-    return new Promise((resolve, reject) => {
-      this.db
-        .find({ protocolId, 'data.edges': { $exists: true } })
-        .projection({ [`data.edges.${pseudoField}`]: 1, _id: 0 })
-        .exec(resolveOrReject(docs => resolve(docs.reduce((sum, doc) => {
-          sum += doc.data.edges[pseudoField].length;
-          return sum;
-        }, 0)), reject));
-    });
+    return this.edgeStats(protocolId).then(stats => stats && stats.sum);
   }
 };
 

--- a/src/main/data-managers/__tests__/Reportable-test.js
+++ b/src/main/data-managers/__tests__/Reportable-test.js
@@ -63,6 +63,13 @@ describe('Reportable', () => {
           edges: mockData.data.edges.length,
         });
       });
+
+      it('provides summary stats', async () => {
+        await expect(reportDB.summaryStats(mockData.protocolId)).resolves.toMatchObject({
+          nodes: { min: 2, max: 2, mean: 2 },
+          edges: { min: 2, max: 2, mean: 2 },
+        });
+      });
     });
 
     describe('with multiple sessions', () => {

--- a/src/main/server/AdminService.js
+++ b/src/main/server/AdminService.js
@@ -185,6 +185,13 @@ class AdminService {
         .then(() => next());
     });
 
+    // "stats": { "nodes": { "min":0, "max":0, "mean":0 }, "edges": { "min":0, "max":0, "mean":0 } }
+    api.get('/protocols/:id/reports/summary_stats', (req, res, next) => {
+      this.reportDb.summaryStats(req.params.id)
+        .then(stats => res.send({ status: 'ok', stats }))
+        .then(() => next());
+    });
+
     api.get('/protocols/:id/sessions', (req, res, next) => {
       // For now, hardcode response limit & offset
       // TODO: paginated API if needed

--- a/src/renderer/components/DummyDashboardFragment.js
+++ b/src/renderer/components/DummyDashboardFragment.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { BarChart, InterviewWidget, LineChart, PieChart } from '../components';
-import { interviewData, barData, pieData, lineData } from '../utils/dummy_data';
+import { BarChart, LineChart, PieChart } from '../components';
+import { barData, pieData, lineData } from '../utils/dummy_data';
 
 const DummyDashboardFragment = ({ className }) => (
   <React.Fragment>
-    <div className={`${className}__panel ${className}__panel-mock`}><InterviewWidget data={interviewData} /></div>
     <div className={`${className}__panel ${className}__panel-mock`}><BarChart data={barData} dataKeys={['pv', 'uv']} /></div>
     <div className={`${className}__panel ${className}__panel-mock`}><PieChart data={pieData} /></div>
     <div className={`${className}__panel ${className}__panel-mock`}><LineChart data={lineData} /></div>

--- a/src/renderer/components/charts/CountsWidget.js
+++ b/src/renderer/components/charts/CountsWidget.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { formatNumber } from '../../utils/formatters';
+
 const CountsWidget = ({ className, data }) => (
   <div className={`counts-widget ${className}`}>
     {data.map((entry, index) => (
       <div key={index} className="counts-widget__content">
         <p className="counts-widget__key">{entry.name}: </p>
-        <p className="counts-widget__value">{entry.count}</p>
+        <p className="counts-widget__value">{formatNumber(entry.count)}</p>
       </div>))}
   </div>
 );

--- a/src/renderer/components/charts/InterviewWidget.js
+++ b/src/renderer/components/charts/InterviewWidget.js
@@ -2,22 +2,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import CountsWidget from './CountsWidget';
 
-const InterviewWidget = ({ className, data }) => (
-  <div className={`interview-widget ${className}`}>
-    {data.map((entry, index) => (
-      <div key={index}>
-        <h4 className="interview-widget__label">{entry.name}</h4>
-        <CountsWidget className="interview-widget__data" data={entry.data} />
-      </div>))}
+const InterviewWidget = ({ data }) => (
+  <div className="interview-widget">
+    <h4>Summary Stats</h4>
+    <div>
+      {
+        data.map((entry, index) => (
+          <div key={index}>
+            <h4 className="interview-widget__label">{entry.name}</h4>
+            <CountsWidget className="interview-widget__data" data={entry.data} />
+          </div>
+        ))
+      }
+    </div>
   </div>
 );
 
-InterviewWidget.defaultProps = {
-  className: '',
-};
-
 InterviewWidget.propTypes = {
-  className: PropTypes.string,
   data: PropTypes.array.isRequired,
 };
 

--- a/src/renderer/containers/InterviewStatsPanel.js
+++ b/src/renderer/containers/InterviewStatsPanel.js
@@ -1,0 +1,80 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import InterviewWidget from '../components/charts/InterviewWidget';
+import withApiClient from '../components/withApiClient';
+import { formatDecimal } from '../utils/formatters';
+
+const shapeStatsData = ({ nodes = {}, edges = {} }) => ([
+  { name: 'Node count',
+    data: [
+      { name: 'Mean', count: formatDecimal(nodes.mean) },
+      { name: 'Min', count: nodes.min },
+      { name: 'Max', count: nodes.max },
+    ],
+  },
+  { name: 'Edge count',
+    data: [
+      { name: 'Mean', count: formatDecimal(edges.mean) },
+      { name: 'Min', count: edges.min },
+      { name: 'Max', count: edges.max },
+    ],
+  },
+]);
+
+class InterviewStatsPanel extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      statsData: shapeStatsData({}),
+    };
+  }
+
+  componentDidMount() {
+    this.loadData();
+  }
+
+  componentDidUpdate(prevProps) {
+    const prevCount = prevProps.sessionCount;
+    const newCount = this.props.sessionCount;
+    // When mounted (on each workspace load), sessionCount is null.
+    // Only reload data when session count changes (i.e., a session was
+    // imported or deleted while on this workspace).
+    if (newCount !== null && prevCount !== null && newCount !== prevCount) {
+      this.loadData();
+    }
+  }
+
+  loadData() {
+    const route = `/protocols/${this.props.protocolId}/reports/summary_stats`;
+    this.props.apiClient.get(route)
+      .then(({ stats }) => stats && this.setState({
+        statsData: shapeStatsData(stats),
+      }));
+  }
+
+  render() {
+    return (
+      <div className="dashboard__panel">
+        <InterviewWidget data={this.state.statsData} />
+      </div>
+    );
+  }
+}
+
+InterviewStatsPanel.defaultProps = {
+  apiClient: null,
+  sessionCount: null,
+};
+
+InterviewStatsPanel.propTypes = {
+  apiClient: PropTypes.object,
+  sessionCount: PropTypes.number,
+  protocolId: PropTypes.string.isRequired,
+};
+
+export default withApiClient(InterviewStatsPanel);
+
+export {
+  InterviewStatsPanel as UnconnectedInterviewStatsPanel,
+};

--- a/src/renderer/containers/ProtocolCountsPanel.js
+++ b/src/renderer/containers/ProtocolCountsPanel.js
@@ -3,14 +3,11 @@ import PropTypes from 'prop-types';
 
 import CountsWidget from '../components/charts/CountsWidget';
 import withApiClient from '../components/withApiClient';
-import { formatDecimal } from '../utils/formatters';
 
 const shapeCountData = (nodeCount, edgeCount, sessionCount) => ([
+  { name: 'Total Interviews', count: sessionCount },
   { name: 'Total Nodes', count: nodeCount },
   { name: 'Total Edges', count: edgeCount },
-  { name: 'Total Interviews', count: sessionCount },
-  { name: 'Mean Nodes / Interview', count: sessionCount && formatDecimal(nodeCount / sessionCount) },
-  { name: 'Mean Edges / Interview', count: sessionCount && formatDecimal(edgeCount / sessionCount) },
 ]);
 
 class ProtocolCountsPanel extends Component {
@@ -47,6 +44,7 @@ class ProtocolCountsPanel extends Component {
   render() {
     return (
       <div className="dashboard__panel">
+        <h4>Total Counts</h4>
         <CountsWidget data={this.state.countsData} />
       </div>
     );

--- a/src/renderer/containers/WorkspaceScreen.js
+++ b/src/renderer/containers/WorkspaceScreen.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { ipcRenderer } from 'electron';
 
 import Types from '../types';
+import InterviewStatsPanel from './InterviewStatsPanel';
 import ProtocolCountsPanel from './ProtocolCountsPanel';
 import withApiClient from '../components/withApiClient';
 import viewModelMapper from '../utils/baseViewModelMapper';
@@ -117,6 +118,10 @@ class WorkspaceScreen extends Component {
             updatedAt={protocol.updatedAt}
             sessionCount={totalSessionsCount}
           />
+          {
+            sessions &&
+              <InterviewStatsPanel protocolId={protocol.id} sessionCount={totalSessionsCount} />
+          }
           <SessionPanel
             sessions={sessions}
             totalCount={totalSessionsCount}

--- a/src/renderer/containers/__tests__/InterviewStatsPanel-test.js
+++ b/src/renderer/containers/__tests__/InterviewStatsPanel-test.js
@@ -1,0 +1,44 @@
+/* eslint-env jest */
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+
+import InterviewStatsPanel from '../InterviewStatsPanel';
+import AdminApiClient from '../../utils/adminApiClient';
+
+jest.mock('../../utils/adminApiClient');
+
+describe('InterviewStatsPanel', () => {
+  let mockApiClient;
+  beforeEach(() => {
+    mockApiClient = new AdminApiClient();
+  });
+
+  it('manages an API client instance', () => {
+    const subject = shallow(<InterviewStatsPanel protocolId="1" />);
+    expect(subject.prop('apiClient')).toBeInstanceOf(Object);
+  });
+
+  describe('mounted', () => {
+    let subject;
+    beforeEach(() => {
+      subject = mount(<InterviewStatsPanel protocolId="1" />);
+    });
+
+    it('renders an interview widget', () => {
+      expect(subject.find('InterviewWidget')).toHaveLength(1);
+    });
+
+    it('loads data', () => {
+      mount(<InterviewStatsPanel protocolId="1" />);
+      expect(mockApiClient.get).toHaveBeenCalled();
+    });
+
+    it('loads data from API when sessionCount changes', () => {
+      subject.setProps({ sessionCount: 1 });
+      mockApiClient.get.mockClear();
+      expect(mockApiClient.get).toHaveBeenCalledTimes(0);
+      subject.setProps({ sessionCount: 2 });
+      expect(mockApiClient.get).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/renderer/containers/__tests__/ProtocolCountsPanel-test.js
+++ b/src/renderer/containers/__tests__/ProtocolCountsPanel-test.js
@@ -36,8 +36,6 @@ describe('ProtocolCountsPanel', () => {
     const text = subject.find('CountsWidget').text();
     expect(text).toMatch(/Total Nodes: 15/);
     expect(text).toMatch(/Total Edges: 13/);
-    expect(text).toMatch(/Mean.*: 7\.5/);
-    expect(text).toMatch(/Mean.*: 6\.5/);
   });
 
   describe('api client', () => {

--- a/src/renderer/containers/index.js
+++ b/src/renderer/containers/index.js
@@ -1,5 +1,6 @@
 export { default as App } from './App';
 export { default as ExportScreen } from './ExportScreen';
+export { default as InterviewStatsPanel } from './InterviewStatsPanel';
 export { default as OverviewScreen } from './OverviewScreen';
 export { default as PairDevice } from './PairDevice';
 export { default as ProtocolCountsPanel } from './ProtocolCountsPanel';

--- a/src/renderer/styles/components/_counts-widget.scss
+++ b/src/renderer/styles/components/_counts-widget.scss
@@ -2,19 +2,26 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: 1rem;
+  padding: spacing(medium) 0;
 
   @include element(content) {
-    align-items: center;
     display: flex;
-    justify-content: space-between;
+    margin: 0 spacing(small);
+    flex: 0 1 auto;
+    width: 100%;
   }
 
   @include element(key) {
-    margin: spacing(small) 0;
+    margin: spacing(small) spacing(small) spacing(small) 0;
+    display: flex;
+    flex: 0 1 50%;
+    justify-content: flex-start;
   }
 
   @include element(value) {
     margin: spacing(small) 0;
+    display: flex;
+    justify-content: flex-end;
+    flex: 0 1 50%;
   }
 }

--- a/src/renderer/styles/components/_interview-widget.scss
+++ b/src/renderer/styles/components/_interview-widget.scss
@@ -2,7 +2,6 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: 1rem;
 
   &__label {
     border-bottom: solid 1px;

--- a/src/renderer/styles/components/_interview-widget.scss
+++ b/src/renderer/styles/components/_interview-widget.scss
@@ -12,6 +12,5 @@
   .counts-widget {
     flex-direction: row;
     justify-content: space-between;
-    padding: 0;
   }
 }

--- a/src/renderer/utils/dummy_data.js
+++ b/src/renderer/utils/dummy_data.js
@@ -1,18 +1,3 @@
-const interviewData = [
-  { name: 'Duration (minutes)',
-    data: [{ name: 'Mean', count: 23 },
-      { name: 'Min', count: 12 },
-      { name: 'Max', count: 56 }] },
-  { name: 'Node count',
-    data: [{ name: 'Mean', count: 15 },
-      { name: 'Min', count: 2 },
-      { name: 'Max', count: 67 }] },
-  { name: 'Edge count',
-    data: [{ name: 'Mean', count: 12 },
-      { name: 'Min', count: 2 },
-      { name: 'Max', count: 78 }] },
-];
-
 const barData = [
   { name: 'Page A', uv: 4000, pv: 2400, amt: 2400 },
   { name: 'Page B', uv: 3000, pv: 1398, amt: 2210 },
@@ -46,7 +31,6 @@ const lineData = [
   { time: new Date(2017, 7, 3).toLocaleDateString(), value: 15, other: 89 }];
 
 export {
-  interviewData,
   barData,
   pieData,
   lineData,

--- a/src/renderer/utils/formatters.js
+++ b/src/renderer/utils/formatters.js
@@ -1,11 +1,13 @@
 const dateOpts = { year: '2-digit', month: 'numeric', day: 'numeric' };
 
-const decimalFormatter = new Intl.NumberFormat();
+const decimalFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 });
 
 const formatDate = d => (d ? d.toLocaleString(undefined, dateOpts) : '');
 const formatDecimal = n => (isNaN(n) ? '' : decimalFormatter.format(n));
+const formatNumber = n => (Number.isInteger(n) ? n.toString() : formatDecimal(n));
 
 export {
   formatDate,
   formatDecimal,
+  formatNumber,
 };


### PR DESCRIPTION
This replaces the mock stats panel with real summary data (min/max/mean), dropping "duration" (since that information is not collected).
