### PR TITLE
Fix & test exporting

### DIFF
--- a/__mocks__/electron-updater.js
+++ b/__mocks__/electron-updater.js
@@ -7,6 +7,7 @@ const autoUpdater = {
   checkForUpdatesAndNotify: jest.fn(),
   checkForUpdates: jest.fn().mockResolvedValue({}),
   on: jest.fn((name, cb) => { mockHandlers[name] = cb; }),
+  quitAndInstall: jest.fn(),
 };
 
 module.exports = { autoUpdater };

--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -22,11 +22,16 @@ const app = {
   getPath: jest.fn(() => '.'),
   makeSingleInstance: jest.fn(),
   on: jest.fn(),
+  removeAllListeners: jest.fn(),
   quit: jest.fn(),
 };
 
 const dialog = {
-  showMessageBox: jest.fn(),
+  showErrorBox: jest.fn(),
+  showMessageBox: jest.fn().mockImplementation((browserWindow, options, callback) => {
+    const cb = typeof options === 'function' ? options : callback;
+    if (cb) { cb(); }
+  }),
   showOpenDialog: jest.fn(),
   showSaveDialog: jest.fn(),
 };

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}",
+      "!src/main/components/loadDevToolsExtensions.js",
       "!src/renderer/ui/**",
       "!src/main/utils/network-query/**",
       "!src/renderer/components/Filter/**",

--- a/scripts/db-size.js
+++ b/scripts/db-size.js
@@ -40,7 +40,7 @@ let db;
 function initDb() {
   const initDbTime = process.hrtime();
   return new Promise(resolve => {
-    db = new SessionDB(dbFile, false, { onload: (err) => {
+    db = new SessionDB(dbFile, { onload: (err) => {
       if (err) {
         console.error(err);
         process.exit(1);

--- a/src/main/__tests__/updater-test.js
+++ b/src/main/__tests__/updater-test.js
@@ -1,10 +1,13 @@
 /* eslint-env jest */
 
+const { app } = require('electron');
+
 const updater = require('../updater');
 const dialog = require('../dialog');
 
 jest.mock('electron');
 jest.mock('electron-updater');
+jest.mock('electron-log');
 jest.mock('../dialog');
 
 describe('updater', () => {
@@ -30,8 +33,22 @@ describe('updater', () => {
     expect(dialog.showMessageBox).toHaveBeenCalled();
   });
 
+  it('removes listeners & quits when download ready', (done) => {
+    updater.simulate('update-downloaded', {});
+    setImmediate(() => {
+      expect(app.removeAllListeners).toHaveBeenCalled();
+      expect(updater.quitAndInstall).toHaveBeenCalled();
+      done();
+    });
+  });
+
   it('shows a message when no update available', () => {
     updater.simulate('update-not-available', {});
     expect(dialog.showMessageBox).toHaveBeenCalled();
+  });
+
+  it('shows errors to the user', () => {
+    updater.simulate('error', new Error());
+    expect(dialog.showErrorBox).toHaveBeenCalled();
   });
 });

--- a/src/main/components/__tests__/tray-test.js
+++ b/src/main/components/__tests__/tray-test.js
@@ -8,4 +8,36 @@ describe('tray', () => {
     const tray = createTray();
     expect(tray.setContextMenu).toHaveBeenCalled();
   });
+
+  describe('image', () => {
+    let mockPlatform;
+    let getTrayImage;
+
+    beforeEach(() => {
+      jest.resetModules();
+      jest.mock('os', () => ({ platform: () => mockPlatform }));
+      getTrayImage = require('../tray').getTrayImage; // eslint-disable-line global-require
+    });
+
+    it('has a default', () => {
+      expect(getTrayImage()).toMatch('trayDefault.png');
+    });
+
+    describe('on windows', () => {
+      beforeAll(() => { mockPlatform = 'win32'; });
+
+      it('uses the correct file', () => {
+        expect(getTrayImage()).toMatch('trayWindows.png');
+      });
+    });
+
+    describe('on macOS', () => {
+      beforeAll(() => { mockPlatform = 'darwin'; });
+
+      it('uses the correct file', () => {
+        expect(getTrayImage()).toMatch('trayTemplate.png');
+      });
+    });
+  });
 });
+

--- a/src/main/components/loadDevToolsExtensions.js
+++ b/src/main/components/loadDevToolsExtensions.js
@@ -1,0 +1,20 @@
+const { BrowserWindow } = require('electron');
+
+const loadDevToolsExtensions = () => {
+  const extensions = process.env.NC_DEVTOOLS_EXENSION_PATH;
+  if (process.env.NODE_ENV !== 'development' || !extensions) {
+    return;
+  }
+  try {
+    extensions.split(';').forEach(filepath => BrowserWindow.addDevToolsExtension(filepath));
+  } catch (err) {
+    /* eslint-disable no-console, global-require */
+    const chalk = require('chalk');
+    console.warn(err);
+    console.warn(chalk.yellow('A Chrome dev tools extension failed to load. If the extension has upgraded, update your NC_DEVTOOLS_EXENSION_PATH:'));
+    console.warn(chalk.yellow(process.env.NC_DEVTOOLS_EXENSION_PATH));
+    /* eslint-enable */
+  }
+};
+
+module.exports = loadDevToolsExtensions;

--- a/src/main/components/mainWindow.js
+++ b/src/main/components/mainWindow.js
@@ -2,24 +2,9 @@ const path = require('path');
 const url = require('url');
 const { BrowserWindow } = require('electron');
 
-const DefaultHomeRoute = '/overview';
+const loadDevToolsExtensions = require('./loadDevToolsExtensions');
 
-const loadDevToolsExtensions = () => {
-  const extensions = process.env.NC_DEVTOOLS_EXENSION_PATH;
-  if (process.env.NODE_ENV !== 'development' || !extensions) {
-    return;
-  }
-  try {
-    extensions.split(';').forEach(filepath => BrowserWindow.addDevToolsExtension(filepath));
-  } catch (err) {
-    /* eslint-disable no-console, global-require */
-    const chalk = require('chalk');
-    console.warn(err);
-    console.warn(chalk.yellow('A Chrome dev tools extension failed to load. If the extension has upgraded, update your NC_DEVTOOLS_EXENSION_PATH:'));
-    console.warn(chalk.yellow(process.env.NC_DEVTOOLS_EXENSION_PATH));
-    /* eslint-enable */
-  }
-};
+const DefaultHomeRoute = '/overview';
 
 /**
  * Convert an app route to a full URL using hash-based routing.

--- a/src/main/components/tray.js
+++ b/src/main/components/tray.js
@@ -26,3 +26,5 @@ exports.createTray = (template) => {
 
   return tray;
 };
+
+exports.getTrayImage = getTrayImage;

--- a/src/main/data-managers/ExportManager.js
+++ b/src/main/data-managers/ExportManager.js
@@ -196,8 +196,12 @@ class ExportManager {
                   exportOpts)))));
         return Promise.all(promisedExports);
       })
-      // TODO: check length; if 0: reject, if 1: don't zip?
-      .then(exportedPaths => archive(exportedPaths, destinationFilepath))
+      .then((exportedPaths) => {
+        if (exportedPaths.length === 0) {
+          throw new RequestError(ErrorMessages.NothingToExport);
+        }
+        return archive(exportedPaths, destinationFilepath);
+      })
       .catch((err) => {
         cleanUp();
         logger.error(err);

--- a/src/main/data-managers/ExportManager.js
+++ b/src/main/data-managers/ExportManager.js
@@ -106,7 +106,8 @@ class ExportManager {
    * @async
    * @param {Object} protocol the saved protocol from DB
    * @param {string} options.destinationFilepath local FS path to output the final file
-   * @param {string} options.exportFormat "csv" or "graphml"
+   * @param {Array<string>} options.exportFormats
+   *        Possible values: "adjacencyMatrix", "attributeList", "edgeList", "graphml"
    * @param {Array} options.csvTypes if `exportFormat` is "csv", then include these types in output.
    *                                 Options: ["adjacencyMatrix", "attributeList", "edgeList"]
    * @param {boolean} options.exportNetworkUnion true if all interview networks should be merged

--- a/src/main/errors/RequestError.js
+++ b/src/main/errors/RequestError.js
@@ -24,6 +24,7 @@ const ErrorMessages = {
   InvalidExportOptions: 'Invalid export options',
   MissingProtocolFile: 'Missing protocol file',
   NotFound: 'Not found',
+  NothingToExport: 'No data available to export',
   ProtocolNotFoundForSession: 'The associated protocol does not exist on this server',
   VerificationFailed: 'Request verification failed',
 };

--- a/src/main/server/__tests__/AdminService-test.js
+++ b/src/main/server/__tests__/AdminService-test.js
@@ -10,6 +10,9 @@ jest.mock('electron-log');
 jest.mock('../../data-managers/DeviceManager');
 jest.mock('../../data-managers/ProtocolManager');
 jest.mock('../devices/PairingRequestService');
+jest.mock('../../data-managers/ExportManager', () => class {
+  createExportFile = jest.fn().mockResolvedValue({ abort: jest.fn() })
+});
 
 const testPortNumber = 52001;
 
@@ -299,6 +302,27 @@ describe('the AdminService', () => {
           const res = await jsonClient.get(endpoint);
           expect(res.json.status).toBe('ok');
           expect(res.json.entities).toMatchObject([]);
+        });
+      });
+
+      describe('exports', () => {
+        beforeEach(() => {
+          adminService.protocolManager.getProtocol = jest.fn().mockResolvedValue({});
+        });
+
+        it('requires valid export options', async () => {
+          const endpoint = makeUrl('protocols/1/export_requests', apiBase);
+          const error = new Error('Mock Invalid Options');
+          adminService.exportManager.createExportFile.mockRejectedValueOnce(error);
+          await expect(jsonClient.post(endpoint, {})).rejects.toMatchObject({
+            json: { message: error.message },
+          });
+        });
+
+        it('reponds to a POST request', async () => {
+          const endpoint = makeUrl('protocols/1/export_requests', apiBase);
+          const res = await jsonClient.post(endpoint, { destinationFilepath: '/tmp', exportFormats: ['graphml'] });
+          expect(res.json.status).toBe('ok');
         });
       });
     });

--- a/src/main/utils/formatters/__tests__/attribute-list-test.js
+++ b/src/main/utils/formatters/__tests__/attribute-list-test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 import { makeWriteableStream } from '../../../../../config/jest/setupTestEnv';
-import { asAttributeList, toCSVStream } from '../attribute-list';
+import { asAttributeList, toCSVStream, AttributeListFormatter } from '../attribute-list';
 
 describe('asAttributeList', () => {
   it('transforms a network to nodes', () => {
@@ -57,5 +57,19 @@ describe('toCSVStream', () => {
     toCSVStream([{ _uid: 1, attributes: { prop: false } }], writable);
     const csv = await writable.asString();
     expect(csv).toEqual('_uid,prop\r\n1,false\r\n');
+  });
+});
+
+describe('AttributeListFormatter', () => {
+  let writable;
+
+  beforeEach(() => {
+    writable = makeWriteableStream();
+  });
+
+  it('writeToStream returns an abort controller', () => {
+    const formatter = new AttributeListFormatter({});
+    const controller = formatter.writeToStream(writable);
+    expect(controller.abort).toBeInstanceOf(Function);
   });
 });

--- a/src/main/utils/formatters/__tests__/edge-list-test.js
+++ b/src/main/utils/formatters/__tests__/edge-list-test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { makeWriteableStream } from '../../../../../config/jest/setupTestEnv';
-import { asEdgeList, toCSVStream } from '../edge-list';
+import { asEdgeList, toCSVStream, EdgeListFormatter } from '../edge-list';
 
 const listFromEdges = (edges, directed) => asEdgeList({ edges }, directed);
 
@@ -65,5 +65,19 @@ describe('toCSVStream', () => {
     toCSVStream(list, writable);
     const csv = await writable.asString();
     expect(csv).toEqual('1,2\r\n2,1\r\n');
+  });
+});
+
+describe('EdgeListFormatter', () => {
+  let writable;
+
+  beforeEach(() => {
+    writable = makeWriteableStream();
+  });
+
+  it('writeToStream returns an abort controller', () => {
+    const formatter = new EdgeListFormatter({});
+    const controller = formatter.writeToStream(writable);
+    expect(controller.abort).toBeInstanceOf(Function);
   });
 });

--- a/src/main/utils/formatters/__tests__/matrix-test.js
+++ b/src/main/utils/formatters/__tests__/matrix-test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { makeWriteableStream } from '../../../../../config/jest/setupTestEnv';
-import { asAdjacencyMatrix } from '../matrix';
+import { asAdjacencyMatrix, AdjacencyMatrixFormatter } from '../matrix';
 
 const mockNetwork = edges => ({
   edges,
@@ -124,5 +124,19 @@ describe('toCSVStream', () => {
       '10,0,0,0,0,0,0,0,0,1,0\r\n',
     ];
     expect(csv).toEqual(rows.join('\r\n'));
+  });
+});
+
+describe('AdjacencyMatrixFormatter', () => {
+  let writable;
+
+  beforeEach(() => {
+    writable = makeWriteableStream();
+  });
+
+  it('writeToStream returns an abort controller', () => {
+    const formatter = new AdjacencyMatrixFormatter({});
+    const controller = formatter.writeToStream(writable);
+    expect(controller.abort).toBeInstanceOf(Function);
   });
 });

--- a/src/main/utils/formatters/attribute-list.js
+++ b/src/main/utils/formatters/attribute-list.js
@@ -66,10 +66,10 @@ const toCSVStream = (nodes, outStream) => {
 
 class AttributeListFormatter {
   constructor(data, directed = false) {
-    this.list = asAttributeList(data, directed);
+    this.list = asAttributeList(data, directed) || [];
   }
   writeToStream(outStream) {
-    toCSVStream(this.list, outStream);
+    return toCSVStream(this.list, outStream);
   }
 }
 

--- a/src/main/utils/formatters/edge-list.js
+++ b/src/main/utils/formatters/edge-list.js
@@ -18,7 +18,6 @@ const { csvEOL } = require('./csv');
  * ```
  *
  * @param  {Object} network NC network containing edges
- * @param  {Array} network.edges
  * @param  {Boolean} directed if false, adjacencies are represented in both directions
  *                            default: false
  * @return {Object.<string, Set>} the adjacency list
@@ -80,7 +79,7 @@ class EdgeListFormatter {
     this.list = asEdgeList(data, directed);
   }
   writeToStream(outStream) {
-    toCSVStream(this.list, outStream);
+    return toCSVStream(this.list, outStream);
   }
 }
 

--- a/src/main/utils/formatters/graphml/__tests__/GraphMLFormatter-test.js
+++ b/src/main/utils/formatters/graphml/__tests__/GraphMLFormatter-test.js
@@ -1,0 +1,29 @@
+/* eslint-env jest */
+
+import { makeWriteableStream } from '../../../../../../config/jest/setupTestEnv';
+import GraphMLFormatter from '../GraphMLFormatter';
+
+describe('GraphMLFormatter writeToStream', () => {
+  let network;
+  let variableRegistry;
+  let writable;
+
+  beforeEach(() => {
+    writable = makeWriteableStream();
+    network = { nodes: [], edges: [] };
+    variableRegistry = { node: {} };
+  });
+
+  it('returns an abort controller', () => {
+    const formatter = new GraphMLFormatter(network, false, variableRegistry);
+    const controller = formatter.writeToStream(writable);
+    expect(controller.abort).toBeInstanceOf(Function);
+  });
+
+  it('produces XML', async () => {
+    const formatter = new GraphMLFormatter(network, false, variableRegistry);
+    formatter.writeToStream(writable);
+    const xml = await writable.asString();
+    expect(xml).toMatch('<graphml');
+  });
+});

--- a/src/main/utils/formatters/graphml/__tests__/helpers-test.js
+++ b/src/main/utils/formatters/graphml/__tests__/helpers-test.js
@@ -1,0 +1,89 @@
+/* eslint-env jest */
+
+import { getGraphMLTypeForKey } from '../helpers';
+
+describe('getGraphMLTypeForKey', () => {
+  it('defaults to empty', () => {
+    expect(getGraphMLTypeForKey([])).toEqual('');
+  });
+
+  it('returns empty for null values', () => {
+    const node = { attributes: { name: null } };
+    expect(getGraphMLTypeForKey([node], 'name')).toEqual('');
+  });
+
+  it('identifies a string', () => {
+    const node = { attributes: { name: 'alice' } };
+    expect(getGraphMLTypeForKey([node], 'name')).toEqual('string');
+  });
+
+  it('identifies an int', () => {
+    const node = { attributes: { age: 23 } };
+    expect(getGraphMLTypeForKey([node], 'age')).toEqual('int');
+  });
+
+  it('identifies an int from strings', () => {
+    const node = { attributes: { age: '23' } };
+    expect(getGraphMLTypeForKey([node], 'age')).toEqual('int');
+  });
+
+  it('identifies a double', () => {
+    const node = { attributes: { avg: 1.5 } };
+    expect(getGraphMLTypeForKey([node], 'avg')).toEqual('double');
+  });
+
+  it('identifies a double from strings', () => {
+    const node = { attributes: { avg: '1.5' } };
+    expect(getGraphMLTypeForKey([node], 'avg')).toEqual('double');
+  });
+
+  it('identifies a boolean', () => {
+    const node = { attributes: { isSet: true } };
+    expect(getGraphMLTypeForKey([node], 'isSet')).toEqual('boolean');
+  });
+
+  it('favors later (non-null) values when types conflict', () => {
+    const nodeA = { attributes: { a: true } };
+    const nodeB = { attributes: { a: 'foo' } };
+    const nodeC = { attributes: { a: null } };
+    expect(getGraphMLTypeForKey([nodeA, nodeB, nodeC], 'a')).toEqual('string');
+  });
+
+  it('favors double over int when mixed', () => {
+    const nodeA = { attributes: { a: 1 } };
+    const nodeB = { attributes: { a: 2.1 } };
+    expect(getGraphMLTypeForKey([nodeA, nodeB], 'a')).toEqual('double');
+  });
+
+  it('favors double over int when mixed (int last)', () => {
+    const nodeA = { attributes: { a: 1.1 } };
+    const nodeB = { attributes: { a: 2 } };
+    expect(getGraphMLTypeForKey([nodeA, nodeB], 'a')).toEqual('double');
+  });
+
+  it('favors double over int when mixed strings', () => {
+    const nodeA = { attributes: { a: '1' } };
+    const nodeB = { attributes: { a: '2.1' } };
+    expect(getGraphMLTypeForKey([nodeA, nodeB], 'a')).toEqual('double');
+  });
+
+  it('favors double over int when mixed strings (int last)', () => {
+    const nodeA = { attributes: { a: '1.1' } };
+    const nodeB = { attributes: { a: '2' } };
+    expect(getGraphMLTypeForKey([nodeA, nodeB], 'a')).toEqual('double');
+  });
+
+  it('defaults to a string in some cases?', () => {
+    // TODO: review; this was the original implementation, but seems unexpected
+    const nodeA = { attributes: { a: 2 } };
+    const nodeB = { attributes: { a: false } };
+    expect(getGraphMLTypeForKey([nodeA, nodeB], 'a')).toEqual('string');
+  });
+
+  it('defaults to a double in some cases?', () => {
+    // TODO: review; this was the original implementation, but seems unexpected
+    const nodeA = { attributes: { a: 'name' } };
+    const nodeB = { attributes: { a: 2 } };
+    expect(getGraphMLTypeForKey([nodeA, nodeB], 'a')).toEqual('double');
+  });
+});

--- a/src/main/utils/formatters/matrix.js
+++ b/src/main/utils/formatters/matrix.js
@@ -56,7 +56,8 @@ class AdjacencyMatrix {
     // TODO: Store a quote-escaped version?
     // Track only unique IDs (duplicates are discarded). The ordering here provides the ordering for
     // both header and data output.
-    const uniqueNodeIds = [...new Set(network.nodes.map(node => node[nodePrimaryKeyProperty]))];
+    const nodes = network.nodes || [];
+    const uniqueNodeIds = [...new Set(nodes.map(node => node[nodePrimaryKeyProperty]))];
     this.uniqueNodeIds = uniqueNodeIds;
 
     const dimension = uniqueNodeIds.length;
@@ -103,7 +104,7 @@ class AdjacencyMatrix {
       return acc;
     }, {});
 
-    this.network.edges.forEach(({ from, to }) => {
+    (this.network.edges || []).forEach(({ from, to }) => {
       this.setAdjacent(from, to);
       if (directed === false) {
         this.setAdjacent(to, from);

--- a/src/renderer/ducks/modules/appMessages.js
+++ b/src/renderer/ducks/modules/appMessages.js
@@ -84,7 +84,9 @@ const actionCreators = {
 
 const actionTypes = {
   DISMISS_MESSAGES,
+  DISMISS_MESSAGE,
   SHOW_MESSAGE,
+  UPDATE_MESSAGE_STATE,
 };
 
 export default reducer;
@@ -94,4 +96,5 @@ export {
   actionTypes,
   messageTypes,
   messages,
+  messageLifetimeMillis,
 };


### PR DESCRIPTION
This fixes a few issues related to exporting from last release:
- Ensure all formatters return the same controller for cancellation
- Fix the constructor in the DBSize `main` script (for testing)
- Fix API docs for exporting

Also augments test coverage for exporting and for the app in general.