### PR TITLE
Display multiple 'value distribution' charts

### DIFF
--- a/scripts/build-api-spec.js
+++ b/scripts/build-api-spec.js
@@ -42,7 +42,7 @@ const options = {
 };
 
 const destDir = path.join(paths.config, 'api');
-const destPath = path.join(destDir, `api-spec-${DeviceAPIConfig.version}.json`);
+const destPath = path.join(destDir, `api-spec-${DeviceAPIConfig.Version}.json`);
 const destFile = fs.openSync(destPath, 'w');
 
 const apiSpec = swaggerJSDoc(options);

--- a/src/main/data-managers/Reportable.js
+++ b/src/main/data-managers/Reportable.js
@@ -140,12 +140,9 @@ const Reportable = Super => class extends Super {
           return entries;
         }, []);
 
-
         const keys = [...entities.reduce((acc, entity) => {
           Object.keys(entity).forEach((key) => {
-            if (key !== 'time') {
-              acc.add(key);
-            }
+            if (key !== 'time') { acc.add(key); }
           });
           return acc;
         }, new Set())];

--- a/src/main/data-managers/Reportable.js
+++ b/src/main/data-managers/Reportable.js
@@ -37,7 +37,7 @@ const entityKey = (entityName) => {
 // See entityTimeSeries for the format of `types`
 const reduceEntityTypeCounts = (types = [], entityName = 'node') =>
   types.reduce((sumMap, type) => {
-    const typeKey = `node_${type}`;
+    const typeKey = `${entityName}_${type}`;
     sumMap[typeKey] = sumMap[typeKey] || 0;
     sumMap[typeKey] += 1;
     sumMap[entityName] += 1;

--- a/src/main/data-managers/__tests__/Reportable-test.js
+++ b/src/main/data-managers/__tests__/Reportable-test.js
@@ -133,13 +133,28 @@ describe('Reportable', () => {
         });
       });
 
+      it('returns entities and keys', async () => {
+        await expect(reportDB.entityTimeSeries(mockData.protocolId)).resolves.toMatchObject({
+          entities: expect.any(Array),
+          keys: expect.any(Array),
+        });
+      });
+
       it('produces entity counts as a time series', async () => {
-        await expect(reportDB.entityTimeSeries(mockData.protocolId)).resolves.toContainEqual({
+        const result = await reportDB.entityTimeSeries(mockData.protocolId);
+        expect(result.entities).toContainEqual({
           time: expect.any(Number),
           edge: 0,
           node: 2,
           node_person: 2,
         });
+      });
+
+      it('produces keys for all entries in time series', async () => {
+        const result = await reportDB.entityTimeSeries(mockData.protocolId);
+        expect(result.keys).toContainEqual('node');
+        expect(result.keys).toContainEqual('node_person');
+        expect(result.keys).toContainEqual('edge');
       });
     });
   });

--- a/src/main/data-managers/__tests__/Reportable-test.js
+++ b/src/main/data-managers/__tests__/Reportable-test.js
@@ -113,8 +113,23 @@ describe('Reportable', () => {
       beforeAll(() => { mockData = NodeDataSession; });
       it('summarizes an ordinal variable', async () => {
         await expect(reportDB.optionValueBuckets(mockData.protocolId, 'frequencyOrdinal')).resolves.toMatchObject({
-          1: 1,
-          2: 1,
+          person: {
+            frequencyOrdinal: {
+              1: 1,
+              2: 1,
+            },
+          },
+        });
+      });
+
+      it('summarizes a categorical variable', async () => {
+        await expect(reportDB.optionValueBuckets(mockData.protocolId, 'preferenceCategorical')).resolves.toMatchObject({
+          person: {
+            preferenceCategorical: {
+              a: 2,
+              b: 1,
+            },
+          },
         });
       });
 

--- a/src/main/data-managers/__tests__/Reportable-test.js
+++ b/src/main/data-managers/__tests__/Reportable-test.js
@@ -112,7 +112,7 @@ describe('Reportable', () => {
     describe('with node variables', () => {
       beforeAll(() => { mockData = NodeDataSession; });
       it('summarizes an ordinal variable', async () => {
-        await expect(reportDB.optionValueBuckets(mockData.protocolId, 'frequencyOrdinal')).resolves.toMatchObject({
+        await expect(reportDB.optionValueBuckets(mockData.protocolId, ['frequencyOrdinal'])).resolves.toMatchObject({
           person: {
             frequencyOrdinal: {
               1: 1,
@@ -123,7 +123,7 @@ describe('Reportable', () => {
       });
 
       it('summarizes a categorical variable', async () => {
-        await expect(reportDB.optionValueBuckets(mockData.protocolId, 'preferenceCategorical')).resolves.toMatchObject({
+        await expect(reportDB.optionValueBuckets(mockData.protocolId, ['preferenceCategorical'])).resolves.toMatchObject({
           person: {
             preferenceCategorical: {
               a: 2,

--- a/src/main/data-managers/__tests__/data/node-data-session.json
+++ b/src/main/data-managers/__tests__/data/node-data-session.json
@@ -6,14 +6,16 @@
                 "_uid": "91980bde-1cc1-4681-b482-8a6ede07c2c8",
                 "type": "person",
                 "attributes": {
-                    "frequencyOrdinal": 1
+                    "frequencyOrdinal": 1,
+                    "preferenceCategorical": ["a", "b"]
                 }
             },
             {
                 "_uid": "d5fb6341-91a0-4674-b615-039280c9c212",
                 "type": "person",
                 "attributes": {
-                    "frequencyOrdinal": 2
+                    "frequencyOrdinal": 2,
+                    "preferenceCategorical": ["a"]
                 }
             }
         ]

--- a/src/main/server/AdminService.js
+++ b/src/main/server/AdminService.js
@@ -193,7 +193,7 @@ class AdminService {
         .then(() => next());
     });
 
-    // "buckets": {}
+    // "buckets": { "person": { "varName": { "val1": 0, "val2": 0 } } }
     api.get('/protocols/:id/reports/option_buckets', (req, res, next) => {
       const { variableName, entityName, entityType } = req.query;
       this.reportDb.optionValueBuckets(req.params.id, variableName, entityName, entityType)

--- a/src/main/server/AdminService.js
+++ b/src/main/server/AdminService.js
@@ -193,10 +193,11 @@ class AdminService {
         .then(() => next());
     });
 
-    // "buckets": { "person": { "varName": { "val1": 0, "val2": 0 } } }
+    // ?variableNames=var1,var2&entityName=node
+    // "buckets": { "person": { "var1": { "val1": 0, "val2": 0 }, "var2": {} } }
     api.get('/protocols/:id/reports/option_buckets', (req, res, next) => {
-      const { variableName, entityName, entityType } = req.query;
-      this.reportDb.optionValueBuckets(req.params.id, variableName, entityName, entityType)
+      const { variableNames = '', entityName = 'node' } = req.query;
+      this.reportDb.optionValueBuckets(req.params.id, variableNames.split(','), entityName)
         .then(buckets => res.send({ status: 'ok', buckets }))
         .then(() => next());
     });

--- a/src/main/server/AdminService.js
+++ b/src/main/server/AdminService.js
@@ -205,7 +205,7 @@ class AdminService {
     // "entities": [{ time: 1546455484765, node: 20, edge: 0 }]
     api.get('/protocols/:id/reports/entity_time_series', (req, res, next) => {
       this.reportDb.entityTimeSeries(req.params.id)
-        .then(entities => res.send({ status: 'ok', entities }))
+        .then(({ entities, keys }) => res.send({ status: 'ok', entities, keys }))
         .then(() => next());
     });
 

--- a/src/main/server/__tests__/AdminService-test.js
+++ b/src/main/server/__tests__/AdminService-test.js
@@ -269,13 +269,14 @@ describe('the AdminService', () => {
       describe('reports', () => {
         const countsResult = { nodes: 0, edges: 0 };
         const bucketsResult = { one: 4, two: 0 };
+        const timeSeriesResult = { entities: [], keys: [] };
 
         beforeAll(() => {
           ProtocolManager.mockImplementation(() => ({
             reportDb: {
               totalCounts: jest.fn().mockResolvedValue(countsResult),
               optionValueBuckets: jest.fn().mockResolvedValue(bucketsResult),
-              entityTimeSeries: jest.fn().mockResolvedValue([]),
+              entityTimeSeries: jest.fn().mockResolvedValue(timeSeriesResult),
             },
           }));
         });
@@ -298,7 +299,7 @@ describe('the AdminService', () => {
           const endpoint = makeUrl('protocols/1/reports/entity_time_series', apiBase);
           const res = await jsonClient.get(endpoint);
           expect(res.json.status).toBe('ok');
-          expect(res.json.entities).toMatchObject([]);
+          expect(res.json).toMatchObject(timeSeriesResult);
         });
       });
     });

--- a/src/renderer/components/AnswerDistributionPanel.js
+++ b/src/renderer/components/AnswerDistributionPanel.js
@@ -22,22 +22,28 @@ const content = (chartData, variableType) => {
  * Depending on variableType, renders either a pie chart with a distribution of categorical
  * node attributes, or a Bar chart with a distribution of ordinal attributes.
  */
-const AnswerDistributionPanel = ({ chartData, variableDefinition }) => (
-  <div className="dashboard__panel dashboard__panel--chart">
-    <h4 className="dashboard__header-text">
-      {variableDefinition.label}
-      <small className="dashboard__header-subtext">
-        {headerLabel(variableDefinition.type)} distribution
-      </small>
-    </h4>
-    <div className="dashboard__chartContainer">
-      {content(chartData, variableDefinition.type)}
+const AnswerDistributionPanel = ({ chartData, variableDefinition }) => {
+  const totalObservations = sumValues(chartData);
+  return (
+    <div className="dashboard__panel dashboard__panel--chart">
+      <h4 className="dashboard__header-text">
+        {variableDefinition.label}
+        <small className="dashboard__header-subtext">
+          {headerLabel(variableDefinition.type)} distribution
+        </small>
+      </h4>
+      <div className="dashboard__chartContainer">
+        {content(chartData, variableDefinition.type)}
+      </div>
+      <div className="dashboard__chartFooter">
+        {
+          totalObservations > 0 &&
+          `Total: ${totalObservations} observations`
+        }
+      </div>
     </div>
-    <div className="dashboard__chartFooter">
-      Total: {sumValues(chartData)} observations
-    </div>
-  </div>
-);
+  );
+};
 
 AnswerDistributionPanel.defaultProps = {
   chartData: [],

--- a/src/renderer/components/AnswerDistributionPanel.js
+++ b/src/renderer/components/AnswerDistributionPanel.js
@@ -20,25 +20,26 @@ const content = (chartData, variableType) => {
  * Depending on variableType, renders either a pie chart with a distribution of categorical
  * node attributes, or a Bar chart with a distribution of ordinal attributes.
  */
-const AnswerDistributionPanel = ({ chartData, variableType, variableDefinition }) => (
+const AnswerDistributionPanel = ({ chartData, variableDefinition }) => (
   <div className="dashboard__panel dashboard__panel--chart">
     <h4 className="dashboard__header-text">
       {variableDefinition.label}
-      <small className="dashboard__header-subtext">{headerLabel(variableType)} distribution</small>
+      <small className="dashboard__header-subtext">
+        {headerLabel(variableDefinition.type)} distribution
+      </small>
     </h4>
     <div className="dashboard__chartContainer">
-      {content(chartData, variableType)}
+      {content(chartData, variableDefinition.type)}
     </div>
   </div>
 );
 
 AnswerDistributionPanel.defaultProps = {
-  chartData: null,
+  chartData: [],
 };
 
 AnswerDistributionPanel.propTypes = {
   chartData: PropTypes.array,
-  variableType: PropTypes.oneOf(['categorical', 'ordinal']).isRequired,
   variableDefinition: Types.variableDefinition.isRequired,
 };
 

--- a/src/renderer/components/AnswerDistributionPanel.js
+++ b/src/renderer/components/AnswerDistributionPanel.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Types from '../types';
+import { BarChart, EmptyData, PieChart } from '../components';
+
+const chartComponent = variableType => ((variableType === 'categorical') ? PieChart : BarChart);
+
+const headerLabel = variableType => ((variableType === 'categorical') ? 'Categorical' : 'Ordinal');
+
+const content = (chartData, variableType) => {
+  const Chart = chartComponent(variableType);
+  if (chartData.length) {
+    return <Chart allowDecimals={false} data={chartData} dataKeys={['value']} />;
+  }
+  return <EmptyData />;
+};
+
+/**
+ * Depending on variableType, renders either a pie chart with a distribution of categorical
+ * node attributes, or a Bar chart with a distribution of ordinal attributes.
+ */
+const AnswerDistributionPanel = ({ chartData, variableType, variableDefinition }) => (
+  <div className="dashboard__panel dashboard__panel--chart">
+    <h4 className="dashboard__header-text">
+      {headerLabel(variableType)} distribution: {variableDefinition.label}
+    </h4>
+    <div className="dashboard__chartContainer">
+      {content(chartData, variableType)}
+    </div>
+  </div>
+);
+
+AnswerDistributionPanel.defaultProps = {
+  chartData: null,
+};
+
+AnswerDistributionPanel.propTypes = {
+  chartData: PropTypes.array,
+  variableType: PropTypes.oneOf(['categorical', 'ordinal']).isRequired,
+  variableDefinition: Types.variableDefinition.isRequired,
+};
+
+export default AnswerDistributionPanel;

--- a/src/renderer/components/AnswerDistributionPanel.js
+++ b/src/renderer/components/AnswerDistributionPanel.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import Types from '../types';
 import { BarChart, EmptyData, PieChart } from '../components';
 
+const sumValues = groups => groups.reduce((sum, group) => sum + group.value, 0);
+
 const chartComponent = variableType => ((variableType === 'categorical') ? PieChart : BarChart);
 
 const headerLabel = variableType => ((variableType === 'categorical') ? 'Categorical' : 'Ordinal');
@@ -30,6 +32,9 @@ const AnswerDistributionPanel = ({ chartData, variableDefinition }) => (
     </h4>
     <div className="dashboard__chartContainer">
       {content(chartData, variableDefinition.type)}
+    </div>
+    <div className="dashboard__chartFooter">
+      Total: {sumValues(chartData)} observations
     </div>
   </div>
 );

--- a/src/renderer/components/AnswerDistributionPanel.js
+++ b/src/renderer/components/AnswerDistributionPanel.js
@@ -23,7 +23,8 @@ const content = (chartData, variableType) => {
 const AnswerDistributionPanel = ({ chartData, variableType, variableDefinition }) => (
   <div className="dashboard__panel dashboard__panel--chart">
     <h4 className="dashboard__header-text">
-      {headerLabel(variableType)} distribution: {variableDefinition.label}
+      {variableDefinition.label}
+      <small className="dashboard__header-subtext">{headerLabel(variableType)} distribution</small>
     </h4>
     <div className="dashboard__chartContainer">
       {content(chartData, variableType)}

--- a/src/renderer/components/SessionHistoryPanel.js
+++ b/src/renderer/components/SessionHistoryPanel.js
@@ -27,7 +27,7 @@ const buildChartContent = (sessions) => {
     .map(([dateStr, count]) => ({ name: dateStr, [dataLabel]: count }))
     .reverse();
 
-  return <BarChart data={barData} dataKeys={[dataLabel]} />;
+  return <BarChart allowDecimals={false} data={barData} dataKeys={[dataLabel]} />;
 };
 
 /**

--- a/src/renderer/components/__tests__/AnswerDistributionPanel-test.js
+++ b/src/renderer/components/__tests__/AnswerDistributionPanel-test.js
@@ -1,0 +1,63 @@
+/* eslint-env jest */
+import React from 'react';
+import { mount } from 'enzyme';
+import AnswerDistributionPanel from '../AnswerDistributionPanel';
+
+jest.mock('recharts');
+
+describe('AnswerDistributionPanel', () => {
+  let chartData;
+  let props;
+  let subject;
+  let variableType;
+
+  beforeAll(() => {
+    chartData = [];
+    variableType = 'categorical';
+  });
+
+  beforeEach(() => {
+    props = {
+      chartData,
+      variableType,
+      variableDefinition: {
+        label: '',
+        name: 'distributionVariable',
+        options: [
+          { label: 'a', value: 1 },
+          { label: 'b', value: 2 },
+          { label: 'c', value: 3 },
+        ],
+      },
+    };
+    subject = mount(<AnswerDistributionPanel {...props} />);
+  });
+
+  it('renders an empty view before data loads', () => {
+    expect(subject.find('BarChart')).toHaveLength(0);
+    expect(subject.find('PieChart')).toHaveLength(0);
+    expect(subject.find('.dashboard__emptyData')).toHaveLength(1);
+  });
+
+  describe('for ordinal variables', () => {
+    beforeAll(() => {
+      chartData = [{ name: '1', value: 4 }, { name: '2', value: 5 }];
+      variableType = 'ordinal';
+    });
+
+    it('renders a bar chart', () => {
+      expect(subject.find('BarChart')).toHaveLength(1);
+    });
+  });
+
+  describe('for categorical variables', () => {
+    beforeAll(() => {
+      chartData = [{ name: '1', value: [4] }, { name: '2', value: [5] }];
+      variableType = 'categorical';
+    });
+
+    it('renders a pie chart', () => {
+      expect(subject.find('PieChart')).toHaveLength(1);
+    });
+  });
+});

--- a/src/renderer/components/__tests__/AnswerDistributionPanel-test.js
+++ b/src/renderer/components/__tests__/AnswerDistributionPanel-test.js
@@ -19,10 +19,10 @@ describe('AnswerDistributionPanel', () => {
   beforeEach(() => {
     props = {
       chartData,
-      variableType,
       variableDefinition: {
         label: '',
         name: 'distributionVariable',
+        type: variableType,
         options: [
           { label: 'a', value: 1 },
           { label: 'b', value: 2 },

--- a/src/renderer/components/charts/PieChart.js
+++ b/src/renderer/components/charts/PieChart.js
@@ -2,14 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { PieChart as RechartPieChart, Pie, Cell, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 
-import { getCSSValues } from '../../utils/CSSVariables';
+import { getCSSValueRange } from '../../utils/CSSVariables';
 
-const colors = getCSSValues(
-  '--graph-data-1',
-  '--graph-data-2',
-  '--graph-data-3',
-  '--graph-data-4',
-);
+const colors = getCSSValueRange('--graph-data-', 1, 15);
 
 // 99% width to work around recharts problem with resizing
 const PieChart = ({ className, data }) => (

--- a/src/renderer/components/charts/TimeSeriesChart.js
+++ b/src/renderer/components/charts/TimeSeriesChart.js
@@ -20,19 +20,19 @@ const tooltipColor = getCSSValue('--graph-tooltip');
 const timeFormatter = timestamp => formatDatetime(new Date(timestamp));
 
 // 99% width to work around recharts problem with resizing
-const TimeSeriesChart = ({ className, data, dataKeys }) => (
+const TimeSeriesChart = ({ className, data, series }) => (
   <ResponsiveContainer height="100%" width="99%">
     <LineChart
       data={data}
       className={className}
     >
       {
-        dataKeys &&
-        dataKeys.map((dataKey, i) => (
+        series &&
+        series.map((oneSeries, i) => (
           <Line
-            key={dataKey}
-            dataKey={dataKey}
-            name={dataKey}
+            key={oneSeries.key}
+            dataKey={oneSeries.key}
+            name={oneSeries.label || oneSeries.key}
             stroke={colors[(i % colors.length)]}
             connectNulls
           />
@@ -64,7 +64,12 @@ TimeSeriesChart.defaultProps = {
 TimeSeriesChart.propTypes = {
   className: PropTypes.string,
   data: PropTypes.array.isRequired,
-  dataKeys: PropTypes.array.isRequired,
+  series: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      label: PropTypes.string,
+    }),
+  ).isRequired,
 };
 
 export default TimeSeriesChart;

--- a/src/renderer/components/charts/TimeSeriesChart.js
+++ b/src/renderer/components/charts/TimeSeriesChart.js
@@ -11,16 +11,11 @@ import {
   YAxis,
 } from 'recharts';
 
-import { getCSSValueDict } from '../../utils/CSSVariables';
+import { getCSSValue, getCSSValueRange } from '../../utils/CSSVariables';
 import { formatDatetime } from '../../utils/formatters';
 
-const colorDict = getCSSValueDict(
-  '--graph-data-1',
-  '--graph-data-2',
-  '--graph-data-3',
-  '--graph-data-4',
-  '--graph-tooltip',
-);
+const colors = getCSSValueRange('--graph-data-', 1, 15);
+const tooltipColor = getCSSValue('--graph-tooltip');
 
 const timeFormatter = timestamp => formatDatetime(new Date(timestamp));
 
@@ -38,7 +33,7 @@ const TimeSeriesChart = ({ className, data, dataKeys }) => (
             key={dataKey}
             dataKey={dataKey}
             name={dataKey}
-            stroke={colorDict[`--graph-data-${(i % 4) + 1}`]}
+            stroke={colors[(i % colors.length)]}
             connectNulls
           />
         ))
@@ -56,7 +51,7 @@ const TimeSeriesChart = ({ className, data, dataKeys }) => (
       <Legend />
       <Tooltip
         labelFormatter={timeFormatter}
-        labelStyle={{ color: colorDict['--graph-tooltip'] }}
+        labelStyle={{ color: tooltipColor }}
       />
     </LineChart>
   </ResponsiveContainer>

--- a/src/renderer/components/charts/TimeSeriesChart.js
+++ b/src/renderer/components/charts/TimeSeriesChart.js
@@ -34,6 +34,7 @@ const TimeSeriesChart = ({ className, data, series }) => (
             dataKey={oneSeries.key}
             name={oneSeries.label || oneSeries.key}
             stroke={colors[(i % colors.length)]}
+            strokeWidth={2}
             connectNulls
           />
         ))

--- a/src/renderer/components/charts/__tests__/TimeSeriesChart-test.js
+++ b/src/renderer/components/charts/__tests__/TimeSeriesChart-test.js
@@ -5,7 +5,7 @@ import TimeSeriesChart from '../TimeSeriesChart';
 
 describe('<TimeSeriesChart />', () => {
   it('defines a Line series', () => {
-    const wrapper = shallow(<TimeSeriesChart data={[{ value: 1 }]} dataKeys={['value']} />);
+    const wrapper = shallow(<TimeSeriesChart data={[{ value: 1 }]} series={[{ key: 'value' }]} />);
     expect(wrapper.find('Line').length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/src/renderer/containers/AnswerDistributionPanel.js
+++ b/src/renderer/containers/AnswerDistributionPanel.js
@@ -46,12 +46,13 @@ class AnswerDistributionPanel extends Component {
     }
     this.props.apiClient.get(route, query)
       .then(({ buckets }) => {
-        if (Object.keys(buckets).length) {
+        const data = buckets[entityType] && buckets[entityType][variableDefinition.name];
+        if (data && Object.keys(data).length) {
           // Provide data for every ordinal option, even if one has no data
           this.setState({
             chartData: variableDefinition.options.map(({ label, value = '' }) => ({
               name: label,
-              value: buckets[value.toString()] || 0,
+              value: data[value.toString()] || 0,
             })),
           });
         } else {

--- a/src/renderer/containers/AnswerDistributionPanels.js
+++ b/src/renderer/containers/AnswerDistributionPanels.js
@@ -3,7 +3,53 @@ import PropTypes from 'prop-types';
 
 import withApiClient from '../components/withApiClient';
 import AnswerDistributionPanel from '../components/AnswerDistributionPanel';
+import { transposedRegistry } from '../../main/utils/formatters/network'; // TODO: move
 import Types from '../types';
+
+const hasData = bucket => bucket && Object.keys(bucket).length > 0;
+
+/**
+ * Translates the node variables and the data available for ordinal & categorical variables
+ * into a series of chart definitions.
+ *
+ * One chart definition is produced for each ordinal & categorical variable. If session data
+ * contains any answers for that variable, then the entire range of answers is returned (including
+ * `0` values). If no data is available for a variable, then the chart contains an empty chartData
+ * value, so the child component can easily render an empty data view.
+ *
+ * @private
+ *
+ * @param {Object} transposedNodeRegistry `variableRegistry.node`, with transposed names
+ * @param {Object} buckets The API response from `option_buckets`
+ * @return {Array} chartDefinitions
+ */
+const shapeBucketData = (transposedNodeRegistry, buckets) =>
+  Object.entries(transposedNodeRegistry).reduce((acc, [entityType, { variables }]) => {
+    Object.entries(variables).forEach(([variableName, def]) => {
+      if (def.type === 'ordinal' || def.type === 'categorical') {
+        const data = buckets[entityType] && buckets[entityType][variableName];
+        const values = hasData(data) && def.options.map((option) => {
+          // Option defs are usually in the format { label, value }, however:
+          // - options may be strings or numerics instead of objects
+          const isOptionObject = option && typeof option === 'object';
+          // - label is optional, in which case `value` is used as the label
+          const name = isOptionObject ? (option.label || option.value) : option;
+          const dataKey = (isOptionObject ? option.value : option).toString();
+          return {
+            name,
+            value: data[dataKey] || 0,
+          };
+        });
+        acc.push({
+          entityType,
+          variableType: def.type,
+          variableDefinition: def,
+          chartData: values || [],
+        });
+      }
+    });
+    return acc;
+  }, []);
 
 /**
  * Renders a collection of ordinal & categorical distribution panels
@@ -12,7 +58,7 @@ class AnswerDistributionPanels extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      chartData: [],
+      charts: [],
     };
   }
 
@@ -32,54 +78,46 @@ class AnswerDistributionPanels extends Component {
   }
 
   loadData() {
-    const { entityName, entityType, variableDefinition } = this.props;
+    const { variableRegistry } = this.props;
+    const nodeRegistry = transposedRegistry(variableRegistry).node || {};
+    const variableNames = Object.values(nodeRegistry).reduce((acc, nodeTypeDefinition) => {
+      acc.push(...Object.keys(nodeTypeDefinition.variables || {}));
+      return acc;
+    }, []);
+
     const route = `/protocols/${this.props.protocolId}/reports/option_buckets`;
-    const query = { variableName: variableDefinition.name };
-    if (entityName && entityType) {
-      query.entityName = entityName;
-      query.entityType = entityType;
-    }
+    const query = { variableNames };
+
     this.props.apiClient.get(route, query)
       .then(({ buckets }) => {
-        const data = buckets[entityType] && buckets[entityType][variableDefinition.name];
-        if (data && Object.keys(data).length) {
-          // Provide data for every ordinal option, even if one has no data
-          this.setState({
-            chartData: variableDefinition.options.map(({ label, value = '' }) => ({
-              name: label,
-              value: data[value.toString()] || 0,
-            })),
-          });
-        } else {
-          this.setState({ chartData: [] });
-        }
+        this.setState({
+          charts: shapeBucketData(nodeRegistry, buckets),
+        });
       });
   }
 
   render() {
-    const { chartData } = this.state;
-    const { variableType, variableDefinition } = this.props;
-    const panelProps = { chartData, variableType, variableDefinition };
-    // TODO: render one per variable
-    return (
-      <AnswerDistributionPanel {...panelProps} />
-    );
+    return this.state.charts.map(chart => (
+      <AnswerDistributionPanel
+        key={`${chart.variableType}-${chart.entityType}-${chart.variableDefinition.name}`}
+        chartData={chart.chartData}
+        variableType={chart.variableType}
+        variableDefinition={chart.variableDefinition}
+      />
+    ));
   }
 }
 
 AnswerDistributionPanels.defaultProps = {
   apiClient: null,
-  entityName: 'node',
-  entityType: null,
   sessionCount: null,
 };
 
 AnswerDistributionPanels.propTypes = {
   apiClient: PropTypes.object,
-  entityName: Types.entityName,
-  entityType: PropTypes.string,
   protocolId: PropTypes.string.isRequired,
   sessionCount: PropTypes.number,
+  variableRegistry: Types.variableRegistry.isRequired,
 };
 
 export default withApiClient(AnswerDistributionPanels);

--- a/src/renderer/containers/AnswerDistributionPanels.js
+++ b/src/renderer/containers/AnswerDistributionPanels.js
@@ -4,10 +4,12 @@ import { connect } from 'react-redux';
 
 import withApiClient from '../components/withApiClient';
 import AnswerDistributionPanel from '../components/AnswerDistributionPanel';
-import { selectors } from '../ducks/modules/protocols';
+import { selectors as protocolSelectors } from '../ducks/modules/protocols';
+import { selectors as variableSelectors } from '../ducks/modules/excludedChartVariables';
 import Types from '../types';
 
-const isDistributionVariable = selectors.isDistributionVariable;
+const { isDistributionVariable } = protocolSelectors;
+const { excludedVariablesForCurrentProtocol } = variableSelectors;
 
 const hasData = bucket => bucket && Object.keys(bucket).length > 0;
 
@@ -111,8 +113,8 @@ class AnswerDistributionPanels extends Component {
   }
 }
 
-const mapStateToProps = state => ({
-  excludedChartVariables: state.excludedChartVariables,
+const mapStateToProps = (state, ownProps) => ({
+  excludedChartVariables: excludedVariablesForCurrentProtocol(state, ownProps),
 });
 
 AnswerDistributionPanels.defaultProps = {

--- a/src/renderer/containers/AnswerDistributionPanels.js
+++ b/src/renderer/containers/AnswerDistributionPanels.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import withApiClient from '../components/withApiClient';
 import AnswerDistributionPanel from '../components/AnswerDistributionPanel';
-import { transposedRegistry } from '../../main/utils/formatters/network'; // TODO: move
 import Types from '../types';
 
 const hasData = bucket => bucket && Object.keys(bucket).length > 0;
@@ -19,7 +18,7 @@ const hasData = bucket => bucket && Object.keys(bucket).length > 0;
  *
  * @private
  *
- * @param {Object} transposedNodeRegistry `variableRegistry.node`, with transposed names
+ * @param {Object} transposedNodeRegistry `transposedRegistry.node`, with transposed names
  * @param {Object} buckets The API response from `option_buckets`
  * @return {Array} chartDefinitions
  */
@@ -78,8 +77,7 @@ class AnswerDistributionPanels extends Component {
   }
 
   loadData() {
-    const { variableRegistry } = this.props;
-    const nodeRegistry = transposedRegistry(variableRegistry).node || {};
+    const { transposedRegistry: { node: nodeRegistry = {} } } = this.props;
     const variableNames = Object.values(nodeRegistry).reduce((acc, nodeTypeDefinition) => {
       acc.push(...Object.keys(nodeTypeDefinition.variables || {}));
       return acc;
@@ -117,7 +115,7 @@ AnswerDistributionPanels.propTypes = {
   apiClient: PropTypes.object,
   protocolId: PropTypes.string.isRequired,
   sessionCount: PropTypes.number,
-  variableRegistry: Types.variableRegistry.isRequired,
+  transposedRegistry: Types.variableRegistry.isRequired,
 };
 
 export default withApiClient(AnswerDistributionPanels);

--- a/src/renderer/containers/AnswerDistributionPanels.js
+++ b/src/renderer/containers/AnswerDistributionPanels.js
@@ -2,18 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import withApiClient from '../components/withApiClient';
+import AnswerDistributionPanel from '../components/AnswerDistributionPanel';
 import Types from '../types';
-import { BarChart, EmptyData, PieChart } from '../components';
-
-const chartComponent = variableType => ((variableType === 'categorical') ? PieChart : BarChart);
-
-const headerLabel = variableType => ((variableType === 'categorical') ? 'Categorical' : 'Ordinal');
 
 /**
- * Depending on variableType, renders either a pie chart with a distribution of categorical
- * node attributes, or a Bar chart with a distribution of ordinal attributes.
+ * Renders a collection of ordinal & categorical distribution panels
  */
-class AnswerDistributionPanel extends Component {
+class AnswerDistributionPanels extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -64,42 +59,27 @@ class AnswerDistributionPanel extends Component {
   render() {
     const { chartData } = this.state;
     const { variableType, variableDefinition } = this.props;
-    const Chart = chartComponent(variableType);
-    const header = headerLabel(variableType);
-    let content;
-    if (chartData.length) {
-      content = <Chart allowDecimals={false} data={chartData} dataKeys={['value']} />;
-    } else {
-      content = <EmptyData />;
-    }
+    const panelProps = { chartData, variableType, variableDefinition };
+    // TODO: render one per variable
     return (
-      <div className="dashboard__panel dashboard__panel--chart">
-        <h4 className="dashboard__header-text">
-          {header} distribution: {variableDefinition.label}
-        </h4>
-        <div className="dashboard__chartContainer">
-          {content}
-        </div>
-      </div>
+      <AnswerDistributionPanel {...panelProps} />
     );
   }
 }
 
-AnswerDistributionPanel.defaultProps = {
+AnswerDistributionPanels.defaultProps = {
   apiClient: null,
   entityName: 'node',
   entityType: null,
   sessionCount: null,
 };
 
-AnswerDistributionPanel.propTypes = {
+AnswerDistributionPanels.propTypes = {
   apiClient: PropTypes.object,
   entityName: Types.entityName,
   entityType: PropTypes.string,
   protocolId: PropTypes.string.isRequired,
   sessionCount: PropTypes.number,
-  variableDefinition: Types.variableDefinition.isRequired,
-  variableType: PropTypes.oneOf(['categorical', 'ordinal']).isRequired,
 };
 
-export default withApiClient(AnswerDistributionPanel);
+export default withApiClient(AnswerDistributionPanels);

--- a/src/renderer/containers/EntityTimeSeriesPanel.js
+++ b/src/renderer/containers/EntityTimeSeriesPanel.js
@@ -4,11 +4,30 @@ import PropTypes from 'prop-types';
 import { EmptyData, TimeSeriesChart } from '../components';
 import withApiClient from '../components/withApiClient';
 
+const pluckDataKeys = (timeSeriesKeys) => {
+  const allKeys = [];
+  const nodeSubtypes = timeSeriesKeys.filter(key => (/node_/).test(key));
+  const edgeSubtypes = timeSeriesKeys.filter(key => (/edge_/).test(key));
+  if (timeSeriesKeys.includes('node')) { allKeys.push('node'); }
+  if (timeSeriesKeys.includes('edge')) { allKeys.push('edge'); }
+  if (nodeSubtypes.length > 1) {
+    allKeys.push(...nodeSubtypes);
+  }
+  if (edgeSubtypes.length > 1) {
+    allKeys.push(...edgeSubtypes);
+  }
+  return allKeys;
+};
+
+/**
+ * Render a line chart with each entity type as a series
+ */
 class EntityTimeSeriesPanel extends Component {
   constructor(props) {
     super(props);
     this.state = {
       timeSeriesData: [],
+      timeSeriesKeys: [],
     };
   }
 
@@ -30,15 +49,15 @@ class EntityTimeSeriesPanel extends Component {
   loadData() {
     const route = `/protocols/${this.props.protocolId}/reports/entity_time_series`;
     this.props.apiClient.get(route)
-      .then(({ entities }) => entities && this.setState({
+      .then(({ entities, keys }) => entities && this.setState({
         timeSeriesData: entities,
+        timeSeriesKeys: keys,
       }));
   }
 
   render() {
-    // For now, just render node & edge counts
-    const dataKeys = ['node', 'edge'];
-    const { timeSeriesData } = this.state;
+    const { timeSeriesData, timeSeriesKeys } = this.state;
+    const dataKeys = pluckDataKeys(timeSeriesKeys);
     let content;
     if (timeSeriesData.length > 0) {
       content = <TimeSeriesChart data={this.state.timeSeriesData} dataKeys={dataKeys} />;

--- a/src/renderer/containers/SettingsScreen.js
+++ b/src/renderer/containers/SettingsScreen.js
@@ -6,8 +6,8 @@ import { Redirect } from 'react-router-dom';
 
 import Types from '../types';
 import CheckboxGroup from '../ui/components/Fields/CheckboxGroup';
-import { actionCreators, selectors } from '../ducks/modules/protocols';
-import { actionCreators as chartActionCreators } from '../ducks/modules/excludedChartVariables';
+import { actionCreators, selectors as protocolSelectors } from '../ducks/modules/protocols';
+import { actionCreators as chartActionCreators, selectors as chartSelectors } from '../ducks/modules/excludedChartVariables';
 import { Button, Spinner } from '../ui';
 
 class SettingsScreen extends Component {
@@ -19,7 +19,7 @@ class SettingsScreen extends Component {
   }
 
   get chartConfigSection() {
-    const { distributionVariables, setExcludedVariables } = this.props;
+    const { distributionVariables, protocol, setExcludedVariables } = this.props;
     if (!Object.keys(distributionVariables).length) {
       return null;
     }
@@ -41,7 +41,8 @@ class SettingsScreen extends Component {
                 input={{
                   value: this.includedChartVariablesForSection(section),
                   onChange: (newValue) => {
-                    setExcludedVariables(section, vars.filter(v => !newValue.includes(v)));
+                    const newExcluded = vars.filter(v => !newValue.includes(v));
+                    setExcludedVariables(protocol.id, section, newExcluded);
                   },
                 }}
                 options={vars.map(v => ({ value: v, label: v }))}
@@ -103,10 +104,10 @@ class SettingsScreen extends Component {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  excludedChartVariables: state.excludedChartVariables,
-  protocolsHaveLoaded: selectors.protocolsHaveLoaded(state),
-  protocol: selectors.currentProtocol(state, ownProps),
-  distributionVariables: selectors.ordinalAndCategoricalVariables(state, ownProps),
+  excludedChartVariables: chartSelectors.excludedVariablesForCurrentProtocol(state, ownProps),
+  protocolsHaveLoaded: protocolSelectors.protocolsHaveLoaded(state),
+  protocol: protocolSelectors.currentProtocol(state, ownProps),
+  distributionVariables: protocolSelectors.ordinalAndCategoricalVariables(state, ownProps),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/renderer/containers/WorkspaceScreen.js
+++ b/src/renderer/containers/WorkspaceScreen.js
@@ -7,7 +7,7 @@ import { ipcRenderer } from 'electron';
 import Types from '../types';
 import InterviewStatsPanel from './InterviewStatsPanel';
 import ProtocolCountsPanel from './ProtocolCountsPanel';
-import AnswerDistributionPanel from './AnswerDistributionPanel';
+import AnswerDistributionPanels from './AnswerDistributionPanels';
 import EntityTimeSeriesPanel from './EntityTimeSeriesPanel';
 import withApiClient from '../components/withApiClient';
 import viewModelMapper from '../utils/baseViewModelMapper';
@@ -99,7 +99,7 @@ class WorkspaceScreen extends Component {
 
     if (ordinalDefinition) {
       content.push(
-        <AnswerDistributionPanel
+        <AnswerDistributionPanels
           variableType="ordinal"
           key="ordinal-panel"
           protocolId={protocol.id}
@@ -112,7 +112,7 @@ class WorkspaceScreen extends Component {
 
     if (categoricalDefinition) {
       content.push(
-        <AnswerDistributionPanel
+        <AnswerDistributionPanels
           variableType="categorical"
           key="cagtegorical-panel"
           protocolId={protocol.id}

--- a/src/renderer/containers/WorkspaceScreen.js
+++ b/src/renderer/containers/WorkspaceScreen.js
@@ -11,7 +11,6 @@ import AnswerDistributionPanels from './AnswerDistributionPanels';
 import EntityTimeSeriesPanel from './EntityTimeSeriesPanel';
 import withApiClient from '../components/withApiClient';
 import viewModelMapper from '../utils/baseViewModelMapper';
-import { transposedRegistry } from '../../main/utils/formatters/network'; // TODO: move
 import { Spinner } from '../ui';
 import { selectors } from '../ducks/modules/protocols';
 import {
@@ -65,66 +64,6 @@ class WorkspaceScreen extends Component {
     return id && `/protocols/${id}/sessions`;
   }
 
-  get answerDistributionCharts() {
-    const content = [];
-    let categoricalDefinition = null;
-    let categoricalEntityType = null;
-    let ordinalDefinition = null;
-    let ordinalEntityType = null;
-
-    const { totalSessionsCount } = this.state;
-    const { protocol } = this.props;
-    const variableRegistry = transposedRegistry(protocol.variableRegistry);
-    const nodeDefinitions = Object.values(variableRegistry.node || {});
-
-    let entityType;
-    // Ordinal: default to the first ordinal variable found in the registry
-    // TODO: allow user to select entityType used
-    // TODO: select from edges as well, once supported by NC
-    entityType = nodeDefinitions.find((typeDefinition) => {
-      ordinalDefinition = Object.values(typeDefinition.variables)
-        .find(variable => variable.type === 'ordinal');
-      return !!ordinalDefinition;
-    });
-    ordinalEntityType = entityType && entityType.name;
-
-    // Categorical: default to the first categorical node variable
-    // TODO: allow user to select entityType used
-    entityType = nodeDefinitions.find((typeDefinition) => {
-      categoricalDefinition = Object.values(typeDefinition.variables)
-        .find(variable => variable.type === 'categorical');
-      return !!categoricalDefinition;
-    });
-    categoricalEntityType = entityType && entityType.name;
-
-    if (ordinalDefinition) {
-      content.push(
-        <AnswerDistributionPanels
-          variableType="ordinal"
-          key="ordinal-panel"
-          protocolId={protocol.id}
-          variableDefinition={ordinalDefinition}
-          entityName="node"
-          entityType={ordinalEntityType}
-          sessionCount={totalSessionsCount}
-        />);
-    }
-
-    if (categoricalDefinition) {
-      content.push(
-        <AnswerDistributionPanels
-          variableType="categorical"
-          key="cagtegorical-panel"
-          protocolId={protocol.id}
-          variableDefinition={categoricalDefinition}
-          entityType={categoricalEntityType}
-          sessionCount={totalSessionsCount}
-        />);
-    }
-
-    return content;
-  }
-
   sessionEndpoint(sessionId) {
     const base = this.sessionsEndpoint;
     return base && `${base}/${sessionId}`;
@@ -175,8 +114,6 @@ class WorkspaceScreen extends Component {
           <ServerPanel className="dashboard__panel dashboard__panel--server-stats" />
           <ProtocolPanel protocol={protocol} />
 
-          { this.answerDistributionCharts }
-
           <ProtocolCountsPanel
             key={`protocol-counts-${protocol.id}`}
             protocolId={protocol.id}
@@ -200,6 +137,12 @@ class WorkspaceScreen extends Component {
             sessions &&
               <EntityTimeSeriesPanel protocolId={protocol.id} sessionCount={totalSessionsCount} />
           }
+
+          <AnswerDistributionPanels
+            protocolId={protocol.id}
+            sessionCount={totalSessionsCount}
+            variableRegistry={protocol.variableRegistry}
+          />
         </div>
       </div>
     );

--- a/src/renderer/containers/WorkspaceScreen.js
+++ b/src/renderer/containers/WorkspaceScreen.js
@@ -102,7 +102,7 @@ class WorkspaceScreen extends Component {
   }
 
   render() {
-    const { protocol } = this.props;
+    const { protocol, transposedRegistry } = this.props;
     const { sessions, totalSessionsCount } = this.state;
     if (!protocol || !sessions) {
       return <div className="workspace--loading"><Spinner /></div>;
@@ -141,7 +141,7 @@ class WorkspaceScreen extends Component {
           <AnswerDistributionPanels
             protocolId={protocol.id}
             sessionCount={totalSessionsCount}
-            variableRegistry={protocol.variableRegistry}
+            transposedRegistry={transposedRegistry}
           />
         </div>
       </div>
@@ -151,6 +151,7 @@ class WorkspaceScreen extends Component {
 
 const mapStateToProps = (state, ownProps) => ({
   protocol: selectors.currentProtocol(state, ownProps),
+  transposedRegistry: selectors.transposedRegistry(state, ownProps),
 });
 
 WorkspaceScreen.defaultProps = {
@@ -160,6 +161,7 @@ WorkspaceScreen.defaultProps = {
 WorkspaceScreen.propTypes = {
   apiClient: PropTypes.object.isRequired,
   protocol: Types.protocol,
+  transposedRegistry: Types.variableRegistry.isRequired,
 };
 
 export default connect(mapStateToProps)(withApiClient(WorkspaceScreen));

--- a/src/renderer/containers/__tests__/AnswerDistributionPanel-test.js
+++ b/src/renderer/containers/__tests__/AnswerDistributionPanel-test.js
@@ -8,7 +8,9 @@ import AdminApiClient from '../../utils/adminApiClient';
 jest.mock('recharts');
 jest.mock('../../utils/adminApiClient', () => {
   function MockApiClient() {}
-  MockApiClient.prototype.get = jest.fn().mockResolvedValue({ buckets: { 1: 4, 2: 5 } });
+  MockApiClient.prototype.get = jest.fn().mockResolvedValue({
+    buckets: { person: { distributionVariable: { 1: 4, 2: 5 } } },
+  });
   return MockApiClient;
 });
 
@@ -30,7 +32,7 @@ describe('AnswerDistributionPanel', () => {
       entityName: 'node',
       variableDefinition: {
         label: '',
-        name: '',
+        name: 'distributionVariable',
         options: [
           { label: 'a', value: 1 },
           { label: 'b', value: 2 },

--- a/src/renderer/containers/__tests__/AnswerDistributionPanels-test.js
+++ b/src/renderer/containers/__tests__/AnswerDistributionPanels-test.js
@@ -27,14 +27,12 @@ describe('AnswerDistributionPanels', () => {
   beforeEach(() => {
     props = {
       protocolId: '1',
-      variableRegistry: {
+      transposedRegistry: {
         node: {
           person: {
-            name: 'person',
             variables: {
               distributionVariable: {
                 label: '',
-                name: 'distributionVariable',
                 type: 'ordinal',
                 options: [
                   { label: 'a', value: 1 },

--- a/src/renderer/containers/__tests__/AnswerDistributionPanels-test.js
+++ b/src/renderer/containers/__tests__/AnswerDistributionPanels-test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import React from 'react';
 import { mount, shallow } from 'enzyme';
-import AnswerDistributionPanels from '../AnswerDistributionPanels';
+import { UnconnectedAnswerDistributionPanels as AnswerDistributionPanels } from '../AnswerDistributionPanels';
 
 import AdminApiClient from '../../utils/adminApiClient';
 

--- a/src/renderer/containers/__tests__/AnswerDistributionPanels-test.js
+++ b/src/renderer/containers/__tests__/AnswerDistributionPanels-test.js
@@ -18,26 +18,33 @@ describe('AnswerDistributionPanels', () => {
   let props;
   let subject;
   let mockApiClient;
-  let variableType;
+  // let variableType;
 
-  beforeAll(() => {
-    variableType = 'categorical';
-  });
+  // beforeAll(() => {
+  //   variableType = 'categorical';
+  // });
 
   beforeEach(() => {
     props = {
-      variableType,
       protocolId: '1',
-      entityType: 'person',
-      entityName: 'node',
-      variableDefinition: {
-        label: '',
-        name: 'distributionVariable',
-        options: [
-          { label: 'a', value: 1 },
-          { label: 'b', value: 2 },
-          { label: 'c', value: 3 },
-        ],
+      variableRegistry: {
+        node: {
+          person: {
+            name: 'person',
+            variables: {
+              distributionVariable: {
+                label: '',
+                name: 'distributionVariable',
+                type: 'ordinal',
+                options: [
+                  { label: 'a', value: 1 },
+                  { label: 'b', value: 2 },
+                  { label: 'c', value: 3 },
+                ],
+              },
+            },
+          },
+        },
       },
     };
     mockApiClient = new AdminApiClient();
@@ -62,13 +69,18 @@ describe('AnswerDistributionPanels', () => {
       await subject.instance().loadData();
     });
 
+    it('renders one chart per variable', () => {
+      expect(subject.state('charts')).toHaveLength(1);
+    });
+
     it('sets correct data format', async () => {
-      expect(subject.state('chartData')).toContainEqual({ name: 'a', value: 4 });
-      expect(subject.state('chartData')).toContainEqual({ name: 'b', value: 5 });
+      const chart = subject.state('charts')[0];
+      expect(chart.chartData).toContainEqual({ name: 'a', value: 4 });
+      expect(chart.chartData).toContainEqual({ name: 'b', value: 5 });
     });
 
     it('sets zeros for missing values', async () => {
-      expect(subject.state('chartData')).toContainEqual({ name: 'c', value: 0 });
+      expect(subject.state('charts')[0].chartData).toContainEqual({ name: 'c', value: 0 });
     });
   });
 });

--- a/src/renderer/containers/__tests__/AnswerDistributionPanels-test.js
+++ b/src/renderer/containers/__tests__/AnswerDistributionPanels-test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import React from 'react';
 import { mount, shallow } from 'enzyme';
-import AnswerDistributionPanel from '../AnswerDistributionPanel';
+import AnswerDistributionPanels from '../AnswerDistributionPanels';
 
 import AdminApiClient from '../../utils/adminApiClient';
 
@@ -14,7 +14,7 @@ jest.mock('../../utils/adminApiClient', () => {
   return MockApiClient;
 });
 
-describe('AnswerDistributionPanel', () => {
+describe('AnswerDistributionPanels', () => {
   let props;
   let subject;
   let mockApiClient;
@@ -41,7 +41,7 @@ describe('AnswerDistributionPanel', () => {
       },
     };
     mockApiClient = new AdminApiClient();
-    subject = mount(<AnswerDistributionPanel {...props} />);
+    subject = mount(<AnswerDistributionPanels {...props} />);
   });
 
   it('loads data', () => {
@@ -56,37 +56,9 @@ describe('AnswerDistributionPanel', () => {
     expect(mockApiClient.get).toHaveBeenCalledTimes(1);
   });
 
-  it('renders an empty view before data loads', () => {
-    expect(subject.find('BarChart')).toHaveLength(0);
-    expect(subject.find('PieChart')).toHaveLength(0);
-    expect(subject.find('.dashboard__emptyData')).toHaveLength(1);
-  });
-
-  describe('for ordinal variables', () => {
-    beforeAll(() => {
-      variableType = 'ordinal';
-    });
-
-    it('renders a bar chart', () => {
-      subject.mount(); // wait for loaded data
-      expect(subject.find('BarChart')).toHaveLength(1);
-    });
-  });
-
-  describe('for categorical variables', () => {
-    beforeAll(() => {
-      variableType = 'categorical';
-    });
-
-    it('renders a pie chart', () => {
-      subject.mount(); // wait for loaded data
-      expect(subject.find('PieChart')).toHaveLength(1);
-    });
-  });
-
   describe('API handler', () => {
     beforeEach(async () => {
-      subject = shallow(<AnswerDistributionPanel {...props} />).dive();
+      subject = shallow(<AnswerDistributionPanels {...props} />).dive();
       await subject.instance().loadData();
     });
 

--- a/src/renderer/containers/__tests__/SettingsScreen-test.js
+++ b/src/renderer/containers/__tests__/SettingsScreen-test.js
@@ -7,12 +7,18 @@ import ConnectedSettingsScreen, { UnconnectedSettingsScreen as SettingsScreen } 
 
 describe('<SettingsScreen />', () => {
   const deleteProtocol = jest.fn();
+  const setExcludedVariables = jest.fn();
   const mockProtocol = { id: '1', name: '1', createdAt: new Date() };
   let subject;
 
   beforeEach(() => {
     const match = { params: { id: mockProtocol.id } };
-    const props = { match, deleteProtocol, protocolsHaveLoaded: true };
+    const props = {
+      match,
+      deleteProtocol,
+      protocolsHaveLoaded: true,
+      setExcludedVariables,
+    };
     subject = shallow(<SettingsScreen {...props} />);
   });
 
@@ -29,6 +35,22 @@ describe('<SettingsScreen />', () => {
   it('renders a delete button', () => {
     subject.setProps({ protocol: mockProtocol });
     expect(subject.find('Button')).toHaveLength(1);
+  });
+
+  it('renders checkboxes for chart variable selection', () => {
+    const distributionVariables = { person: ['catVar'] };
+    subject.setProps({ protocol: mockProtocol, distributionVariables });
+    expect(subject.find('CheckboxGroup')).toHaveLength(1);
+  });
+
+  it('updates excluded variables from checkbox input', () => {
+    const distributionVariables = { person: ['catVar'] };
+    subject.setProps({ protocol: mockProtocol, distributionVariables });
+    expect(setExcludedVariables).not.toHaveBeenCalled();
+    const checkboxes = subject.find('CheckboxGroup');
+    const input = checkboxes.dive().find('Checkbox').dive().find('input');
+    input.simulate('change', []);
+    expect(setExcludedVariables).toHaveBeenCalled();
   });
 
   describe('clicking delete', () => {

--- a/src/renderer/containers/__tests__/SettingsScreen-test.js
+++ b/src/renderer/containers/__tests__/SettingsScreen-test.js
@@ -74,7 +74,7 @@ describe('<SettingsScreen />', () => {
   describe('when connected', () => {
     it('sets protocol based on store state & URL match', () => {
       const mockStore = createStore(() => (
-        { protocols: [mockProtocol] }
+        { protocols: [mockProtocol], excludedChartVariables: {} }
       ));
       const subj = shallow((
         <ConnectedSettingsScreen

--- a/src/renderer/containers/__tests__/WorkspaceScreen-test.js
+++ b/src/renderer/containers/__tests__/WorkspaceScreen-test.js
@@ -8,6 +8,7 @@ import AdminApiClient from '../../utils/adminApiClient';
 import { mockProtocol } from '../../../../config/jest/setupTestEnv';
 
 jest.mock('electron-log');
+jest.mock('../AnswerDistributionPanels');
 jest.mock('../../utils/adminApiClient');
 jest.mock('../../components/withApiClient', () => component => component);
 
@@ -123,7 +124,7 @@ describe('<WorkspaceScreen />', () => {
       },
     };
 
-    it('renders an ordinal panel', () => {
+    it('renders a distribution panel if an ordinal is available', () => {
       protocol.variableRegistry.node.person.variables = {
         ord: { label: 'ord', name: 'ord', type: 'ordinal' },
       };
@@ -131,10 +132,9 @@ describe('<WorkspaceScreen />', () => {
       wrapper.setProps({ protocol });
       const panel = wrapper.find('AnswerDistributionPanels');
       expect(panel).toHaveLength(1);
-      expect(panel.prop('variableType')).toEqual('ordinal');
     });
 
-    it('renders a categorical panel', () => {
+    it('renders a distribution panel if a categorical is available', () => {
       protocol.variableRegistry.node.person.variables = {
         cat: { label: 'cat', name: 'cat', type: 'categorical' },
       };
@@ -142,7 +142,6 @@ describe('<WorkspaceScreen />', () => {
       wrapper.setProps({ protocol });
       const panel = wrapper.find('AnswerDistributionPanels');
       expect(panel).toHaveLength(1);
-      expect(panel.prop('variableType')).toEqual('categorical');
     });
 
     it('sets sessionCount to drive updates', () => {

--- a/src/renderer/containers/__tests__/WorkspaceScreen-test.js
+++ b/src/renderer/containers/__tests__/WorkspaceScreen-test.js
@@ -8,7 +8,7 @@ import AdminApiClient from '../../utils/adminApiClient';
 import { mockProtocol } from '../../../../config/jest/setupTestEnv';
 
 jest.mock('electron-log');
-jest.mock('../AnswerDistributionPanels');
+jest.mock('../AnswerDistributionPanels', () => 'AnswerDistributionPanels');
 jest.mock('../../utils/adminApiClient');
 jest.mock('../../components/withApiClient', () => component => component);
 
@@ -113,6 +113,7 @@ describe('<WorkspaceScreen />', () => {
   });
 
   describe('with a distribution variable', () => {
+    const panelSelector = 'AnswerDistributionPanels';
     const protocol = {
       ...mockProtocol,
       variableRegistry: {
@@ -131,8 +132,7 @@ describe('<WorkspaceScreen />', () => {
       };
       wrapper.setState({ sessions: [{}] });
       wrapper.setProps({ protocol });
-      const panel = wrapper.find('AnswerDistributionPanels');
-      expect(panel).toHaveLength(1);
+      expect(wrapper.find(panelSelector)).toHaveLength(1);
     });
 
     it('renders a distribution panel if a categorical is available', () => {
@@ -141,14 +141,13 @@ describe('<WorkspaceScreen />', () => {
       };
       wrapper.setState({ sessions: [{}] });
       wrapper.setProps({ protocol });
-      const panel = wrapper.find('AnswerDistributionPanels');
-      expect(panel).toHaveLength(1);
+      expect(wrapper.find(panelSelector)).toHaveLength(1);
     });
 
     it('sets sessionCount to drive updates', () => {
       wrapper.setState({ sessions: [{}, {}], totalSessionsCount: 2 });
       wrapper.setProps({ protocol });
-      expect(wrapper.find('AnswerDistributionPanels').prop('sessionCount')).toEqual(2);
+      expect(wrapper.find(panelSelector).prop('sessionCount')).toEqual(2);
     });
   });
 

--- a/src/renderer/containers/__tests__/WorkspaceScreen-test.js
+++ b/src/renderer/containers/__tests__/WorkspaceScreen-test.js
@@ -23,6 +23,7 @@ describe('<WorkspaceScreen />', () => {
       <WorkspaceScreen
         apiClient={mockApiClient}
         match={{ params: { id: 1 } }}
+        transposedRegistry={{ node: {} }}
       />
     ));
   });

--- a/src/renderer/containers/__tests__/WorkspaceScreen-test.js
+++ b/src/renderer/containers/__tests__/WorkspaceScreen-test.js
@@ -129,7 +129,7 @@ describe('<WorkspaceScreen />', () => {
       };
       wrapper.setState({ sessions: [{}] });
       wrapper.setProps({ protocol });
-      const panel = wrapper.find('AnswerDistributionPanel');
+      const panel = wrapper.find('AnswerDistributionPanels');
       expect(panel).toHaveLength(1);
       expect(panel.prop('variableType')).toEqual('ordinal');
     });
@@ -140,7 +140,7 @@ describe('<WorkspaceScreen />', () => {
       };
       wrapper.setState({ sessions: [{}] });
       wrapper.setProps({ protocol });
-      const panel = wrapper.find('AnswerDistributionPanel');
+      const panel = wrapper.find('AnswerDistributionPanels');
       expect(panel).toHaveLength(1);
       expect(panel.prop('variableType')).toEqual('categorical');
     });
@@ -148,7 +148,7 @@ describe('<WorkspaceScreen />', () => {
     it('sets sessionCount to drive updates', () => {
       wrapper.setState({ sessions: [{}, {}], totalSessionsCount: 2 });
       wrapper.setProps({ protocol });
-      expect(wrapper.find('AnswerDistributionPanel').prop('sessionCount')).toEqual(2);
+      expect(wrapper.find('AnswerDistributionPanels').prop('sessionCount')).toEqual(2);
     });
   });
 

--- a/src/renderer/ducks/modules/__tests__/excludedChartVariables-test.js
+++ b/src/renderer/ducks/modules/__tests__/excludedChartVariables-test.js
@@ -1,34 +1,70 @@
 /* eslint-env jest */
-import reducer, { actionCreators, actionTypes } from '../excludedChartVariables';
+import reducer, { actionCreators, actionTypes, selectors } from '../excludedChartVariables';
 
 jest.mock('../../../utils/adminApiClient');
+jest.mock('../protocols', () => ({
+  selectors: {
+    currentProtocol: jest.fn().mockReturnValue({ id: '1' }),
+  },
+}));
 
 describe('excludedChartVariables', () => {
   describe('reducer', () => {
     it('returns an empty initial state', () => {
-      expect(reducer()).toEqual({});
+      expect(reducer({})).toEqual({});
     });
 
-    it('returns a new state with excluded variables', () => {
+    it('partitons state by protocol ID', () => {
+      const action = {
+        type: actionTypes.SET_EXCLUDED_VARIABLES,
+        protocolId: 'protocol1',
+        section: 'person',
+        variables: ['someVar'],
+      };
+      expect(reducer({}, action)).toHaveProperty('protocol1');
+    });
+
+    it('returns current state if no protocol ID given', () => {
       const action = {
         type: actionTypes.SET_EXCLUDED_VARIABLES,
         section: 'person',
         variables: ['someVar'],
       };
+      expect(reducer({}, action)).toEqual({});
+    });
+
+    it('returns a new state with excluded variables', () => {
+      const action = {
+        type: actionTypes.SET_EXCLUDED_VARIABLES,
+        protocolId: '1',
+        section: 'person',
+        variables: ['someVar'],
+      };
       expect(reducer({}, action)).toEqual({
-        person: ['someVar'],
+        1: { person: ['someVar'] },
       });
     });
   });
 
-  describe('setExcludedVariables', () => {
+  describe('setExcludedVariables action creator', () => {
     it('produces an exclude action', () => {
-      const action = actionCreators.setExcludedVariables('person', ['someVar']);
+      const action = actionCreators.setExcludedVariables('1', 'person', ['someVar']);
       expect(action).toEqual({
         type: actionTypes.SET_EXCLUDED_VARIABLES,
+        protocolId: '1',
         section: 'person',
         variables: ['someVar'],
       });
+    });
+  });
+
+  describe('excludedVariablesForCurrentProtocol selector', () => {
+    const { excludedVariablesForCurrentProtocol } = selectors;
+    it('returns variables for the protocol', () => {
+      const excludedChartVariables = { 1: { person: ['someVar'] } };
+      const state = { protocols: [{ id: '1' }], excludedChartVariables };
+      const props = { match: { params: { id: '1' } } };
+      expect(excludedVariablesForCurrentProtocol(state, props)).toEqual({ person: ['someVar'] });
     });
   });
 });

--- a/src/renderer/ducks/modules/__tests__/excludedChartVariables-test.js
+++ b/src/renderer/ducks/modules/__tests__/excludedChartVariables-test.js
@@ -1,0 +1,35 @@
+/* eslint-env jest */
+import reducer, { actionCreators, actionTypes } from '../excludedChartVariables';
+
+jest.mock('../../../utils/adminApiClient');
+
+describe('excludedChartVariables', () => {
+  describe('reducer', () => {
+    it('returns an empty initial state', () => {
+      expect(reducer()).toEqual({});
+    });
+
+    it('returns a new state with excluded variables', () => {
+      const action = {
+        type: actionTypes.SET_EXCLUDED_VARIABLES,
+        section: 'person',
+        variables: ['someVar'],
+      };
+      expect(reducer({}, action)).toEqual({
+        person: ['someVar'],
+      });
+    });
+  });
+
+  describe('setExcludedVariables', () => {
+    it('produces an exclude action', () => {
+      const action = actionCreators.setExcludedVariables('person', ['someVar']);
+      expect(action).toEqual({
+        type: actionTypes.SET_EXCLUDED_VARIABLES,
+        section: 'person',
+        variables: ['someVar'],
+      });
+    });
+  });
+});
+

--- a/src/renderer/ducks/modules/__tests__/protocols-test.js
+++ b/src/renderer/ducks/modules/__tests__/protocols-test.js
@@ -97,13 +97,63 @@ describe('the protocols module', () => {
   });
 
   describe('selectors', () => {
-    const { currentProtocol, protocolsHaveLoaded, transposedRegistry } = selectors;
+    const {
+      currentProtocol,
+      isDistributionVariable,
+      ordinalAndCategoricalVariables,
+      protocolsHaveLoaded,
+      transposedRegistry,
+    } = selectors;
 
     describe('currentProtocol', () => {
       it('returns the current protocol object', () => {
         const state = { protocols: [{ id: '1' }] };
         const props = { match: { params: { id: '1' } } };
         expect(currentProtocol(state, props)).toEqual(state.protocols[0]);
+      });
+    });
+
+    describe('isDistributionVariable', () => {
+      it('returns true for categorical variables', () => {
+        expect(isDistributionVariable({ type: 'ordinal' })).toBe(true);
+      });
+
+      it('returns true for ordinal variables', () => {
+        expect(isDistributionVariable({ type: 'categorical' })).toBe(true);
+      });
+
+      it('returns false by default', () => {
+        expect(isDistributionVariable({})).toBe(false);
+      });
+    });
+
+    describe('ordinalAndCategoricalVariables', () => {
+      it('returns node variable names sectioned by entity type', () => {
+        const variableRegistry = {
+          node: { 'node-type-id': { name: 'person', variables: { 'var-id-1': { name: 'catVar', type: 'categorical' } } } },
+        };
+        const state = { protocols: [{ id: '1', variableRegistry }] };
+        const props = { match: { params: { id: '1' } } };
+        expect(ordinalAndCategoricalVariables(state, props)).toEqual({ person: ['catVar'] });
+      });
+
+      it('ignores sections without these variables', () => {
+        const variableRegistry = {
+          node: { 'node-type-id': { name: 'venue', variables: { 'var-id-1': { name: 'intVar', type: 'number' } } } },
+        };
+        const state = { protocols: [{ id: '1', variableRegistry }] };
+        const props = { match: { params: { id: '1' } } };
+        expect(ordinalAndCategoricalVariables(state, props)).not.toHaveProperty('venue');
+      });
+
+      it('returns an empty object if node registry unavailable', () => {
+        const state = { protocols: [{ id: '1', variableRegistry: {} }] };
+        const props = { match: { params: { id: '1' } } };
+        expect(ordinalAndCategoricalVariables(state, props)).toEqual({});
+      });
+
+      it('returns an empty object if protocol unavailable', () => {
+        expect(ordinalAndCategoricalVariables({}, {})).toEqual({});
       });
     });
 

--- a/src/renderer/ducks/modules/excludedChartVariables.js
+++ b/src/renderer/ducks/modules/excludedChartVariables.js
@@ -1,0 +1,54 @@
+/**
+ * @module excludedChartVariables
+ *
+ * @description
+ * Allows the user to hide certain ordinal/variable charts from a protocol's Overview display.
+ * These are user settings and should be persisted.
+ *
+ * State shape is sectioned by entity type:
+ * ```
+ * {
+ *   [entityType]: [variableName1, variableName2]
+ * }
+ * ```
+ */
+
+const SET_EXCLUDED_VARIABLES = 'SET_EXCLUDED_VARIABLES';
+
+const initialState = {};
+
+const reducer = (state = initialState, action = {}) => {
+  switch (action.type) {
+    case SET_EXCLUDED_VARIABLES:
+      return { ...state, [action.section]: action.variables };
+    default:
+      return state;
+  }
+};
+
+/**
+ * @memberof module:excludedChartVariables
+ * @param {string} section corresponds to an entity (node) type
+ * @param {Array} variables list of variable names to exclude
+ * @return {Object} excluded variable names, sectioned by entity type
+ */
+const setExcludedVariables = (section, variables) => ({
+  type: SET_EXCLUDED_VARIABLES,
+  section,
+  variables,
+});
+
+const actionCreators = {
+  setExcludedVariables,
+};
+
+const actionTypes = {
+  SET_EXCLUDED_VARIABLES,
+};
+
+export {
+  actionCreators,
+  actionTypes,
+};
+
+export default reducer;

--- a/src/renderer/ducks/modules/excludedChartVariables.js
+++ b/src/renderer/ducks/modules/excludedChartVariables.js
@@ -1,3 +1,5 @@
+import { selectors as protocolSelectors } from './protocols';
+
 /**
  * @module excludedChartVariables
  *
@@ -5,10 +7,12 @@
  * Allows the user to hide certain ordinal/variable charts from a protocol's Overview display.
  * These are user settings and should be persisted.
  *
- * State shape is sectioned by entity type:
+ * State shape is sectioned by protocol ID and entity type:
  * ```
  * {
- *   [entityType]: [variableName1, variableName2]
+ *   [protocolId]: {
+ *     [entityType]: [variableName1, variableName2]
+ *   }
  * }
  * ```
  */
@@ -19,8 +23,14 @@ const initialState = {};
 
 const reducer = (state = initialState, action = {}) => {
   switch (action.type) {
-    case SET_EXCLUDED_VARIABLES:
-      return { ...state, [action.section]: action.variables };
+    case SET_EXCLUDED_VARIABLES: {
+      const protocolId = action.protocolId;
+      if (!protocolId) {
+        return state;
+      }
+      const protocolState = { ...state[protocolId], [action.section]: action.variables };
+      return { ...state, [protocolId]: protocolState };
+    }
     default:
       return state;
   }
@@ -32,11 +42,17 @@ const reducer = (state = initialState, action = {}) => {
  * @param {Array} variables list of variable names to exclude
  * @return {Object} excluded variable names, sectioned by entity type
  */
-const setExcludedVariables = (section, variables) => ({
+const setExcludedVariables = (protocolId, section, variables) => ({
   type: SET_EXCLUDED_VARIABLES,
+  protocolId,
   section,
   variables,
 });
+
+const excludedVariablesForCurrentProtocol = (state, props) => {
+  const protocol = protocolSelectors.currentProtocol(state, props);
+  return protocol && state.excludedChartVariables[protocol.id];
+};
 
 const actionCreators = {
   setExcludedVariables,
@@ -46,9 +62,14 @@ const actionTypes = {
   SET_EXCLUDED_VARIABLES,
 };
 
+const selectors = {
+  excludedVariablesForCurrentProtocol,
+};
+
 export {
   actionCreators,
   actionTypes,
+  selectors,
 };
 
 export default reducer;

--- a/src/renderer/ducks/modules/protocols.js
+++ b/src/renderer/ducks/modules/protocols.js
@@ -33,9 +33,10 @@ const reducer = (state = initialState, action = {}) => {
   }
 };
 
+// Select the current protocol based either on a `protocolId` prop or 'id' in the routing params
 const currentProtocol = (state, props) => {
   const protocols = state.protocols;
-  const id = props.match && props.match.params.id;
+  const id = props.protocolId || (props.match && props.match.params.id);
   return protocols && id && protocols.find(p => p.id === id);
 };
 

--- a/src/renderer/ducks/modules/protocols.js
+++ b/src/renderer/ducks/modules/protocols.js
@@ -44,7 +44,7 @@ const currentProtocol = (state, props) => {
 const transposedRegistry = (state, props) => {
   const protocol = currentProtocol(state, props);
   if (!protocol) {
-    return null;
+    return {};
   }
 
   const registry = protocol.variableRegistry || {};
@@ -52,6 +52,31 @@ const transposedRegistry = (state, props) => {
     edge: transposedRegistrySection(registry.edge),
     node: transposedRegistrySection(registry.node),
   };
+};
+
+const distributionVariableTypes = ['ordinal', 'categorical'];
+const isDistributionVariable = variable => distributionVariableTypes.includes(variable.type);
+
+/**
+ * @return {Object} all node ordinal & categorical variable names, sectioned by node type
+ */
+const ordinalAndCategoricalVariables = (state, props) => {
+  const registry = transposedRegistry(state, props);
+  if (!registry) {
+    return {};
+  }
+  return Object.entries(registry.node || {}).reduce((acc, [entityType, { variables }]) => {
+    const variableNames = Object.entries(variables).reduce((arr, [variableName, variable]) => {
+      if (isDistributionVariable(variable)) {
+        arr.push(variableName);
+      }
+      return arr;
+    }, []);
+    if (variableNames.length) {
+      acc[entityType] = variableNames;
+    }
+    return acc;
+  }, {});
 };
 
 const protocolsHaveLoaded = state => state.protocols !== initialState;
@@ -104,8 +129,10 @@ const actionTypes = {
 
 const selectors = {
   currentProtocol,
+  isDistributionVariable,
   protocolsHaveLoaded,
   transposedRegistry,
+  ordinalAndCategoricalVariables,
 };
 
 export {

--- a/src/renderer/ducks/modules/rootReducer.js
+++ b/src/renderer/ducks/modules/rootReducer.js
@@ -3,6 +3,7 @@ import { combineReducers } from 'redux';
 import appMessages from './appMessages';
 import connectionInfo from './connectionInfo';
 import devices from './devices';
+import excludedChartVariables from './excludedChartVariables';
 import pairingRequest from './pairingRequest';
 import protocols from './protocols';
 
@@ -10,6 +11,7 @@ const appReducer = combineReducers({
   appMessages,
   connectionInfo,
   devices,
+  excludedChartVariables,
   pairingRequest,
   protocols,
 });

--- a/src/renderer/ducks/store.js
+++ b/src/renderer/ducks/store.js
@@ -16,8 +16,7 @@ export const store = createStore(
   ),
 );
 
-// TODO: remove redux-persist, or use for settings
 export const persistor = persistStore(
   store,
-  { whitelist: [] },
+  { whitelist: ['excludedChartVariables'] },
 );

--- a/src/renderer/styles/_variables.scss
+++ b/src/renderer/styles/_variables.scss
@@ -2,6 +2,7 @@
   // Colors
   --base-background-color: var(--color-platinum);
   --base-border-color: var(--color-platinum--dark);
+  --dashboard-panel-accent-color: var(--color-sea-serpent);
   --inverse-background-color: var(--color-navy-taupe);
   --inverse-text-color: var(--color-white);
   --message-background-color: var(--color-sea-green--dark);
@@ -22,4 +23,5 @@
   --app-sidebar-width: 9rem;
   --app-titlebar-height: 22px;
   --modal-window-padding: #{spacing(huge)};
+  --dashboard-panel-accent-radius: 4px;
 }

--- a/src/renderer/styles/components/_dashboard.scss
+++ b/src/renderer/styles/components/_dashboard.scss
@@ -45,6 +45,12 @@
     flex: 0 1 100%;
   }
 
+  @include element(chartFooter) {
+    color: var(--text-dark);
+    flex: 0 0 auto;
+    text-align: center;
+  }
+
   @include element(emptyData) {
     color: var(--color-platinum--dark);
     display: flex;

--- a/src/renderer/styles/components/_dashboard.scss
+++ b/src/renderer/styles/components/_dashboard.scss
@@ -1,14 +1,15 @@
 .dashboard {
   $min-grid-row: 0;
-  $max-grid-row: 18rem;
+  $max-grid-row: 27rem;
   $top-grid-row: auto;
+  $second-grid-row: auto;
   $column-count: 3;
 
   display: grid;
   grid-auto-rows: minmax($min-grid-row, $max-grid-row);
   grid-gap: spacing(medium);
   grid-template-columns: repeat($column-count, 1fr);
-  grid-template-rows: $top-grid-row;
+  grid-template-rows: $top-grid-row $second-grid-row;
 
   @include element(panel) {
     background-color: var(--color-white);

--- a/src/renderer/styles/components/_dashboard.scss
+++ b/src/renderer/styles/components/_dashboard.scss
@@ -39,6 +39,11 @@
     @include modifier(server-stats) {
       grid-area: 1 / span $column-count;
     }
+
+    &:not(:first-child) {
+      border-bottom: var(--dashboard-panel-accent-radius) solid var(--dashboard-panel-accent-color);
+      border-radius: 0 0 var(--dashboard-panel-accent-radius) var(--dashboard-panel-accent-radius);
+    }
   }
 
   @include element(chartContainer) {
@@ -48,6 +53,7 @@
   @include element(chartFooter) {
     color: var(--text-dark);
     flex: 0 0 auto;
+    padding: 0.5rem 0;
     text-align: center;
   }
 

--- a/src/renderer/styles/components/_dashboard.scss
+++ b/src/renderer/styles/components/_dashboard.scss
@@ -56,4 +56,8 @@
   @include element(header-text) {
     white-space: nowrap;
   }
+
+  @include element(header-subtext) {
+    display: block;
+  }
 }

--- a/src/renderer/styles/components/_dashboard.scss
+++ b/src/renderer/styles/components/_dashboard.scss
@@ -53,7 +53,7 @@
   @include element(chartFooter) {
     color: var(--text-dark);
     flex: 0 0 auto;
-    padding: 0.5rem 0;
+    padding-top: spacing(small);
     text-align: center;
   }
 

--- a/src/renderer/styles/containers/_settings.scss
+++ b/src/renderer/styles/containers/_settings.scss
@@ -14,4 +14,12 @@
   @include element(action) {
     flex: 0 0 auto;
   }
+
+  @include element(checkbox-group) {
+    .form-field {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      justify-items: left;
+    }
+  }
 }

--- a/src/renderer/types.js
+++ b/src/renderer/types.js
@@ -20,7 +20,7 @@ const protocols = PropTypes.arrayOf(protocol);
 
 const variableDefinition = PropTypes.shape({
   label: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
+  name: PropTypes.string,
   options: PropTypes.arrayOf(PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,

--- a/src/renderer/types.js
+++ b/src/renderer/types.js
@@ -21,10 +21,21 @@ const protocols = PropTypes.arrayOf(protocol);
 const variableDefinition = PropTypes.shape({
   label: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  options: PropTypes.arrayOf(PropTypes.shape({
-    label: PropTypes.string.isRequired,
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  })),
+  options: PropTypes.arrayOf(PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    }),
+  ])),
+});
+
+const entityType = PropTypes.shape({ variables: PropTypes.objectOf(variableDefinition) });
+
+const variableRegistry = PropTypes.shape({
+  node: PropTypes.objectOf(entityType).isRequired,
+  edge: PropTypes.objectOf(entityType),
 });
 
 const entityName = PropTypes.oneOf(['node', 'edge']);
@@ -37,6 +48,7 @@ const Types = {
   protocol,
   protocols,
   variableDefinition,
+  variableRegistry,
 };
 
 export default Object.freeze(Types);

--- a/src/renderer/types.js
+++ b/src/renderer/types.js
@@ -34,7 +34,7 @@ const variableDefinition = PropTypes.shape({
 const entityType = PropTypes.shape({ variables: PropTypes.objectOf(variableDefinition) });
 
 const variableRegistry = PropTypes.shape({
-  node: PropTypes.objectOf(entityType).isRequired,
+  node: PropTypes.objectOf(entityType),
   edge: PropTypes.objectOf(entityType),
 });
 

--- a/src/renderer/utils/CSSVariables.js
+++ b/src/renderer/utils/CSSVariables.js
@@ -16,6 +16,16 @@ const getCSSVariableAsNumber = getCSSNumber;
 const getCSSValues = (...props) => props.map(prop => getCSSValue(prop));
 
 /**
+ * Produce a range of related values, e.g. for graph colors.
+ * @param {string} prefix beginning of the CSS variable name, e.g. '--graph-data-'
+ * @param {Number} fromIndex
+ * @param {Number} toIndex must be greater than fromIndex
+ * @return {Array} computed property values
+ */
+const getCSSValueRange = (prefix, fromIndex, toIndex) =>
+  Array.from(Array(toIndex - fromIndex + 1)).map((el, i) => getCSSValue(`${prefix}${i + fromIndex}`));
+
+/**
  * @param  {...string} props property names (example: '--color-1')
  * @return {object} CSS custom properties, keyed by property name
  */
@@ -32,4 +42,5 @@ export {
   getCSSVariableAsNumber,
   getCSSValues,
   getCSSValueDict,
+  getCSSValueRange,
 };


### PR DESCRIPTION
This renders one chart per ordinal & categorical variable defined in the protocol, and allows the user to hide or show the charts by toggling selections on the Settings tab. By default, all charts are shown. Chart ordering will happen in a future PR; I imagine ordering should be supported across different panel types.

Known issue: [UI defines only 4 chart colors](https://github.com/codaco/Network-Canvas-UI/blob/42cef82/styles/global/_default.scss#L77-L80); we probably want to increase that there, but I'm not sure if there's rhyme or reason to the color ordering.

![charts](https://user-images.githubusercontent.com/39674/50850696-97fca200-1348-11e9-9e7b-94c479ae8b12.png)

To test this, I added a copy of the development protocol to Server, then generated and exported both manually-created & mock data from NC.
