### PR TITLE
Feature/export ego

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6224,6 +6224,11 @@
         "tryer": "^1.0.0"
       }
     },
+    "big-integer": {
+      "version": "1.6.43",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.43.tgz",
+      "integrity": "sha512-9dULc9jsKmXl0Aeunug8wbF+58n+hQoFjqClN7WeZwGLh0XJUWyJJ9Ee+Ep+Ql/J9fRsTVaeThp8MhiCCrY0Jg=="
+    },
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
@@ -9472,7 +9477,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
   "dependencies": {
     "animejs": "^2.2.0",
     "archiver": "^2.1.1",
+    "big-integer": "^1.6.43",
     "classnames": "^2.2.6",
     "detect-port": "^1.2.3",
     "jszip": "^3.1.5",

--- a/src/main/data-managers/ExportManager.js
+++ b/src/main/data-managers/ExportManager.js
@@ -11,7 +11,7 @@ const { RequestError, ErrorMessages } = require('../errors/RequestError');
 const { makeTempDir, removeTempDir } = require('../utils/formatters/dir');
 const {
   insertEgoInNetworks,
-  transposedRegistry,
+  transposedCodebook,
   unionOfNetworks,
 } = require('../utils/formatters/network');
 const {
@@ -42,7 +42,7 @@ const makeFilename = (prefix, edgeType, exportFormat, extension) => {
  * @param  {object} network NC-formatted network `({ nodes, edges, ego })`
  * @param  {object} [options]
  * @param  {boolean} [options.useDirectedEdges=false] true to force directed edges
- * @param  {Object} [options.variableRegistry] needed for graphML export
+ * @param  {Object} [options.codebook] needed for graphML export
  * @return {Promise} promise decorated with an `abort` method.
  *                           If aborted, the returned promise will never settle.
  * @private
@@ -53,7 +53,7 @@ const exportFile = (
   exportFormat,
   outDir,
   network,
-  { useDirectedEdges, useEgoData, variableRegistry } = {},
+  { useDirectedEdges, useEgoData, codebook } = {},
 ) => {
   const Formatter = getFormatterClass(exportFormat);
   const extension = getFileExtension(exportFormat);
@@ -65,7 +65,7 @@ const exportFile = (
   let writeStream;
 
   const pathPromise = new Promise((resolve, reject) => {
-    const formatter = new Formatter(network, useDirectedEdges, useEgoData, variableRegistry);
+    const formatter = new Formatter(network, useDirectedEdges, useEgoData, codebook);
     const outputName = makeFilename(namePrefix, edgeType, exportFormat, extension);
     const filepath = path.join(outDir, outputName);
     writeStream = fs.createWriteStream(filepath);
@@ -143,7 +143,7 @@ class ExportManager {
     const exportOpts = {
       useDirectedEdges,
       useEgoData,
-      variableRegistry: transposedRegistry(protocol.variableRegistry),
+      codebook: transposedCodebook(protocol.codebook),
     };
 
     // Export flow:

--- a/src/main/data-managers/ProtocolDB.js
+++ b/src/main/data-managers/ProtocolDB.js
@@ -58,7 +58,7 @@ class ProtocolDB extends DatabaseAdapter {
         return;
       }
 
-      const { description, variableRegistry, networkCanvasVersion } = metadata;
+      const { description, codebook, networkCanvasVersion } = metadata;
       const lastModified = validatedModifyTime(metadata);
 
       let oldDoc;
@@ -75,7 +75,7 @@ class ProtocolDB extends DatabaseAdapter {
         description,
         lastModified,
         networkCanvasVersion,
-        variableRegistry,
+        codebook,
         sha256Digest: contentsDigest,
       }, {
         multi: false,

--- a/src/main/data-managers/__tests__/ExportManager-test.js
+++ b/src/main/data-managers/__tests__/ExportManager-test.js
@@ -80,7 +80,7 @@ describe('ExportManager', () => {
   // TODO: make the stream interface more testable
   describe('with data', () => {
     beforeEach(() => {
-      protocol.variableRegistry = {};
+      protocol.codebook = {};
       manager.sessionDB = {
         findAll: jest.fn().mockResolvedValue([{ data: { nodes: [], edges: [] } }]),
       };

--- a/src/main/data-managers/__tests__/ProtocolDB-test.js
+++ b/src/main/data-managers/__tests__/ProtocolDB-test.js
@@ -18,10 +18,10 @@ describe('ProtocolDB', () => {
     expect(result).toMatchObject(mockProtocol);
   });
 
-  it('persists the variable registry', async () => {
-    const registry = { variableRegistry: { nodes: {} } };
-    const result = await db.save('a.netcanvas', Buffer.from([]), { ...mockProtocol, ...registry });
-    expect(result).toMatchObject(registry);
+  it('persists the codebook', async () => {
+    const codebook = { codebook: { nodes: {} } };
+    const result = await db.save('a.netcanvas', Buffer.from([]), { ...mockProtocol, ...codebook });
+    expect(result).toMatchObject(codebook);
   });
 
   it('inserts metadata with new name', async () => {

--- a/src/main/utils/formatters/__tests__/attribute-list-test.js
+++ b/src/main/utils/formatters/__tests__/attribute-list-test.js
@@ -20,49 +20,49 @@ describe('toCSVStream', () => {
   it('writes a simple CSV', async () => {
     toCSVStream([{ _uid: 1, _egoID: 2, attributes: { name: 'Jane' } }], writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,name\r\n1,Jane\r\n');
+    expect(csv).toEqual('networkCanvasAlterID,name\r\n1,Jane\r\n');
   });
 
   it('escapes quotes', async () => {
     toCSVStream([{ _uid: 1, attributes: { nickname: '"Nicky"' } }], writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,nickname\r\n1,"""Nicky"""\r\n');
+    expect(csv).toEqual('networkCanvasAlterID,nickname\r\n1,"""Nicky"""\r\n');
   });
 
   it('escapes quotes in attr names', async () => {
     toCSVStream([{ _uid: 1, attributes: { '"quoted"': 1 } }], writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,"""quoted"""\r\n1,1\r\n');
+    expect(csv).toEqual('networkCanvasAlterID,"""quoted"""\r\n1,1\r\n');
   });
 
   it('stringifies and quotes objects', async () => {
     toCSVStream([{ _uid: 1, attributes: { location: { x: 1, y: 1 } } }], writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,location\r\n1,"{""x"":1,""y"":1}"\r\n');
+    expect(csv).toEqual('networkCanvasAlterID,location\r\n1,"{""x"":1,""y"":1}"\r\n');
   });
 
   it('exports undefined values as blank', async () => {
     toCSVStream([{ _uid: 1, attributes: { prop: undefined } }], writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,prop\r\n1,\r\n');
+    expect(csv).toEqual('networkCanvasAlterID,prop\r\n1,\r\n');
   });
 
   it('exports null values as blank', async () => {
     toCSVStream([{ _uid: 1, attributes: { prop: null } }], writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,prop\r\n1,\r\n');
+    expect(csv).toEqual('networkCanvasAlterID,prop\r\n1,\r\n');
   });
 
   it('exports `false` values as "false"', async () => {
     toCSVStream([{ _uid: 1, attributes: { prop: false } }], writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,prop\r\n1,false\r\n');
+    expect(csv).toEqual('networkCanvasAlterID,prop\r\n1,false\r\n');
   });
 
   it('exports egoID', async () => {
     toCSVStream([{ _uid: 1, _egoID: 2, attributes: { prop: false } }], writable, true);
     const csv = await writable.asString();
-    expect(csv).toEqual('_egoID,_uid,prop\r\n2,1,false\r\n');
+    expect(csv).toEqual('networkCanvasEgoID,networkCanvasAlterID,prop\r\n2,1,false\r\n');
   });
 });
 

--- a/src/main/utils/formatters/__tests__/attribute-list-test.js
+++ b/src/main/utils/formatters/__tests__/attribute-list-test.js
@@ -18,7 +18,7 @@ describe('toCSVStream', () => {
   });
 
   it('writes a simple CSV', async () => {
-    toCSVStream([{ _uid: 1, attributes: { name: 'Jane' } }], writable);
+    toCSVStream([{ _uid: 1, _egoID: 2, attributes: { name: 'Jane' } }], writable);
     const csv = await writable.asString();
     expect(csv).toEqual('_uid,name\r\n1,Jane\r\n');
   });
@@ -57,6 +57,12 @@ describe('toCSVStream', () => {
     toCSVStream([{ _uid: 1, attributes: { prop: false } }], writable);
     const csv = await writable.asString();
     expect(csv).toEqual('_uid,prop\r\n1,false\r\n');
+  });
+
+  it('exports egoID', async () => {
+    toCSVStream([{ _uid: 1, _egoID: 2, attributes: { prop: false } }], writable, true);
+    const csv = await writable.asString();
+    expect(csv).toEqual('_egoID,_uid,prop\r\n2,1,false\r\n');
   });
 });
 

--- a/src/main/utils/formatters/__tests__/edge-list-test.js
+++ b/src/main/utils/formatters/__tests__/edge-list-test.js
@@ -51,7 +51,7 @@ describe('toCSVStream', () => {
     const list = listFromEdges([{ _uid: 123, from: 1, to: 2 }]);
     toCSVStream(list, writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('networkCanvasEdgeID,networkCanvasSource,networkCanvasTarget\r\n123,1,2\r\n123,2,1\r\n');
+    expect(csv).toEqual('networkCanvasEdgeID,networkCanvasSource,networkCanvasTarget\r\n291,1,2\r\n291,2,1\r\n');
   });
 
   it('Writes multiple edges', async () => {
@@ -82,7 +82,7 @@ describe('toCSVStream', () => {
     );
     toCSVStream(list, writable, true);
     const csv = await writable.asString();
-    expect(csv).toEqual('networkCanvasEgoID,networkCanvasEdgeID,networkCanvasSource,networkCanvasTarget\r\n123,,1,2\r\n456,,3,1\r\n');
+    expect(csv).toEqual('networkCanvasEgoID,networkCanvasEdgeID,networkCanvasSource,networkCanvasTarget\r\n291,,1,2\r\n1110,,3,1\r\n');
   });
 
   it('Writes a csv with attributes', async () => {

--- a/src/main/utils/formatters/__tests__/edge-list-test.js
+++ b/src/main/utils/formatters/__tests__/edge-list-test.js
@@ -6,22 +6,37 @@ const listFromEdges = (edges, directed) => asEdgeList({ edges }, directed);
 
 describe('asEdgeList', () => {
   it('takes a network as input', () => {
-    const network = { nodes: [], edges: [{ from: 'nodeA', to: 'nodeB' }] };
-    expect(asEdgeList(network)).toHaveProperty('nodeA');
-  });
-
-  it('represents an edgeless network', () => {
-    expect(listFromEdges([])).toEqual({});
-  });
-
-  it('represents a single undirected edge', () => {
-    expect(
-      listFromEdges([{ from: 1, to: 2 }])).toEqual({ 1: new Set([2]), 2: new Set([1]) },
+    const network = {
+      nodes: [],
+      edges: [{ _uid: 456, from: 'nodeA', to: 'nodeB', attributes: {} }],
+      ego: { _uid: 123 },
+    };
+    expect(asEdgeList(network)[0]).toEqual(
+      { _uid: 456, _source: 'nodeA', _target: 'nodeB', to: 'nodeB', from: 'nodeA', attributes: {} },
     );
   });
 
+  it('represents an edgeless network', () => {
+    expect(listFromEdges([])).toEqual([]);
+  });
+
+  it('represents a single undirected edge', () => {
+    expect(listFromEdges([{ from: 1, to: 2 }])).toEqual([
+      { _source: 1, _target: 2, from: 1, to: 2 },
+      { _source: 2, _target: 1, from: 1, to: 2 },
+    ]);
+  });
+
   it('represents a single directed edge', () => {
-    expect(listFromEdges([{ from: 1, to: 2 }], true)).toEqual({ 1: new Set([2]) });
+    expect(listFromEdges([{ from: 1, to: 2 }], true)).toEqual([
+      { _source: 1, _target: 2, from: 1, to: 2 },
+    ]);
+  });
+
+  it('include egoID', () => {
+    expect(listFromEdges([{ _egoID: 123, from: 1, to: 2 }], true)).toEqual([
+      { _egoID: 123, _source: 1, _target: 2, from: 1, to: 2 },
+    ]);
   });
 });
 
@@ -33,38 +48,48 @@ describe('toCSVStream', () => {
   });
 
   it('Writes a simple csv', async () => {
-    const list = listFromEdges([{ from: 1, to: 2 }]);
+    const list = listFromEdges([{ _uid: 123, from: 1, to: 2 }]);
     toCSVStream(list, writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('1,2\r\n2,1\r\n');
+    expect(csv).toEqual('_uid,_source,_target\r\n123,1,2\r\n123,2,1\r\n');
   });
 
   it('Writes multiple edges', async () => {
     const list = listFromEdges([{ from: 1, to: 2 }, { from: 1, to: 3 }]);
     toCSVStream(list, writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('1,2\r\n1,3\r\n2,1\r\n3,1\r\n');
+    expect(csv).toEqual('_uid,_source,_target\r\n,1,2\r\n,2,1\r\n,1,3\r\n,3,1\r\n');
   });
 
   it('Writes a csv for directed edges', async () => {
     const list = listFromEdges([{ from: 1, to: 2 }, { from: 1, to: 3 }], true);
     toCSVStream(list, writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('1,2\r\n1,3\r\n');
+    expect(csv).toEqual('_uid,_source,_target\r\n,1,2\r\n,1,3\r\n');
   });
 
   it('Writes a csv for directed edges (inverse)', async () => {
     const list = listFromEdges([{ from: 1, to: 2 }, { from: 3, to: 1 }], true);
     toCSVStream(list, writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('1,2\r\n3,1\r\n');
+    expect(csv).toEqual('_uid,_source,_target\r\n,1,2\r\n,3,1\r\n');
   });
 
-  it('Ignores duplicate edges', async () => {
-    const list = listFromEdges([{ from: 1, to: 2 }, { from: 1, to: 2 }]);
+  it('Writes a csv with egoID', async () => {
+    const list = listFromEdges(
+      [{ _egoID: 123, from: 1, to: 2 }, { _egoID: 456, from: 3, to: 1 }],
+      true,
+    );
+    toCSVStream(list, writable, true);
+    const csv = await writable.asString();
+    expect(csv).toEqual('_egoID,_uid,_source,_target\r\n123,,1,2\r\n456,,3,1\r\n');
+  });
+
+  it('Writes a csv with attributes', async () => {
+    const list = listFromEdges([{ from: 1, to: 2, attributes: { a: 1 } }], true);
     toCSVStream(list, writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('1,2\r\n2,1\r\n');
+    expect(csv).toEqual('_uid,_source,_target,a\r\n,1,2,1\r\n');
   });
 });
 

--- a/src/main/utils/formatters/__tests__/edge-list-test.js
+++ b/src/main/utils/formatters/__tests__/edge-list-test.js
@@ -12,7 +12,7 @@ describe('asEdgeList', () => {
       ego: { _uid: 123 },
     };
     expect(asEdgeList(network)[0]).toEqual(
-      { _uid: 456, _source: 'nodeA', _target: 'nodeB', to: 'nodeB', from: 'nodeA', attributes: {} },
+      { _uid: 456, to: 'nodeB', from: 'nodeA', attributes: {} },
     );
   });
 
@@ -22,20 +22,20 @@ describe('asEdgeList', () => {
 
   it('represents a single undirected edge', () => {
     expect(listFromEdges([{ from: 1, to: 2 }])).toEqual([
-      { _source: 1, _target: 2, from: 1, to: 2 },
-      { _source: 2, _target: 1, from: 1, to: 2 },
+      { from: 1, to: 2 },
+      { from: 2, to: 1 },
     ]);
   });
 
   it('represents a single directed edge', () => {
     expect(listFromEdges([{ from: 1, to: 2 }], true)).toEqual([
-      { _source: 1, _target: 2, from: 1, to: 2 },
+      { from: 1, to: 2 },
     ]);
   });
 
   it('include egoID', () => {
     expect(listFromEdges([{ _egoID: 123, from: 1, to: 2 }], true)).toEqual([
-      { _egoID: 123, _source: 1, _target: 2, from: 1, to: 2 },
+      { _egoID: 123, from: 1, to: 2 },
     ]);
   });
 });
@@ -51,28 +51,28 @@ describe('toCSVStream', () => {
     const list = listFromEdges([{ _uid: 123, from: 1, to: 2 }]);
     toCSVStream(list, writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,_source,_target\r\n123,1,2\r\n123,2,1\r\n');
+    expect(csv).toEqual('networkCanvasEdgeID,networkCanvasSource,networkCanvasTarget\r\n123,1,2\r\n123,2,1\r\n');
   });
 
   it('Writes multiple edges', async () => {
     const list = listFromEdges([{ from: 1, to: 2 }, { from: 1, to: 3 }]);
     toCSVStream(list, writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,_source,_target\r\n,1,2\r\n,2,1\r\n,1,3\r\n,3,1\r\n');
+    expect(csv).toEqual('networkCanvasEdgeID,networkCanvasSource,networkCanvasTarget\r\n,1,2\r\n,2,1\r\n,1,3\r\n,3,1\r\n');
   });
 
   it('Writes a csv for directed edges', async () => {
     const list = listFromEdges([{ from: 1, to: 2 }, { from: 1, to: 3 }], true);
     toCSVStream(list, writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,_source,_target\r\n,1,2\r\n,1,3\r\n');
+    expect(csv).toEqual('networkCanvasEdgeID,networkCanvasSource,networkCanvasTarget\r\n,1,2\r\n,1,3\r\n');
   });
 
   it('Writes a csv for directed edges (inverse)', async () => {
     const list = listFromEdges([{ from: 1, to: 2 }, { from: 3, to: 1 }], true);
     toCSVStream(list, writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,_source,_target\r\n,1,2\r\n,3,1\r\n');
+    expect(csv).toEqual('networkCanvasEdgeID,networkCanvasSource,networkCanvasTarget\r\n,1,2\r\n,3,1\r\n');
   });
 
   it('Writes a csv with egoID', async () => {
@@ -82,14 +82,14 @@ describe('toCSVStream', () => {
     );
     toCSVStream(list, writable, true);
     const csv = await writable.asString();
-    expect(csv).toEqual('_egoID,_uid,_source,_target\r\n123,,1,2\r\n456,,3,1\r\n');
+    expect(csv).toEqual('networkCanvasEgoID,networkCanvasEdgeID,networkCanvasSource,networkCanvasTarget\r\n123,,1,2\r\n456,,3,1\r\n');
   });
 
   it('Writes a csv with attributes', async () => {
     const list = listFromEdges([{ from: 1, to: 2, attributes: { a: 1 } }], true);
     toCSVStream(list, writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,_source,_target,a\r\n,1,2,1\r\n');
+    expect(csv).toEqual('networkCanvasEdgeID,networkCanvasSource,networkCanvasTarget,a\r\n,1,2,1\r\n');
   });
 });
 

--- a/src/main/utils/formatters/__tests__/edge-list-test.js
+++ b/src/main/utils/formatters/__tests__/edge-list-test.js
@@ -22,20 +22,20 @@ describe('asEdgeList', () => {
 
   it('represents a single undirected edge', () => {
     expect(listFromEdges([{ from: 1, to: 2 }])).toEqual([
-      { from: 1, to: 2 },
-      { from: 2, to: 1 },
+      { from: 1, to: 2, attributes: {} },
+      { from: 2, to: 1, attributes: {} },
     ]);
   });
 
   it('represents a single directed edge', () => {
     expect(listFromEdges([{ from: 1, to: 2 }], true)).toEqual([
-      { from: 1, to: 2 },
+      { from: 1, to: 2, attributes: {} },
     ]);
   });
 
   it('include egoID', () => {
     expect(listFromEdges([{ _egoID: 123, from: 1, to: 2 }], true)).toEqual([
-      { _egoID: 123, from: 1, to: 2 },
+      { _egoID: 123, from: 1, to: 2, attributes: {} },
     ]);
   });
 });

--- a/src/main/utils/formatters/__tests__/ego-list-test.js
+++ b/src/main/utils/formatters/__tests__/ego-list-test.js
@@ -20,43 +20,43 @@ describe('toCSVStream', () => {
   it('writes a simple CSV', async () => {
     toCSVStream([{ _uid: 1, attributes: { name: 'Jane' } }], writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,name\r\n1,Jane\r\n');
+    expect(csv).toEqual('networkCanvasEgoID,networkCanvasCaseID,name\r\n1,,Jane\r\n');
   });
 
   it('escapes quotes', async () => {
     toCSVStream([{ _uid: 1, attributes: { nickname: '"Nicky"' } }], writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,nickname\r\n1,"""Nicky"""\r\n');
+    expect(csv).toEqual('networkCanvasEgoID,networkCanvasCaseID,nickname\r\n1,,"""Nicky"""\r\n');
   });
 
   it('escapes quotes in attr names', async () => {
     toCSVStream([{ _uid: 1, attributes: { '"quoted"': 1 } }], writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,"""quoted"""\r\n1,1\r\n');
+    expect(csv).toEqual('networkCanvasEgoID,networkCanvasCaseID,"""quoted"""\r\n1,,1\r\n');
   });
 
   it('stringifies and quotes objects', async () => {
     toCSVStream([{ _uid: 1, attributes: { location: { x: 1, y: 1 } } }], writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,location\r\n1,"{""x"":1,""y"":1}"\r\n');
+    expect(csv).toEqual('networkCanvasEgoID,networkCanvasCaseID,location\r\n1,,"{""x"":1,""y"":1}"\r\n');
   });
 
   it('exports undefined values as blank', async () => {
     toCSVStream([{ _uid: 1, attributes: { prop: undefined } }], writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,prop\r\n1,\r\n');
+    expect(csv).toEqual('networkCanvasEgoID,networkCanvasCaseID,prop\r\n1,,\r\n');
   });
 
   it('exports null values as blank', async () => {
     toCSVStream([{ _uid: 1, attributes: { prop: null } }], writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,prop\r\n1,\r\n');
+    expect(csv).toEqual('networkCanvasEgoID,networkCanvasCaseID,prop\r\n1,,\r\n');
   });
 
   it('exports `false` values as "false"', async () => {
     toCSVStream([{ _uid: 1, attributes: { prop: false } }], writable);
     const csv = await writable.asString();
-    expect(csv).toEqual('_uid,prop\r\n1,false\r\n');
+    expect(csv).toEqual('networkCanvasEgoID,networkCanvasCaseID,prop\r\n1,,false\r\n');
   });
 });
 

--- a/src/main/utils/formatters/__tests__/ego-list-test.js
+++ b/src/main/utils/formatters/__tests__/ego-list-test.js
@@ -1,0 +1,75 @@
+/* eslint-env jest */
+
+import { makeWriteableStream } from '../../../../../config/jest/setupTestEnv';
+import { asEgoList, toCSVStream, EgoListFormatter } from '../ego-list';
+
+describe('asEgoList', () => {
+  it('transforms a network to ego', () => {
+    const network = { nodes: [], edges: [], ego: { id: 1 } };
+    expect(asEgoList(network)).toEqual([network.ego]);
+  });
+});
+
+describe('toCSVStream', () => {
+  let writable;
+
+  beforeEach(() => {
+    writable = makeWriteableStream();
+  });
+
+  it('writes a simple CSV', async () => {
+    toCSVStream([{ _uid: 1, attributes: { name: 'Jane' } }], writable);
+    const csv = await writable.asString();
+    expect(csv).toEqual('_uid,name\r\n1,Jane\r\n');
+  });
+
+  it('escapes quotes', async () => {
+    toCSVStream([{ _uid: 1, attributes: { nickname: '"Nicky"' } }], writable);
+    const csv = await writable.asString();
+    expect(csv).toEqual('_uid,nickname\r\n1,"""Nicky"""\r\n');
+  });
+
+  it('escapes quotes in attr names', async () => {
+    toCSVStream([{ _uid: 1, attributes: { '"quoted"': 1 } }], writable);
+    const csv = await writable.asString();
+    expect(csv).toEqual('_uid,"""quoted"""\r\n1,1\r\n');
+  });
+
+  it('stringifies and quotes objects', async () => {
+    toCSVStream([{ _uid: 1, attributes: { location: { x: 1, y: 1 } } }], writable);
+    const csv = await writable.asString();
+    expect(csv).toEqual('_uid,location\r\n1,"{""x"":1,""y"":1}"\r\n');
+  });
+
+  it('exports undefined values as blank', async () => {
+    toCSVStream([{ _uid: 1, attributes: { prop: undefined } }], writable);
+    const csv = await writable.asString();
+    expect(csv).toEqual('_uid,prop\r\n1,\r\n');
+  });
+
+  it('exports null values as blank', async () => {
+    toCSVStream([{ _uid: 1, attributes: { prop: null } }], writable);
+    const csv = await writable.asString();
+    expect(csv).toEqual('_uid,prop\r\n1,\r\n');
+  });
+
+  it('exports `false` values as "false"', async () => {
+    toCSVStream([{ _uid: 1, attributes: { prop: false } }], writable);
+    const csv = await writable.asString();
+    expect(csv).toEqual('_uid,prop\r\n1,false\r\n');
+  });
+});
+
+describe('EgoListFormatter', () => {
+  let writable;
+
+  beforeEach(() => {
+    writable = makeWriteableStream();
+  });
+
+  it('writeToStream returns an abort controller', () => {
+    const formatter = new EgoListFormatter({});
+    const controller = formatter.writeToStream(writable);
+    expect(controller.abort).toBeInstanceOf(Function);
+  });
+});

--- a/src/main/utils/formatters/__tests__/ego-list-test.js
+++ b/src/main/utils/formatters/__tests__/ego-list-test.js
@@ -5,7 +5,7 @@ import { asEgoList, toCSVStream, EgoListFormatter } from '../ego-list';
 
 describe('asEgoList', () => {
   it('transforms a network to ego', () => {
-    const network = { nodes: [], edges: [], ego: { id: 1 } };
+    const network = { nodes: [], edges: [], ego: { id: 1, attributes: {} } };
     expect(asEgoList(network)).toEqual([network.ego]);
   });
 });

--- a/src/main/utils/formatters/__tests__/network-test.js
+++ b/src/main/utils/formatters/__tests__/network-test.js
@@ -82,8 +82,8 @@ describe('network format helpers', () => {
       const a = { nodes: [], edges: [], ego: { _uid: 1 }, sessionVariables: { _caseID: 'c' } };
       const b = { nodes: [], edges: [], ego: { _uid: 2 }, sessionVariables: { _caseID: 1 } };
       const egoNetworks = insertEgoInNetworks([a, b]);
-      expect(egoNetworks[0].ego).toEqual({ _uid: 1, attributes: { _caseID: 'c' } });
-      expect(egoNetworks[1].ego).toEqual({ _uid: 2, attributes: { _caseID: 1 } });
+      expect(egoNetworks[0].ego).toEqual({ _uid: 1, _caseID: 'c' });
+      expect(egoNetworks[1].ego).toEqual({ _uid: 2, _caseID: 1 });
     });
   });
 

--- a/src/main/utils/formatters/__tests__/network-test.js
+++ b/src/main/utils/formatters/__tests__/network-test.js
@@ -5,6 +5,7 @@ const {
   getNodeAttributes,
   nodeAttributesProperty,
   unionOfNetworks,
+  insertEgoInNetworks,
 } = require('../network');
 
 describe('network format helpers', () => {
@@ -51,6 +52,30 @@ describe('network format helpers', () => {
       const a = { nodes: [], edges: [{ id: 1 }] };
       const b = { nodes: [], edges: [{ id: 2 }] };
       expect(unionOfNetworks([a, b]).edges).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+
+    it('joins egos of two networks', () => {
+      const a = { nodes: [], edges: [], ego: { id: 1 } };
+      const b = { nodes: [], edges: [], ego: { id: 2 } };
+      expect(unionOfNetworks([a, b]).ego).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+  });
+
+  describe('insertEgoInNetworks', () => {
+    it('inserts ego uid in node objects', () => {
+      const a = { nodes: [{ id: 1 }, { id: 2 }], edges: [], ego: { _uid: 1 } };
+      const b = { nodes: [{ id: a }], edges: [], ego: { _uid: 2 } };
+      const egoNetworks = insertEgoInNetworks([a, b]);
+      expect(egoNetworks[0].nodes).toEqual([{ _egoID: 1, id: 1 }, { _egoID: 1, id: 2 }]);
+      expect(egoNetworks[1].nodes).toEqual([{ _egoID: 2, id: a }]);
+    });
+
+    it('inserts ego uid in edge objects', () => {
+      const a = { nodes: [], edges: [{ id: 1 }, { id: 2 }], ego: { _uid: 1 } };
+      const b = { nodes: [], edges: [{ id: a }], ego: { _uid: 2 } };
+      const egoNetworks = insertEgoInNetworks([a, b]);
+      expect(egoNetworks[0].edges).toEqual([{ _egoID: 1, id: 1 }, { _egoID: 1, id: 2 }]);
+      expect(egoNetworks[1].edges).toEqual([{ _egoID: 2, id: a }]);
     });
   });
 

--- a/src/main/utils/formatters/__tests__/network-test.js
+++ b/src/main/utils/formatters/__tests__/network-test.js
@@ -2,7 +2,7 @@
 const {
   filterNetworkEntities,
   filterNetworksWithQuery,
-  getNodeAttributes,
+  getEntityAttributes,
   nodeAttributesProperty,
   unionOfNetworks,
   insertEgoInNetworks,
@@ -87,10 +87,10 @@ describe('network format helpers', () => {
     });
   });
 
-  describe('getNodeAttributes', () => {
+  describe('getEntityAttributes', () => {
     it('gets nested attributes', () => {
       const node = { id: 1, [nodeAttributesProperty]: { attr: 1 } };
-      expect(getNodeAttributes(node)).toEqual({ attr: 1 });
+      expect(getEntityAttributes(node)).toEqual({ attr: 1 });
     });
   });
 });

--- a/src/main/utils/formatters/__tests__/network-test.js
+++ b/src/main/utils/formatters/__tests__/network-test.js
@@ -77,6 +77,14 @@ describe('network format helpers', () => {
       expect(egoNetworks[0].edges).toEqual([{ _egoID: 1, id: 1 }, { _egoID: 1, id: 2 }]);
       expect(egoNetworks[1].edges).toEqual([{ _egoID: 2, id: a }]);
     });
+
+    it('inserts session variables in ego', () => {
+      const a = { nodes: [], edges: [], ego: { _uid: 1 }, sessionVariables: { _caseID: 'c' } };
+      const b = { nodes: [], edges: [], ego: { _uid: 2 }, sessionVariables: { _caseID: 1 } };
+      const egoNetworks = insertEgoInNetworks([a, b]);
+      expect(egoNetworks[0].ego).toEqual({ _uid: 1, attributes: { _caseID: 'c' } });
+      expect(egoNetworks[1].ego).toEqual({ _uid: 2, attributes: { _caseID: 1 } });
+    });
   });
 
   describe('getNodeAttributes', () => {

--- a/src/main/utils/formatters/__tests__/utils-test.js
+++ b/src/main/utils/formatters/__tests__/utils-test.js
@@ -16,6 +16,7 @@ describe('formatter utilities', () => {
       expect(getFileExtension(formats.adjacencyMatrix)).toEqual('.csv');
       expect(getFileExtension(formats.edgeList)).toEqual('.csv');
       expect(getFileExtension(formats.attributeList)).toEqual('.csv');
+      expect(getFileExtension(formats.ego)).toEqual('.csv');
     });
   });
 

--- a/src/main/utils/formatters/attribute-list.js
+++ b/src/main/utils/formatters/attribute-list.js
@@ -1,6 +1,6 @@
 const { Readable } = require('stream');
 
-const { nodePrimaryKeyProperty, nodeAttributesProperty, egoProperty, processEntityVariables } = require('./network');
+const { convertUuidToDecimal, nodePrimaryKeyProperty, nodeAttributesProperty, egoProperty, processEntityVariables } = require('./network');
 const { cellValue, csvEOL } = require('./csv');
 
 const asAttributeList = (network, _, variableRegistry) => {
@@ -66,7 +66,7 @@ const toCSVStream = (nodes, outStream, withEgo = false) => {
           // The primary key and ego id exist at the top-level; all others inside `.attributes`
           let value;
           if (attrName === nodePrimaryKeyProperty || attrName === egoProperty) {
-            value = node[attrName];
+            value = convertUuidToDecimal(node[attrName]);
           } else {
             value = node[nodeAttributesProperty][attrName];
           }

--- a/src/main/utils/formatters/attribute-list.js
+++ b/src/main/utils/formatters/attribute-list.js
@@ -1,9 +1,17 @@
 const { Readable } = require('stream');
 
-const { nodePrimaryKeyProperty, nodeAttributesProperty, egoProperty } = require('./network');
+const { nodePrimaryKeyProperty, nodeAttributesProperty, egoProperty, processEntityVariables } = require('./network');
 const { cellValue, csvEOL } = require('./csv');
 
-const asAttributeList = network => network.nodes;
+const asAttributeList = (network, _, variableRegistry) => {
+  const processedNodes = (network.nodes || []).map((node) => {
+    if (variableRegistry && variableRegistry.node[node.type]) {
+      return processEntityVariables(node, variableRegistry.node[node.type].variables);
+    }
+    return node;
+  });
+  return processedNodes;
+};
 
 /**
  * The output of this formatter will contain the primary key (_uid)
@@ -82,8 +90,8 @@ const toCSVStream = (nodes, outStream, withEgo = false) => {
 };
 
 class AttributeListFormatter {
-  constructor(data, directed = false, includeEgo = false) {
-    this.list = asAttributeList(data, directed, includeEgo) || [];
+  constructor(data, directed = false, includeEgo = false, variableRegistry) {
+    this.list = asAttributeList(data, directed, variableRegistry) || [];
     this.includeEgo = includeEgo;
   }
   writeToStream(outStream) {

--- a/src/main/utils/formatters/attribute-list.js
+++ b/src/main/utils/formatters/attribute-list.js
@@ -17,7 +17,7 @@ const attributeHeaders = (nodes, withEgo) => {
   initialHeaderSet.add(nodePrimaryKeyProperty);
 
   const headerSet = nodes.reduce((headers, node) => {
-    Object.keys(node.attributes).forEach((key) => {
+    Object.keys(node.attributes || []).forEach((key) => {
       headers.add(key);
     });
     return headers;
@@ -28,7 +28,7 @@ const attributeHeaders = (nodes, withEgo) => {
 /**
  * @return {Object} an abort controller; call the attached abort() method as needed.
  */
-const toCSVStream = (nodes, withEgo, outStream) => {
+const toCSVStream = (nodes, outStream, withEgo = false) => {
   const totalRows = nodes.length;
   const attrNames = attributeHeaders(nodes, withEgo);
   let headerWritten = false;
@@ -76,7 +76,7 @@ class AttributeListFormatter {
     this.includeEgo = includeEgo;
   }
   writeToStream(outStream) {
-    return toCSVStream(this.list, this.includeEgo, outStream);
+    return toCSVStream(this.list, outStream, this.includeEgo);
   }
 }
 

--- a/src/main/utils/formatters/attribute-list.js
+++ b/src/main/utils/formatters/attribute-list.js
@@ -12,17 +12,28 @@ const asAttributeList = network => network.nodes;
 const attributeHeaders = (nodes, withEgo) => {
   const initialHeaderSet = new Set([]);
   if (withEgo) {
-    initialHeaderSet.add({ name: egoProperty, prettyPrint: 'networkCanvasEgoID' });
+    initialHeaderSet.add(egoProperty);
   }
-  initialHeaderSet.add({ name: nodePrimaryKeyProperty, prettyPrint: 'networkCanvasAlterID' });
+  initialHeaderSet.add(nodePrimaryKeyProperty);
 
   const headerSet = nodes.reduce((headers, node) => {
     Object.keys(node[nodeAttributesProperty] || []).forEach((key) => {
-      headers.add({ name: key, prettyPrint: key });
+      headers.add(key);
     });
     return headers;
   }, initialHeaderSet);
   return [...headerSet];
+};
+
+const getPrintableAttribute = (attribute) => {
+  switch (attribute) {
+    case egoProperty:
+      return 'networkCanvasEgoID';
+    case nodePrimaryKeyProperty:
+      return 'networkCanvasAlterID';
+    default:
+      return attribute;
+  }
 };
 
 /**
@@ -39,17 +50,17 @@ const toCSVStream = (nodes, outStream, withEgo = false) => {
   const inStream = new Readable({
     read(/* size */) {
       if (!headerWritten) {
-        this.push(`${attrNames.map(attr => cellValue(attr.prettyPrint)).join(',')}${csvEOL}`);
+        this.push(`${attrNames.map(attr => cellValue(getPrintableAttribute(attr))).join(',')}${csvEOL}`);
         headerWritten = true;
       } else if (rowIndex < totalRows) {
         node = nodes[rowIndex];
-        const values = attrNames.map((attr) => {
+        const values = attrNames.map((attrName) => {
           // The primary key and ego id exist at the top-level; all others inside `.attributes`
           let value;
-          if (attr.name === nodePrimaryKeyProperty || attr.name === egoProperty) {
-            value = node[attr.name];
+          if (attrName === nodePrimaryKeyProperty || attrName === egoProperty) {
+            value = node[attrName];
           } else {
-            value = node[nodeAttributesProperty][attr.name];
+            value = node[nodeAttributesProperty][attrName];
           }
           return cellValue(value);
         });

--- a/src/main/utils/formatters/attribute-list.js
+++ b/src/main/utils/formatters/attribute-list.js
@@ -3,10 +3,10 @@ const { Readable } = require('stream');
 const { convertUuidToDecimal, nodePrimaryKeyProperty, nodeAttributesProperty, egoProperty, processEntityVariables } = require('./network');
 const { cellValue, csvEOL } = require('./csv');
 
-const asAttributeList = (network, _, variableRegistry) => {
+const asAttributeList = (network, _, codebook) => {
   const processedNodes = (network.nodes || []).map((node) => {
-    if (variableRegistry && variableRegistry.node[node.type]) {
-      return processEntityVariables(node, variableRegistry.node[node.type].variables);
+    if (codebook && codebook.node[node.type]) {
+      return processEntityVariables(node, codebook.node[node.type].variables);
     }
     return node;
   });
@@ -90,8 +90,8 @@ const toCSVStream = (nodes, outStream, withEgo = false) => {
 };
 
 class AttributeListFormatter {
-  constructor(data, directed = false, includeEgo = false, variableRegistry) {
-    this.list = asAttributeList(data, directed, variableRegistry) || [];
+  constructor(data, directed = false, includeEgo = false, codebook) {
+    this.list = asAttributeList(data, directed, codebook) || [];
     this.includeEgo = includeEgo;
   }
   writeToStream(outStream) {

--- a/src/main/utils/formatters/csv.js
+++ b/src/main/utils/formatters/csv.js
@@ -27,8 +27,15 @@ const cellValue = (value) => {
       serialized = value.toString(); // value will never be null here
     }
     return quoteValue(serialized);
-  } else if (typeof value === 'string' && value.indexOf('"') >= 0) {
-    return quoteValue(value);
+  } else if (typeof value === 'string') {
+    let escapedValue = value;
+    if (value.indexOf('"') >= 0) {
+      escapedValue = quoteValue(value);
+    }
+    if (escapedValue.indexOf(',') >= 0) {
+      escapedValue = `"${escapedValue}"`; // values containing commas need quotes
+    }
+    return escapedValue;
   }
   return value;
 };

--- a/src/main/utils/formatters/csv.js
+++ b/src/main/utils/formatters/csv.js
@@ -31,8 +31,7 @@ const cellValue = (value) => {
     let escapedValue = value;
     if (value.indexOf('"') >= 0) {
       escapedValue = quoteValue(value);
-    }
-    if (escapedValue.indexOf(',') >= 0) {
+    } else if (escapedValue.indexOf(',') >= 0) {
       escapedValue = `"${escapedValue}"`; // values containing commas need quotes
     }
     return escapedValue;

--- a/src/main/utils/formatters/edge-list.js
+++ b/src/main/utils/formatters/edge-list.js
@@ -23,10 +23,10 @@ const { convertUuidToDecimal, nodePrimaryKeyProperty, egoProperty, nodeAttribute
  *                            default: false
  * @return {Array} the edges list
  */
-const asEdgeList = (network, directed = false, _, variableRegistry) => {
+const asEdgeList = (network, directed = false, _, codebook) => {
   const processedEdges = (network.edges || []).map((edge) => {
-    const variables = variableRegistry && variableRegistry.edge[edge.type] ?
-      variableRegistry.edge[edge.type].variables : {};
+    const variables = codebook && codebook.edge[edge.type] ?
+      codebook.edge[edge.type].variables : {};
     return processEntityVariables(edge, variables);
   });
   if (directed === false) {
@@ -135,8 +135,8 @@ const toCSVStream = (edges, outStream, withEgo = false) => {
 };
 
 class EdgeListFormatter {
-  constructor(data, directed = false, includeEgo = false, variableRegistry) {
-    this.list = asEdgeList(data, directed, includeEgo, variableRegistry);
+  constructor(data, directed = false, includeEgo = false, codebook) {
+    this.list = asEdgeList(data, directed, includeEgo, codebook);
     this.includeEgo = includeEgo;
   }
   writeToStream(outStream) {

--- a/src/main/utils/formatters/edge-list.js
+++ b/src/main/utils/formatters/edge-list.js
@@ -1,7 +1,7 @@
 const { Readable } = require('stream');
 
 const { cellValue, csvEOL } = require('./csv');
-const { nodePrimaryKeyProperty, egoProperty, nodeAttributesProperty, processEntityVariables } = require('./network');
+const { convertUuidToDecimal, nodePrimaryKeyProperty, egoProperty, nodeAttributesProperty, processEntityVariables } = require('./network');
 
 /**
  * Builds an edge list for a network, based only on its edges (it need
@@ -111,7 +111,7 @@ const toCSVStream = (edges, outStream, withEgo = false) => {
           let value;
           if (attrName === nodePrimaryKeyProperty || attrName === egoProperty ||
             attrName === 'to' || attrName === 'from') {
-            value = edge[attrName];
+            value = convertUuidToDecimal(edge[attrName]);
           } else {
             value = edge[nodeAttributesProperty][attrName];
           }

--- a/src/main/utils/formatters/edge-list.js
+++ b/src/main/utils/formatters/edge-list.js
@@ -1,6 +1,7 @@
 const { Readable } = require('stream');
 
-const { csvEOL } = require('./csv');
+const { cellValue, csvEOL } = require('./csv');
+const { nodePrimaryKeyProperty } = require('./network');
 
 /**
  * Builds an edge list for a network, based only on its edges (it need
@@ -20,18 +21,42 @@ const { csvEOL } = require('./csv');
  * @param  {Object} network NC network containing edges
  * @param  {Boolean} directed if false, adjacencies are represented in both directions
  *                            default: false
- * @return {Object.<string, Set>} the adjacency list
+ * @return {Array} the edges list
  */
-const asEdgeList = (network, directed = false) =>
-  (network.edges || []).reduce((acc, val) => {
-    acc[val.from] = acc[val.from] || new Set();
-    acc[val.from].add(val.to);
-    if (directed === false) {
-      acc[val.to] = acc[val.to] || new Set();
-      acc[val.to].add(val.from);
-    }
-    return acc;
-  }, {});
+const asEdgeList = (network, directed = false) => {
+  if (directed === false) {
+    // this may change if we have support for directed vs undirected edges in NC
+    return network.edges.reduce((arr, edge) => (
+      arr.concat(
+        { ...edge, _source: edge.from, _target: edge.to },
+        { ...edge, _source: edge.to, _target: edge.from },
+      )
+    ), []);
+  }
+  return network.edges.map(edge => ({ ...edge, _source: edge.from, _target: edge.to }));
+};
+
+/**
+ * The output of this formatter will contain the primary key (_uid)
+ * and all model data (inside the `attributes` property)
+ */
+const attributeHeaders = (edges, withEgo) => {
+  const initialHeaderSet = new Set([]);
+  if (withEgo) {
+    initialHeaderSet.add('_egoID');
+  }
+  initialHeaderSet.add(nodePrimaryKeyProperty);
+  initialHeaderSet.add('_source');
+  initialHeaderSet.add('_target');
+
+  const headerSet = edges.reduce((headers, edge) => {
+    Object.keys(edge.attributes).forEach((key) => {
+      headers.add(key);
+    });
+    return headers;
+  }, initialHeaderSet);
+  return [...headerSet];
+};
 
 /**
  * Write a CSV reprensentation of the list to the given Writable stream.
@@ -46,19 +71,34 @@ const asEdgeList = (network, directed = false) =>
  *
  * @return {Object} an abort controller; call the attached abort() method as needed.
  */
-// TODO: quoting/escaping (not needed while we're only using UUIDs)
-const toCSVStream = (edgeList, outStream) => {
-  const adjacencies = Object.entries(edgeList);
-  const totalChunks = adjacencies.length;
+const toCSVStream = (edges, withEgo, outStream) => {
+  const totalChunks = edges.length;
   let chunkContent;
   let chunkIndex = 0;
+  const attrNames = attributeHeaders(edges, withEgo);
+  let headerWritten = false;
+  let edge;
 
   const inStream = new Readable({
     read(/* size */) {
-      if (chunkIndex < totalChunks) {
-        const [fromId, destinations] = adjacencies[chunkIndex];
-        chunkContent = [...destinations].map(toId => `${fromId},${toId}`).join(csvEOL);
-        this.push(`${chunkContent}${csvEOL}`);
+      if (!headerWritten) {
+        this.push(`${attrNames.map(attr => cellValue(attr)).join(',')}${csvEOL}`);
+        headerWritten = true;
+      } else if (chunkIndex < totalChunks) {
+        edge = edges[chunkIndex];
+        const values = attrNames.map((attrName) => {
+          // primary key/ego id/to/from exist at the top-level; all others inside `.attributes`
+          let value;
+          if (attrName === nodePrimaryKeyProperty || attrName === '_egoID' ||
+            attrName === '_source' || attrName === '_target') {
+            value = edge[attrName];
+          } else {
+            value = edge.attributes[attrName];
+          }
+          return cellValue(value);
+        });
+        chunkContent = `${values.join(',')}${csvEOL}`;
+        this.push(chunkContent);
         chunkIndex += 1;
       } else {
         this.push(null);
@@ -75,11 +115,12 @@ const toCSVStream = (edgeList, outStream) => {
 };
 
 class EdgeListFormatter {
-  constructor(data, directed = false) {
-    this.list = asEdgeList(data, directed);
+  constructor(data, directed = false, includeEgo = false) {
+    this.list = asEdgeList(data, directed, includeEgo);
+    this.includeEgo = includeEgo;
   }
   writeToStream(outStream) {
-    return toCSVStream(this.list, outStream);
+    return toCSVStream(this.list, this.includeEgo, outStream);
   }
 }
 

--- a/src/main/utils/formatters/edge-list.js
+++ b/src/main/utils/formatters/edge-list.js
@@ -26,7 +26,7 @@ const { nodePrimaryKeyProperty } = require('./network');
 const asEdgeList = (network, directed = false) => {
   if (directed === false) {
     // this may change if we have support for directed vs undirected edges in NC
-    return network.edges.reduce((arr, edge) => (
+    return (network.edges || []).reduce((arr, edge) => (
       arr.concat(
         { ...edge, _source: edge.from, _target: edge.to },
         { ...edge, _source: edge.to, _target: edge.from },
@@ -50,7 +50,7 @@ const attributeHeaders = (edges, withEgo) => {
   initialHeaderSet.add('_target');
 
   const headerSet = edges.reduce((headers, edge) => {
-    Object.keys(edge.attributes).forEach((key) => {
+    Object.keys(edge.attributes || []).forEach((key) => {
       headers.add(key);
     });
     return headers;
@@ -71,7 +71,7 @@ const attributeHeaders = (edges, withEgo) => {
  *
  * @return {Object} an abort controller; call the attached abort() method as needed.
  */
-const toCSVStream = (edges, withEgo, outStream) => {
+const toCSVStream = (edges, outStream, withEgo = false) => {
   const totalChunks = edges.length;
   let chunkContent;
   let chunkIndex = 0;
@@ -120,7 +120,7 @@ class EdgeListFormatter {
     this.includeEgo = includeEgo;
   }
   writeToStream(outStream) {
-    return toCSVStream(this.list, this.includeEgo, outStream);
+    return toCSVStream(this.list, outStream, this.includeEgo);
   }
 }
 

--- a/src/main/utils/formatters/ego-list.js
+++ b/src/main/utils/formatters/ego-list.js
@@ -16,7 +16,7 @@ const attributeHeaders = (egos) => {
   initialHeaderSet.add(nodePrimaryKeyProperty);
 
   const headerSet = egos.reduce((headers, ego) => {
-    Object.keys(ego.attributes).forEach((key) => {
+    Object.keys((ego && ego.attributes) || {}).forEach((key) => {
       headers.add(key);
     });
     return headers;
@@ -41,7 +41,7 @@ const toCSVStream = (egos, outStream) => {
         this.push(`${attrNames.map(attr => cellValue(attr)).join(',')}${csvEOL}`);
         headerWritten = true;
       } else if (rowIndex < totalRows) {
-        ego = egos[rowIndex];
+        ego = egos[rowIndex] || {};
         const values = attrNames.map((attrName) => {
           // The primary key and ego id exist at the top-level; all others inside `.attributes`
           let value;

--- a/src/main/utils/formatters/ego-list.js
+++ b/src/main/utils/formatters/ego-list.js
@@ -1,11 +1,14 @@
 const { Readable } = require('stream');
 
-const { nodePrimaryKeyProperty, nodeAttributesProperty, caseProperty } = require('./network');
+const { nodePrimaryKeyProperty, nodeAttributesProperty, caseProperty, processEntityVariables } = require('./network');
 const { cellValue, csvEOL } = require('./csv');
 
-const asEgoList = network => (
-  Array.isArray(network.ego) ? network.ego : [network.ego]
-);
+const asEgoList = (network, _, variableRegistry) => {
+  const egoList = Array.isArray(network.ego) ? network.ego : [network.ego];
+  const variables = variableRegistry && variableRegistry.ego ? variableRegistry.ego.variables : {};
+  const processedEgo = egoList.map(ego => (processEntityVariables(ego, variables)));
+  return processedEgo;
+};
 
 /**
  * The output of this formatter will contain the primary key (_uid)
@@ -82,8 +85,8 @@ const toCSVStream = (egos, outStream) => {
 };
 
 class EgoListFormatter {
-  constructor(data, directed = false, includeEgo = false) {
-    this.list = asEgoList(data, directed, includeEgo) || [];
+  constructor(data, directed = false, _, variableRegistry) {
+    this.list = asEgoList(data, directed, variableRegistry) || [];
   }
   writeToStream(outStream) {
     // TODO not a list here...somewhere else needs to compile the egos

--- a/src/main/utils/formatters/ego-list.js
+++ b/src/main/utils/formatters/ego-list.js
@@ -3,9 +3,9 @@ const { Readable } = require('stream');
 const { convertUuidToDecimal, nodePrimaryKeyProperty, nodeAttributesProperty, caseProperty, processEntityVariables } = require('./network');
 const { cellValue, csvEOL } = require('./csv');
 
-const asEgoList = (network, _, variableRegistry) => {
+const asEgoList = (network, _, codebook) => {
   const egoList = Array.isArray(network.ego) ? network.ego : [network.ego];
-  const variables = variableRegistry && variableRegistry.ego ? variableRegistry.ego.variables : {};
+  const variables = codebook && codebook.ego ? codebook.ego.variables : {};
   const processedEgo = egoList.map(ego => (processEntityVariables(ego, variables)));
   return processedEgo;
 };
@@ -87,8 +87,8 @@ const toCSVStream = (egos, outStream) => {
 };
 
 class EgoListFormatter {
-  constructor(data, directed = false, _, variableRegistry) {
-    this.list = asEgoList(data, directed, variableRegistry) || [];
+  constructor(data, directed = false, _, codebook) {
+    this.list = asEgoList(data, directed, codebook) || [];
   }
   writeToStream(outStream) {
     // TODO not a list here...somewhere else needs to compile the egos

--- a/src/main/utils/formatters/ego-list.js
+++ b/src/main/utils/formatters/ego-list.js
@@ -1,6 +1,6 @@
 const { Readable } = require('stream');
 
-const { nodePrimaryKeyProperty, nodeAttributesProperty, caseProperty, processEntityVariables } = require('./network');
+const { convertUuidToDecimal, nodePrimaryKeyProperty, nodeAttributesProperty, caseProperty, processEntityVariables } = require('./network');
 const { cellValue, csvEOL } = require('./csv');
 
 const asEgoList = (network, _, variableRegistry) => {
@@ -60,7 +60,9 @@ const toCSVStream = (egos, outStream) => {
         const values = attrNames.map((attrName) => {
           // The primary key and ego id exist at the top-level; all others inside `.attributes`
           let value;
-          if (attrName === nodePrimaryKeyProperty || attrName === caseProperty) {
+          if (attrName === nodePrimaryKeyProperty) {
+            value = convertUuidToDecimal(ego[attrName]);
+          } else if (attrName === caseProperty) {
             value = ego[attrName];
           } else {
             value = ego[nodeAttributesProperty][attrName];

--- a/src/main/utils/formatters/ego-list.js
+++ b/src/main/utils/formatters/ego-list.js
@@ -13,16 +13,27 @@ const asEgoList = network => (
  */
 const attributeHeaders = (egos) => {
   const initialHeaderSet = new Set([]);
-  initialHeaderSet.add({ name: nodePrimaryKeyProperty, prettyPrint: 'networkCanvasEgoID' });
-  initialHeaderSet.add({ name: caseProperty, prettyPrint: 'networkCanvasCaseID' });
+  initialHeaderSet.add(nodePrimaryKeyProperty);
+  initialHeaderSet.add(caseProperty);
 
   const headerSet = egos.reduce((headers, ego) => {
     Object.keys((ego && ego[nodeAttributesProperty]) || {}).forEach((key) => {
-      headers.add({ name: key, prettyPrint: key });
+      headers.add(key);
     });
     return headers;
   }, initialHeaderSet);
   return [...headerSet];
+};
+
+const getPrintableAttribute = (attribute) => {
+  switch (attribute) {
+    case caseProperty:
+      return 'networkCanvasCaseID';
+    case nodePrimaryKeyProperty:
+      return 'networkCanvasEgoID';
+    default:
+      return attribute;
+  }
 };
 
 /**
@@ -39,17 +50,17 @@ const toCSVStream = (egos, outStream) => {
   const inStream = new Readable({
     read(/* size */) {
       if (!headerWritten) {
-        this.push(`${attrNames.map(attr => cellValue(attr.prettyPrint)).join(',')}${csvEOL}`);
+        this.push(`${attrNames.map(attr => cellValue(getPrintableAttribute(attr))).join(',')}${csvEOL}`);
         headerWritten = true;
       } else if (rowIndex < totalRows) {
         ego = egos[rowIndex] || {};
-        const values = attrNames.map((attr) => {
+        const values = attrNames.map((attrName) => {
           // The primary key and ego id exist at the top-level; all others inside `.attributes`
           let value;
-          if (attr.name === nodePrimaryKeyProperty || attr.name === caseProperty) {
-            value = ego[attr.name];
+          if (attrName === nodePrimaryKeyProperty || attrName === caseProperty) {
+            value = ego[attrName];
           } else {
-            value = ego[nodeAttributesProperty][attr.name];
+            value = ego[nodeAttributesProperty][attrName];
           }
           return cellValue(value);
         });

--- a/src/main/utils/formatters/graphml/GraphMLFormatter.js
+++ b/src/main/utils/formatters/graphml/GraphMLFormatter.js
@@ -3,7 +3,7 @@ const { Readable } = require('stream');
 const { graphMLGenerator } = require('./createGraphML');
 
 class GraphMLFormatter {
-  constructor(data, useDirectedEdges, variableRegistry) {
+  constructor(data, useDirectedEdges, _, variableRegistry) {
     this.network = data;
     this.variableRegistry = variableRegistry;
     this.useDirectedEdges = useDirectedEdges;

--- a/src/main/utils/formatters/graphml/GraphMLFormatter.js
+++ b/src/main/utils/formatters/graphml/GraphMLFormatter.js
@@ -3,15 +3,15 @@ const { Readable } = require('stream');
 const { graphMLGenerator } = require('./createGraphML');
 
 class GraphMLFormatter {
-  constructor(data, useDirectedEdges, _, variableRegistry) {
+  constructor(data, useDirectedEdges, _, codebook) {
     this.network = data;
-    this.variableRegistry = variableRegistry;
+    this.codebook = codebook;
     this.useDirectedEdges = useDirectedEdges;
   }
   writeToStream(outStream) {
     const generator = graphMLGenerator(
       this.network,
-      this.variableRegistry,
+      this.codebook,
       this.useDirectedEdges,
     );
     const inStream = new Readable({

--- a/src/main/utils/formatters/graphml/__tests__/GraphMLFormatter-test.js
+++ b/src/main/utils/formatters/graphml/__tests__/GraphMLFormatter-test.js
@@ -5,23 +5,23 @@ import GraphMLFormatter from '../GraphMLFormatter';
 
 describe('GraphMLFormatter writeToStream', () => {
   let network;
-  let variableRegistry;
+  let codebook;
   let writable;
 
   beforeEach(() => {
     writable = makeWriteableStream();
     network = { nodes: [], edges: [] };
-    variableRegistry = { node: {} };
+    codebook = { node: {} };
   });
 
   it('returns an abort controller', () => {
-    const formatter = new GraphMLFormatter(network, false, false, variableRegistry);
+    const formatter = new GraphMLFormatter(network, false, false, codebook);
     const controller = formatter.writeToStream(writable);
     expect(controller.abort).toBeInstanceOf(Function);
   });
 
   it('produces XML', async () => {
-    const formatter = new GraphMLFormatter(network, false, false, variableRegistry);
+    const formatter = new GraphMLFormatter(network, false, false, codebook);
     formatter.writeToStream(writable);
     const xml = await writable.asString();
     expect(xml).toMatch('<graphml');

--- a/src/main/utils/formatters/graphml/__tests__/GraphMLFormatter-test.js
+++ b/src/main/utils/formatters/graphml/__tests__/GraphMLFormatter-test.js
@@ -15,13 +15,13 @@ describe('GraphMLFormatter writeToStream', () => {
   });
 
   it('returns an abort controller', () => {
-    const formatter = new GraphMLFormatter(network, false, variableRegistry);
+    const formatter = new GraphMLFormatter(network, false, false, variableRegistry);
     const controller = formatter.writeToStream(writable);
     expect(controller.abort).toBeInstanceOf(Function);
   });
 
   it('produces XML', async () => {
-    const formatter = new GraphMLFormatter(network, false, variableRegistry);
+    const formatter = new GraphMLFormatter(network, false, false, variableRegistry);
     formatter.writeToStream(writable);
     const xml = await writable.asString();
     expect(xml).toMatch('<graphml');

--- a/src/main/utils/formatters/graphml/__tests__/createGraphML-test.js
+++ b/src/main/utils/formatters/graphml/__tests__/createGraphML-test.js
@@ -13,7 +13,7 @@ describe('buildGraphML', () => {
   };
   const edgeType = 'peer';
   let network;
-  let variableRegistry;
+  let codebook;
   let xml;
 
   beforeEach(() => {
@@ -26,7 +26,7 @@ describe('buildGraphML', () => {
         { from: '1', to: '2', type: 'mock-uuid-3' },
       ],
     };
-    variableRegistry = {
+    codebook = {
       node: {
         person: {
           variables: {
@@ -42,7 +42,7 @@ describe('buildGraphML', () => {
         },
       },
     };
-    xml = buildXML(network, variableRegistry);
+    xml = buildXML(network, codebook);
   });
 
   it('produces a graphml document', () => {
@@ -77,7 +77,7 @@ describe('buildGraphML', () => {
 
   describe('with directed edge option', () => {
     beforeEach(() => {
-      xml = buildXML(network, variableRegistry, true);
+      xml = buildXML(network, codebook, true);
     });
 
     it('specifies directed edges', () => {

--- a/src/main/utils/formatters/graphml/createGraphML.js
+++ b/src/main/utils/formatters/graphml/createGraphML.js
@@ -17,8 +17,8 @@ const { nodePrimaryKeyProperty, nodeAttributesProperty, getEntityAttributes } = 
 const {
   createDataElement,
   getGraphMLTypeForKey,
-  getTypeFromVariableRegistry,
-  variableRegistryExists,
+  getTypeFromCodebook,
+  codebookExists,
   VariableType,
 } = require('./helpers');
 
@@ -59,13 +59,13 @@ const setUpXml = (useDirectedEdges) => {
 
 // <key> elements provide the type definitions for GraphML data elements
 // @return {Object} a fragment to insert, and any variables that were missing from the variable
-//                  registry: `{ fragment: <DocumentFragment>, missingVariables: [] }`.
+//                  codebook: `{ fragment: <DocumentFragment>, missingVariables: [] }`.
 const generateKeyElements = (
   document, // the XML ownerDocument
   entities, // networkData.nodes or edges
   type, // 'node' or 'edge'
   excludeList, // Variables to exlude
-  variableRegistry, // variable registry
+  codebook, // codebook
   layoutVariable, // boolean value uses for edges?
 ) => {
   const fragment = document.createDocumentFragment();
@@ -105,18 +105,18 @@ const generateKeyElements = (
     // Entity data model attributes are now stored under a specific property
 
     Object.keys(iterableElement).forEach((key) => {
-      // transpose ids to names based on registry; fall back to the raw key
-      const keyName = getTypeFromVariableRegistry(variableRegistry, type, element, key, 'name') || key;
+      // transpose ids to names based on codebook; fall back to the raw key
+      const keyName = getTypeFromCodebook(codebook, type, element, key, 'name') || key;
       if (done.indexOf(keyName) === -1 && !excludeList.includes(keyName)) {
         const keyElement = document.createElement('key');
         keyElement.setAttribute('id', keyName);
         keyElement.setAttribute('attr.name', keyName);
 
-        if (!variableRegistryExists(variableRegistry, type, element, key)) {
+        if (!codebookExists(codebook, type, element, key)) {
           missingVariables.push(`"${key}" in ${type}.${element.type}`);
         }
 
-        const variableType = getTypeFromVariableRegistry(variableRegistry, type, element, key);
+        const variableType = getTypeFromCodebook(codebook, type, element, key);
         switch (variableType) {
           case VariableType.boolean:
             keyElement.setAttribute('attr.type', variableType);
@@ -141,7 +141,7 @@ const generateKeyElements = (
             break;
           }
           case VariableType.categorical: {
-            const options = getTypeFromVariableRegistry(variableRegistry, type, element, key, 'options');
+            const options = getTypeFromCodebook(codebook, type, element, key, 'options');
             options.forEach((option, index) => {
               if (index === options.length - 1) {
                 keyElement.setAttribute('id', `${keyName}_${option.value}`);
@@ -181,8 +181,8 @@ const generateDataElements = (
   document, // the XML ownerDocument
   dataList, // List of nodes or edges
   type, // Element type to be created. "node" or "egde"
-  excludeList, // Attributes to exclude lookup of in variable registry
-  variableRegistry, // Copy of variable registry
+  excludeList, // Attributes to exclude lookup of in codebook
+  codebook, // Copy of codebook
   layoutVariable, // Primary layout variable. Null for edges
 ) => {
   const fragment = document.createDocumentFragment();
@@ -204,18 +204,18 @@ const generateDataElements = (
     fragment.appendChild(domElement);
 
     if (type === 'edge') {
-      const label = variableRegistry && variableRegistry[type] &&
-        variableRegistry[type][dataElement.type] && (variableRegistry[type][dataElement.type].name
-          || variableRegistry[type][dataElement.type].label);
+      const label = codebook && codebook[type] &&
+        codebook[type][dataElement.type] && (codebook[type][dataElement.type].name
+          || codebook[type][dataElement.type].label);
 
       domElement.appendChild(createDataElement(document, 'label', label));
 
       Object.keys(dataElement).forEach((key) => {
-        const keyName = getTypeFromVariableRegistry(variableRegistry, type, dataElement, key, 'name') || key;
+        const keyName = getTypeFromCodebook(codebook, type, dataElement, key, 'name') || key;
         if (!excludeList.includes(keyName)) {
           if (typeof dataElement[key] !== 'object') {
             domElement.appendChild(createDataElement(document, keyName, dataElement[key]));
-          } else if (getTypeFromVariableRegistry(variableRegistry, type, dataElement, key) === 'layout') {
+          } else if (getTypeFromCodebook(codebook, type, dataElement, key) === 'layout') {
             domElement.appendChild(createDataElement(document, `${keyName}X`, dataElement[key].x));
             domElement.appendChild(createDataElement(document, `${keyName}Y`, dataElement[key].y));
           } else {
@@ -229,10 +229,10 @@ const generateDataElements = (
 
     // Add entity attributes
     Object.keys(nodeAttrs).forEach((key) => {
-      const keyName = getTypeFromVariableRegistry(variableRegistry, type, dataElement, key, 'name') || key;
+      const keyName = getTypeFromCodebook(codebook, type, dataElement, key, 'name') || key;
       if (!excludeList.includes(keyName) && !!nodeAttrs[key]) {
-        if (getTypeFromVariableRegistry(variableRegistry, type, dataElement, key) === 'categorical') {
-          const options = getTypeFromVariableRegistry(variableRegistry, type, dataElement, key, 'options');
+        if (getTypeFromCodebook(codebook, type, dataElement, key) === 'categorical') {
+          const options = getTypeFromCodebook(codebook, type, dataElement, key, 'options');
           options.forEach((option) => {
             const optionKey = `${keyName}_${option.value}`;
             domElement.appendChild(createDataElement(
@@ -240,7 +240,7 @@ const generateDataElements = (
           });
         } else if (typeof nodeAttrs[key] !== 'object') {
           domElement.appendChild(createDataElement(document, keyName, nodeAttrs[key]));
-        } else if (getTypeFromVariableRegistry(variableRegistry, type, dataElement, key) === 'layout') {
+        } else if (getTypeFromCodebook(codebook, type, dataElement, key) === 'layout') {
           domElement.appendChild(createDataElement(document, `${keyName}X`, nodeAttrs[key].x));
           domElement.appendChild(createDataElement(document, `${keyName}Y`, nodeAttrs[key].y));
         } else {
@@ -263,7 +263,7 @@ const generateDataElements = (
 };
 
 // Generator to supply XML content in chunks to both string and stream producers
-function* graphMLGenerator(networkData, variableRegistry, useDirectedEdges) {
+function* graphMLGenerator(networkData, codebook, useDirectedEdges) {
   const serializer = new globalContext.XMLSerializer();
   const serialize = fragment => `${serializer.serializeToString(fragment)}${eol}`;
 
@@ -273,7 +273,7 @@ function* graphMLGenerator(networkData, variableRegistry, useDirectedEdges) {
 
   // find the first variable of type layout
   let layoutVariable;
-  forInRight(variableRegistry.node, (value) => {
+  forInRight(codebook.node, (value) => {
     layoutVariable = findKey(value.variables, { type: 'layout' });
   });
 
@@ -282,7 +282,7 @@ function* graphMLGenerator(networkData, variableRegistry, useDirectedEdges) {
     nodes,
     'node',
     [nodePrimaryKeyProperty],
-    variableRegistry,
+    codebook,
     layoutVariable,
   );
   const generateEdgeKeys = edges => generateKeyElements(
@@ -290,14 +290,14 @@ function* graphMLGenerator(networkData, variableRegistry, useDirectedEdges) {
     edges,
     'edge',
     [nodePrimaryKeyProperty, 'from', 'to', 'type'],
-    variableRegistry,
+    codebook,
   );
   const generateNodeElements = nodes => generateDataElements(
     xmlDoc,
     nodes,
     'node',
     [nodePrimaryKeyProperty, nodeAttributesProperty],
-    variableRegistry,
+    codebook,
     layoutVariable,
   );
   const generateEdgeElements = edges => generateDataElements(
@@ -305,7 +305,7 @@ function* graphMLGenerator(networkData, variableRegistry, useDirectedEdges) {
     edges,
     'edge',
     [nodePrimaryKeyProperty, nodeAttributesProperty, 'from', 'to', 'type'],
-    variableRegistry,
+    codebook,
   );
 
   // generate keys for nodes
@@ -324,9 +324,9 @@ function* graphMLGenerator(networkData, variableRegistry, useDirectedEdges) {
 
   const missingVariables = [...missingNodeVars, ...missingEdgeVars];
   if (missingVariables.length > 0) {
-    // hard fail if checking the registry fails
+    // hard fail if checking the codebook fails
     // remove this to fall back to using "text" for unknowns
-    // throw new Error(`The variable registry seems to be missing
+    // throw new Error(`The codebook seems to be missing
     // "type" of: ${join(missingVariables, ', ')}.`);
     // return null;
   }
@@ -350,15 +350,15 @@ function* graphMLGenerator(networkData, variableRegistry, useDirectedEdges) {
 /**
  * Network Canvas interface for ExportData
  * @param  {Object} networkData network from redux state
- * @param  {Object} variableRegistry from protocol in redux state
+ * @param  {Object} codebook from protocol in redux state
  * @param  {Function} onError
  * @param  {Function} saveFile injected SaveFile dependency (called with the xml contents)
  * @return {} the return value from saveFile
  */
-const createGraphML = (networkData, variableRegistry, onError, saveFile) => {
+const createGraphML = (networkData, codebook, onError, saveFile) => {
   let xmlString = '';
   try {
-    for (const chunk of graphMLGenerator(networkData, variableRegistry)) { // eslint-disable-line
+    for (const chunk of graphMLGenerator(networkData, codebook)) { // eslint-disable-line
       xmlString += chunk;
     }
   } catch (err) {

--- a/src/main/utils/formatters/graphml/helpers.js
+++ b/src/main/utils/formatters/graphml/helpers.js
@@ -37,20 +37,20 @@ const getGraphMLTypeForKey = (data, key) => (
     return 'string';
   }, ''));
 
-const getVariableInfo = (variableRegistry, type, element, key) => (
-  variableRegistry[type] &&
-  variableRegistry[type][element.type] &&
-  variableRegistry[type][element.type].variables &&
-  variableRegistry[type][element.type].variables[key]
+const getVariableInfo = (codebook, type, element, key) => (
+  codebook[type] &&
+  codebook[type][element.type] &&
+  codebook[type][element.type].variables &&
+  codebook[type][element.type].variables[key]
 );
 
-const variableRegistryExists = (variableRegistry, type, element, key) => {
-  const variableInfo = getVariableInfo(variableRegistry, type, element, key);
+const codebookExists = (codebook, type, element, key) => {
+  const variableInfo = getVariableInfo(codebook, type, element, key);
   return variableInfo && variableInfo.type && VariableTypeValues.includes(variableInfo.type);
 };
 
-const getTypeFromVariableRegistry = (variableRegistry, type, element, key, variableAttribute = 'type') => {
-  const variableInfo = getVariableInfo(variableRegistry, type, element, key);
+const getTypeFromCodebook = (codebook, type, element, key, variableAttribute = 'type') => {
+  const variableInfo = getVariableInfo(codebook, type, element, key);
   return variableInfo && variableInfo[variableAttribute];
 };
 
@@ -70,6 +70,6 @@ const createDataElement = (xmlDoc, key, text) =>
 
 exports.createDataElement = createDataElement;
 exports.getGraphMLTypeForKey = getGraphMLTypeForKey;
-exports.getTypeFromVariableRegistry = getTypeFromVariableRegistry;
-exports.variableRegistryExists = variableRegistryExists;
+exports.getTypeFromCodebook = getTypeFromCodebook;
+exports.codebookExists = codebookExists;
 exports.VariableType = VariableType;

--- a/src/main/utils/formatters/graphml/helpers.js
+++ b/src/main/utils/formatters/graphml/helpers.js
@@ -1,4 +1,4 @@
-const { getNodeAttributes } = require('../network');
+const { getEntityAttributes } = require('../network');
 const { isNil } = require('lodash');
 
 // TODO: VariableType[Values] is shared with 'protocol-consts' in NC
@@ -18,7 +18,7 @@ const VariableTypeValues = Object.freeze(Object.values(VariableType));
 // returns a graphml type
 const getGraphMLTypeForKey = (data, key) => (
   data.reduce((result, value) => {
-    const attrs = getNodeAttributes(value);
+    const attrs = getEntityAttributes(value);
     if (isNil(attrs[key])) return result;
     let currentType = typeof attrs[key];
     if (currentType === 'number') {

--- a/src/main/utils/formatters/index.js
+++ b/src/main/utils/formatters/index.js
@@ -1,11 +1,13 @@
 const GraphMLFormatter = require('./graphml/GraphMLFormatter');
 const { AdjacencyMatrixFormatter } = require('./matrix');
 const { AttributeListFormatter } = require('./attribute-list');
+const { EgoListFormatter } = require('./ego-list');
 const { EdgeListFormatter } = require('./edge-list');
 
 module.exports = {
   AdjacencyMatrixFormatter,
   AttributeListFormatter,
+  EgoListFormatter,
   EdgeListFormatter,
   GraphMLFormatter,
 };

--- a/src/main/utils/formatters/network.js
+++ b/src/main/utils/formatters/network.js
@@ -3,6 +3,8 @@ const getFilter = require('../network-query/filter').default;
 
 // TODO: share with other places this is defined
 const nodePrimaryKeyProperty = '_uid';
+const egoProperty = '_egoID';
+const caseProperty = '_caseID';
 
 const nodeAttributesProperty = 'attributes';
 
@@ -12,7 +14,7 @@ const unionOfNetworks = networks =>
   networks.reduce((union, network) => {
     union.nodes.push(...network.nodes);
     union.edges.push(...network.edges);
-    union.ego.push(network.ego); // TODO undefined is not a function
+    union.ego.push(network.ego);
     return union;
   }, { nodes: [], edges: [], ego: [] });
 
@@ -42,9 +44,13 @@ const filterNetworkEntities = (networks, filterConfig) => {
 
 const insertNetworkEgo = network => (
   {
-    nodes: network.nodes.map(node => ({ _egoID: network.ego[nodePrimaryKeyProperty], ...node })),
-    edges: network.edges.map(edge => ({ _egoID: network.ego[nodePrimaryKeyProperty], ...edge })),
-    ego: { ...network.ego, attributes: { ...network.sessionVariables, ...network.ego.attributes } },
+    nodes: network.nodes.map(node => (
+      { [egoProperty]: network.ego[nodePrimaryKeyProperty], ...node }
+    )),
+    edges: network.edges.map(edge => (
+      { [egoProperty]: network.ego[nodePrimaryKeyProperty], ...edge }
+    )),
+    ego: { ...network.sessionVariables, ...network.ego },
   }
 );
 
@@ -84,6 +90,8 @@ module.exports = {
   getNodeAttributes,
   insertEgoInNetworks,
   nodeAttributesProperty,
+  egoProperty,
+  caseProperty,
   nodePrimaryKeyProperty,
   transposedRegistry,
   transposedRegistrySection,

--- a/src/main/utils/formatters/network.js
+++ b/src/main/utils/formatters/network.js
@@ -91,10 +91,10 @@ const insertEgoInNetworks = networks => (
   networks.map(network => insertNetworkEgo(network))
 );
 
-const transposedRegistryVariables = (sectionRegistry, definition) => {
+const transposedCodebookVariables = (sectionCodebook, definition) => {
   if (!definition.variables) { // not required for edges
-    sectionRegistry[definition.name] = definition; // eslint-disable-line no-param-reassign
-    return sectionRegistry;
+    sectionCodebook[definition.name] = definition; // eslint-disable-line no-param-reassign
+    return sectionCodebook;
   }
 
   const displayVariable = definition.variables[definition.displayVariable];
@@ -103,23 +103,23 @@ const transposedRegistryVariables = (sectionRegistry, definition) => {
     acc[variable.name] = variable;
     return acc;
   }, {});
-  sectionRegistry[definition.name] = { // eslint-disable-line no-param-reassign
+  sectionCodebook[definition.name] = { // eslint-disable-line no-param-reassign
     ...definition,
     displayVariable: displayVariable && displayVariable.name,
     variables,
   };
-  return sectionRegistry;
+  return sectionCodebook;
 };
 
-const transposedRegistrySection = (section = {}) =>
-  Object.values(section).reduce((sectionRegistry, definition) => (
-    transposedRegistryVariables(sectionRegistry, definition)
+const transposedCodebookSection = (section = {}) =>
+  Object.values(section).reduce((sectionCodebook, definition) => (
+    transposedCodebookVariables(sectionCodebook, definition)
   ), {});
 
-const transposedRegistry = (registry = {}) => ({
-  edge: transposedRegistrySection(registry.edge),
-  node: transposedRegistrySection(registry.node),
-  ego: transposedRegistryVariables({}, { ...registry.ego, name: 'ego' }).ego,
+const transposedCodebook = (codebook = {}) => ({
+  edge: transposedCodebookSection(codebook.edge),
+  node: transposedCodebookSection(codebook.node),
+  ego: transposedCodebookVariables({}, { ...codebook.ego, name: 'ego' }).ego,
 });
 
 module.exports = {
@@ -133,7 +133,7 @@ module.exports = {
   caseProperty,
   nodePrimaryKeyProperty,
   processEntityVariables,
-  transposedRegistry,
-  transposedRegistrySection,
+  transposedCodebook,
+  transposedCodebookSection,
   unionOfNetworks,
 };

--- a/src/main/utils/formatters/network.js
+++ b/src/main/utils/formatters/network.js
@@ -12,8 +12,9 @@ const unionOfNetworks = networks =>
   networks.reduce((union, network) => {
     union.nodes.push(...network.nodes);
     union.edges.push(...network.edges);
+    union.ego.push(network.ego); // TODO undefined is not a function
     return union;
-  }, { nodes: [], edges: [] });
+  }, { nodes: [], edges: [], ego: [] });
 
 /**
  * Run the query on each network; filter for those which meet the criteria (i.e., where the query
@@ -38,6 +39,18 @@ const filterNetworkEntities = (networks, filterConfig) => {
   const filter = getFilter(filterConfig);
   return networks.map(network => filter(network));
 };
+
+const insertNetworkEgo = network => (
+  {
+    nodes: network.nodes.map(node => ({ _egoID: network.ego[nodePrimaryKeyProperty], ...node })),
+    edges: network.edges.map(edge => ({ _egoID: network.ego[nodePrimaryKeyProperty], ...edge })),
+    ego: network.ego,
+  }
+);
+
+const insertEgoInNetworks = networks => (
+  networks.map(network => insertNetworkEgo(network))
+);
 
 const transposedRegistrySection = (section = {}) =>
   Object.values(section).reduce((sectionRegistry, definition) => {
@@ -69,6 +82,7 @@ module.exports = {
   filterNetworkEntities,
   filterNetworksWithQuery,
   getNodeAttributes,
+  insertEgoInNetworks,
   nodeAttributesProperty,
   nodePrimaryKeyProperty,
   transposedRegistry,

--- a/src/main/utils/formatters/network.js
+++ b/src/main/utils/formatters/network.js
@@ -1,4 +1,5 @@
 const { includes } = require('lodash');
+const bigInt = require('big-integer');
 
 const getQuery = require('../network-query/query').default;
 const getFilter = require('../network-query/filter').default;
@@ -11,6 +12,11 @@ const caseProperty = '_caseID';
 const nodeAttributesProperty = 'attributes';
 
 const getEntityAttributes = node => (node && node[nodeAttributesProperty]) || {};
+
+const convertUuidToDecimal = uuid => (
+  // BigInt support is in node 10.4, this poly-fills for now
+  uuid ? bigInt(uuid.toString().replace(/-/g, ''), 16).toString(10) : uuid
+);
 
 const unionOfNetworks = networks =>
   networks.reduce((union, network) => {
@@ -117,6 +123,7 @@ const transposedRegistry = (registry = {}) => ({
 });
 
 module.exports = {
+  convertUuidToDecimal,
   filterNetworkEntities,
   filterNetworksWithQuery,
   getEntityAttributes,

--- a/src/main/utils/formatters/network.js
+++ b/src/main/utils/formatters/network.js
@@ -44,7 +44,7 @@ const insertNetworkEgo = network => (
   {
     nodes: network.nodes.map(node => ({ _egoID: network.ego[nodePrimaryKeyProperty], ...node })),
     edges: network.edges.map(edge => ({ _egoID: network.ego[nodePrimaryKeyProperty], ...edge })),
-    ego: network.ego,
+    ego: { ...network.ego, attributes: { ...network.sessionVariables, ...network.ego.attributes } },
   }
 );
 

--- a/src/main/utils/formatters/utils.js
+++ b/src/main/utils/formatters/utils.js
@@ -5,6 +5,7 @@
 const {
   AdjacencyMatrixFormatter,
   AttributeListFormatter,
+  EgoListFormatter,
   EdgeListFormatter,
   GraphMLFormatter,
 } = require('./index');
@@ -19,6 +20,7 @@ const formats = {
   adjacencyMatrix: 'adjacencyMatrix',
   attributeList: 'attributeList',
   edgeList: 'edgeList',
+  ego: 'ego',
 };
 
 const extensions = {
@@ -48,6 +50,7 @@ const formatsAreValid = suppliedFormats =>
 const partitionByEdgeType = (network, format) => {
   switch (format) {
     case formats.graphml:
+    case formats.ego:
     case formats.attributeList:
       return [network];
     case formats.edgeList:
@@ -86,6 +89,7 @@ const getFileExtension = (formatterType) => {
     case formats.adjacencyMatrix:
     case formats.edgeList:
     case formats.attributeList:
+    case formats.ego:
       return extensions.csv;
     default:
       return null;
@@ -107,6 +111,8 @@ const getFormatterClass = (formatterType) => {
       return EdgeListFormatter;
     case formats.attributeList:
       return AttributeListFormatter;
+    case formats.ego:
+      return EgoListFormatter;
     default:
       return null;
   }

--- a/src/renderer/components/Filter/FilterGroup.js
+++ b/src/renderer/components/Filter/FilterGroup.js
@@ -41,7 +41,7 @@ class FilterGroup extends PureComponent {
   static propTypes = {
     filter: PropTypes.object,
     onChange: PropTypes.func,
-    variableRegistry: PropTypes.object.isRequired,
+    codebook: PropTypes.object.isRequired,
     variableTypes: PropTypes.object.isRequired,
   };
 
@@ -110,7 +110,7 @@ class FilterGroup extends PureComponent {
   };
 
   render() {
-    const { filter: { join, rules }, variableRegistry } = this.props;
+    const { filter: { join, rules }, codebook } = this.props;
 
     return (
       <div className={filterGroupClasses(join)}>
@@ -130,7 +130,7 @@ class FilterGroup extends PureComponent {
             onUpdateRule={this.onUpdateRule}
             onDeleteRule={this.onDeleteRule}
             onSortEnd={this.onMoveRule}
-            variableRegistry={variableRegistry}
+            codebook={codebook}
           />
 
           <div className="filter-group__add">

--- a/src/renderer/components/Filter/Rule/AlterRule.js
+++ b/src/renderer/components/Filter/Rule/AlterRule.js
@@ -8,7 +8,7 @@ import { SortableElement } from 'react-sortable-hoc';
 import DragHandle from './DragHandle';
 import DropDown from './DropDown';
 import Input from './Input';
-// import { getVariableRegistry } from '../../../selectors/protocol';
+// import { getCodebook } from '../../../selectors/protocol';
 import { getVariableOptions } from './selectors';
 import { getOperatorsForType } from './operators';
 
@@ -123,16 +123,16 @@ class AlterRule extends PureComponent {
   }
 }
 
-function mapStateToProps(state, { options, variableRegistry }) {
-  // const variableRegistry = getVariableRegistry(state);
-  const nodeTypes = map(variableRegistry.node, (node, nodeId) => [nodeId, node.name]);
+function mapStateToProps(state, { options, codebook }) {
+  // const codebook = getCodebook(state);
+  const nodeTypes = map(codebook.node, (node, nodeId) => [nodeId, node.name]);
   const valueInputType = options ?
-    get(variableRegistry.node, [options.type, 'variables', options.attribute, 'type']) :
+    get(codebook.node, [options.type, 'variables', options.attribute, 'type']) :
     undefined;
 
   return {
     nodeTypes,
-    nodeAttributes: getVariableOptions(variableRegistry.node),
+    nodeAttributes: getVariableOptions(codebook.node),
     valueInputType,
   };
 }

--- a/src/renderer/components/Filter/Rule/EdgeRule.js
+++ b/src/renderer/components/Filter/Rule/EdgeRule.js
@@ -8,7 +8,7 @@ import { SortableElement } from 'react-sortable-hoc';
 import DragHandle from './DragHandle';
 import DropDown from './DropDown';
 import Input from './Input';
-// import { getVariableRegistry } from '../../../selectors/protocol';
+// import { getCodebook } from '../../../selectors/protocol';
 import { getVariableOptions } from './selectors';
 import { getOperatorsForType } from './operators';
 
@@ -123,16 +123,16 @@ class EdgeRule extends PureComponent {
   }
 }
 
-function mapStateToProps(state, { options, variableRegistry }) {
-  // const variableRegistry = getVariableRegistry(state);
-  const edgeTypes = map(variableRegistry.edge, (edge, edgeId) => [edgeId, edge.name]);
+function mapStateToProps(state, { options, codebook }) {
+  // const codebook = getCodebook(state);
+  const edgeTypes = map(codebook.edge, (edge, edgeId) => [edgeId, edge.name]);
   const valueInputType = options ?
-    get(variableRegistry.node, [options.type, 'variables', options.attribute, 'type']) :
+    get(codebook.node, [options.type, 'variables', options.attribute, 'type']) :
     undefined;
 
   return {
     edgeTypes,
-    edgeAttributes: getVariableOptions(variableRegistry.edge),
+    edgeAttributes: getVariableOptions(codebook.edge),
     valueInputType,
   };
 }

--- a/src/renderer/components/Filter/Rule/EgoRule.js
+++ b/src/renderer/components/Filter/Rule/EgoRule.js
@@ -9,7 +9,7 @@ import DragHandle from './DragHandle';
 import DropDown from './DropDown';
 import Input from './Input';
 import { getVariableOptions } from './selectors';
-// import { getVariableRegistry } from '../../../selectors/protocol';
+// import { getCodebook } from '../../../selectors/protocol';
 import { getOperatorsForType } from './operators';
 
 class EgoRule extends PureComponent {
@@ -112,17 +112,17 @@ class EgoRule extends PureComponent {
 
 
 // TODO: person is an implicitly required node type
-function mapStateToProps(state, { options, variableRegistry }) {
-  // const variableRegistry = getVariableRegistry(state);
-  const personType = find(toPairs(variableRegistry.node), ([, node]) => node.name === 'person');
+function mapStateToProps(state, { options, codebook }) {
+  // const codebook = getCodebook(state);
+  const personType = find(toPairs(codebook.node), ([, node]) => node.name === 'person');
   const personId = personType && personType[0];
   const valueInputType = options ?
-    get(variableRegistry.node, [personId, 'variables', options.attribute, 'type']) :
+    get(codebook.node, [personId, 'variables', options.attribute, 'type']) :
     undefined;
 
   return {
     hasPersonType: !!personType,
-    nodeAttributes: getVariableOptions(variableRegistry.node)[personId],
+    nodeAttributes: getVariableOptions(codebook.node)[personId],
     valueInputType,
   };
 }

--- a/src/renderer/components/Filter/Rule/selectors.js
+++ b/src/renderer/components/Filter/Rule/selectors.js
@@ -2,7 +2,7 @@
 
 import { mapValues, reduce, isEqual } from 'lodash';
 import { defaultMemoize, createSelectorCreator } from 'reselect';
-// import { getVariableRegistry } from '../../../selectors/protocol';
+// import { getCodebook } from '../../../selectors/protocol';
 
 const createDeepEqualSelector = createSelectorCreator(
   defaultMemoize,
@@ -18,8 +18,8 @@ const validTypes = [
   'ordinal',
 ];
 
-// Registry is supplied as a prop to keep Filter contained & reusable
-const getVariableRegistry = (state, props) => props.variableRegistry;
+// Codebook is supplied as a prop to keep Filter contained & reusable
+const getCodebook = (state, props) => props.codebook;
 
 export const getVariableOptions = type =>
   mapValues(
@@ -50,10 +50,10 @@ export const getVariableOptions = type =>
  * }
  */
 export const getVariableTypes = createDeepEqualSelector(
-  getVariableRegistry,
-  registry =>
+  getCodebook,
+  codebook =>
     reduce(
-      registry,
+      codebook,
       (memo, entities, type) => ({
         ...memo,
         [type]: mapValues(

--- a/src/renderer/components/Filter/Rules.js
+++ b/src/renderer/components/Filter/Rules.js
@@ -5,7 +5,7 @@ import Rule from './Rule';
 import AppearTransition from '../Transitions/Appear';
 
 const Rules = SortableContainer(
-  ({ rules, onUpdateRule, onDeleteRule, variableRegistry }) => (
+  ({ rules, onUpdateRule, onDeleteRule, codebook }) => (
     <TransitionGroup className="rules">
       {rules.map((rule, index) => (
         <AppearTransition
@@ -18,7 +18,7 @@ const Rules = SortableContainer(
             onUpdateRule={onUpdateRule}
             onDeleteRule={onDeleteRule}
             className="rules__rule"
-            variableRegistry={variableRegistry}
+            codebook={codebook}
           />
         </AppearTransition>
       ))}

--- a/src/renderer/components/workspace/AnswerDistributionPanel.js
+++ b/src/renderer/components/workspace/AnswerDistributionPanel.js
@@ -29,7 +29,7 @@ class AnswerDistributionPanel extends PureComponent {
     return (
       <div className="dashboard__panel dashboard__panel--chart">
         <h4 className="dashboard__header-text">
-          {variableDefinition.label}
+          {variableDefinition.name}
           <small className="dashboard__header-subtext">
             {headerLabel(variableDefinition.type)} distribution
           </small>

--- a/src/renderer/containers/ExportScreen.js
+++ b/src/renderer/containers/ExportScreen.js
@@ -194,8 +194,16 @@ class ExportScreen extends Component {
               }}
             />
           </div>
-          <div>
-            <DrawerTransition in={showCsvOpts}>
+          <DrawerTransition in={showCsvOpts}>
+            <div className="export__csv-types">
+              <Toggle
+                label="Include Ego data?"
+                input={{
+                  name: 'export_ego_data',
+                  onChange: this.handleEgoDataChange,
+                  value: this.state.useEgoData,
+                }}
+              />
               <div className="export__subpanel">
                 <div className="export__subpanel-content">
                   <h4>Include the following files:</h4>
@@ -229,22 +237,9 @@ class ExportScreen extends Component {
                   </DrawerTransition>
                 </div>
               </div>
-            </DrawerTransition>
-          </div>
+            </div>
+          </DrawerTransition>
         </div>
-        <DrawerTransition in={showCsvOpts}>
-          <div className="export__section">
-            <h4>Ego</h4>
-            <Toggle
-              label="Include Ego data?"
-              input={{
-                name: 'export_ego_data',
-                onChange: this.handleEgoDataChange,
-                value: this.state.useEgoData,
-              }}
-            />
-          </div>
-        </DrawerTransition>
         <div className="export__section">
           <h4>Directed Edges</h4>
           <Toggle

--- a/src/renderer/containers/ExportScreen.js
+++ b/src/renderer/containers/ExportScreen.js
@@ -193,6 +193,8 @@ class ExportScreen extends Component {
                 onChange: this.handleFormatChange,
               }}
             />
+          </div>
+          <div>
             <DrawerTransition in={showCsvOpts}>
               <div className="export__subpanel">
                 <div className="export__subpanel-content">

--- a/src/renderer/containers/ExportScreen.js
+++ b/src/renderer/containers/ExportScreen.js
@@ -6,7 +6,6 @@ import { Redirect } from 'react-router-dom';
 import { remote } from 'electron';
 
 import Types from '../types';
-import Filter from '../components/Filter'; // eslint-disable-line import/no-named-as-default
 import DrawerTransition from '../components/Transitions/Drawer';
 import Checkbox from '../ui/components/Fields/Checkbox';
 import Radio from '../ui/components/Fields/Radio';
@@ -16,11 +15,6 @@ import withApiClient from '../components/withApiClient';
 import { selectors } from '../ducks/modules/protocols';
 import { Button, Spinner } from '../ui';
 import { actionCreators as messageActionCreators } from '../ducks/modules/appMessages';
-
-const defaultFilter = {
-  join: '',
-  rules: [],
-};
 
 const availableCsvTypes = {
   adjacencyMatrix: 'Adjacency Matrix',
@@ -35,14 +29,9 @@ class ExportScreen extends Component {
       exportFormat: 'graphml',
       exportNetworkUnion: false,
       csvTypes: new Set([...Object.keys(availableCsvTypes), 'ego']),
-      entityFilter: defaultFilter,
       useDirectedEdges: true,
       useEgoData: true,
     };
-  }
-
-  handleFilterChange = (entityFilter) => {
-    this.setState({ entityFilter });
   }
 
   handleFormatChange = (evt) => {
@@ -119,7 +108,6 @@ class ExportScreen extends Component {
       exportFormat,
       exportNetworkUnion,
       csvTypes,
-      entityFilter,
       useDirectedEdges,
       useEgoData,
     } = this.state;
@@ -133,7 +121,6 @@ class ExportScreen extends Component {
         exportFormats: (exportFormat === 'csv' && [...exportCsvTypes]) || [exportFormat],
         exportNetworkUnion,
         destinationFilepath,
-        entityFilter,
         useDirectedEdges,
         useEgoData,
       })
@@ -143,7 +130,7 @@ class ExportScreen extends Component {
   }
 
   render() {
-    const { protocol, protocolsHaveLoaded, variableRegistry } = this.props;
+    const { protocol, protocolsHaveLoaded } = this.props;
 
     if (protocolsHaveLoaded && !protocol) { // This protocol doesn't exist
       return <Redirect to="/" />;
@@ -280,15 +267,6 @@ class ExportScreen extends Component {
             />
           </div>
         </div>
-        <div className="export__section">
-          <h3>Filtering</h3>
-          <p>Include nodes and edges that meet the following criteria:</p>
-          <Filter
-            filter={this.state.entityFilter}
-            onChange={this.handleFilterChange}
-            variableRegistry={variableRegistry}
-          />
-        </div>
         <Button type="submit" disabled={exportInProgress}>Export</Button>
       </form>
     );
@@ -301,19 +279,16 @@ ExportScreen.propTypes = {
   protocolsHaveLoaded: PropTypes.bool.isRequired,
   showConfirmation: PropTypes.func.isRequired,
   showError: PropTypes.func.isRequired,
-  variableRegistry: PropTypes.object,
 };
 
 ExportScreen.defaultProps = {
   apiClient: null,
   protocol: null,
-  variableRegistry: null,
 };
 
 const mapStateToProps = (state, ownProps) => ({
   protocolsHaveLoaded: selectors.protocolsHaveLoaded(state),
   protocol: selectors.currentProtocol(state, ownProps),
-  variableRegistry: selectors.transposedRegistry(state, ownProps),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/renderer/containers/ExportScreen.js
+++ b/src/renderer/containers/ExportScreen.js
@@ -115,6 +115,7 @@ class ExportScreen extends Component {
     const csvTypesNoEgo = new Set(this.state.csvTypes);
     csvTypesNoEgo.delete('ego');
     const exportCsvTypes = useEgoData ? csvTypes : csvTypesNoEgo;
+    const showCsvOpts = exportFormat === 'csv';
 
     apiClient
       .post(`/protocols/${protocolId}/export_requests`, {
@@ -122,7 +123,7 @@ class ExportScreen extends Component {
         exportNetworkUnion,
         destinationFilepath,
         useDirectedEdges,
-        useEgoData,
+        useEgoData: useEgoData && showCsvOpts,
       })
       .then(() => showConfirmation('Export complete'))
       .catch(err => showError(err.message))

--- a/src/renderer/containers/__tests__/ExportScreen-test.js
+++ b/src/renderer/containers/__tests__/ExportScreen-test.js
@@ -108,12 +108,5 @@ describe('<ExportScreen />', () => {
       subject.instance().handleExport();
       expect(remote.dialog.showSaveDialog).toHaveBeenCalled();
     });
-
-    it('manages filter state', () => {
-      const filterInstance = subject.find('Connect(FilterGroup)');
-      const mockFilter = { join: null, rules: [{ mock: true }] };
-      filterInstance.simulate('change', mockFilter);
-      expect(subject.state('entityFilter')).toEqual(mockFilter);
-    });
   });
 });

--- a/src/renderer/containers/__tests__/ExportScreen-test.js
+++ b/src/renderer/containers/__tests__/ExportScreen-test.js
@@ -98,6 +98,12 @@ describe('<ExportScreen />', () => {
       expect(subject.state('useDirectedEdges')).toBe(true);
     });
 
+    it('toggles ego setting', () => {
+      const radioWrapper = subject.findWhere(n => n.name() === 'Toggle' && (/Ego/).test(n.prop('label')));
+      radioWrapper.dive().find('input').simulate('change', { target: { checked: true } });
+      expect(subject.state('useEgoData')).toBe(true);
+    });
+
     it('prompts for output path before export', () => {
       subject.instance().handleExport();
       expect(remote.dialog.showSaveDialog).toHaveBeenCalled();

--- a/src/renderer/containers/workspace/__tests__/withAnswerDistributionCharts-test.js
+++ b/src/renderer/containers/workspace/__tests__/withAnswerDistributionCharts-test.js
@@ -20,7 +20,7 @@ jest.mock('../../../ducks/modules/protocols', () => ({
     currentProtocol: jest.fn(),
     currentProtocolId: jest.fn().mockReturnValue('1'),
     isDistributionVariable: jest.fn().mockReturnValue(true),
-    transposedRegistry: jest.fn().mockReturnValue({
+    transposedCodebook: jest.fn().mockReturnValue({
       node: {
         person: {
           variables: {

--- a/src/renderer/containers/workspace/withAnswerDistributionCharts.js
+++ b/src/renderer/containers/workspace/withAnswerDistributionCharts.js
@@ -7,7 +7,7 @@ import { selectors as protocolSelectors } from '../../ducks/modules/protocols';
 import { selectors as variableSelectors } from '../../ducks/modules/excludedChartVariables';
 import Types from '../../types';
 
-const { currentProtocolId, isDistributionVariable, transposedRegistry } = protocolSelectors;
+const { currentProtocolId, isDistributionVariable, transposedCodebook } = protocolSelectors;
 const { excludedVariablesForCurrentProtocol } = variableSelectors;
 
 const hasData = bucket => bucket && Object.keys(bucket).length > 0;
@@ -23,12 +23,12 @@ const hasData = bucket => bucket && Object.keys(bucket).length > 0;
  *
  * @private
  *
- * @param {Object} transposedNodeRegistry `transposedRegistry.node`, with transposed names
+ * @param {Object} transposedNodeCodebook `transposedCodebook.node`, with transposed names
  * @param {Object} buckets The API response from `option_buckets`
  * @return {Array} chartDefinitions
  */
-const shapeBucketData = (transposedNodeRegistry, buckets, excludedChartVariables) =>
-  Object.entries(transposedNodeRegistry).reduce((acc, [entityType, { variables }]) => {
+const shapeBucketData = (transposedNodeCodebook, buckets, excludedChartVariables) =>
+  Object.entries(transposedNodeCodebook).reduce((acc, [entityType, { variables }]) => {
     const excludedSectionVariables = excludedChartVariables[entityType] || [];
     Object.entries(variables).forEach(([variableName, def]) => {
       if (!isDistributionVariable(def) || excludedSectionVariables.includes(def.name)) {
@@ -77,7 +77,7 @@ const withAnswerDistributionCharts = (WrappedComponent) => {
       excludedChartVariables: PropTypes.object,
       protocolId: PropTypes.string,
       totalSessionsCount: PropTypes.number,
-      transposedRegistry: Types.variableRegistry.isRequired,
+      transposedCodebook: Types.codebook.isRequired,
     }
 
     constructor(props) {
@@ -109,14 +109,14 @@ const withAnswerDistributionCharts = (WrappedComponent) => {
       const {
         excludedChartVariables,
         protocolId,
-        transposedRegistry: { node: nodeRegistry = {} },
+        transposedCodebook: { node: nodeCodebook = {} },
       } = this.props;
 
       if (!protocolId) {
         return;
       }
 
-      const variableNames = Object.values(nodeRegistry).reduce((acc, nodeTypeDefinition) => {
+      const variableNames = Object.values(nodeCodebook).reduce((acc, nodeTypeDefinition) => {
         acc.push(...Object.keys(nodeTypeDefinition.variables || {}));
         return acc;
       }, []);
@@ -127,7 +127,7 @@ const withAnswerDistributionCharts = (WrappedComponent) => {
       this.apiClient.get(route, query)
         .then(({ buckets }) => {
           this.setState({
-            charts: shapeBucketData(nodeRegistry, buckets, excludedChartVariables),
+            charts: shapeBucketData(nodeCodebook, buckets, excludedChartVariables),
           });
         });
     }
@@ -140,7 +140,7 @@ const withAnswerDistributionCharts = (WrappedComponent) => {
   const mapStateToProps = (state, ownProps) => ({
     excludedChartVariables: excludedVariablesForCurrentProtocol(state, ownProps),
     protocolId: currentProtocolId(state, ownProps),
-    transposedRegistry: transposedRegistry(state, ownProps),
+    transposedCodebook: transposedCodebook(state, ownProps),
   });
 
   return connect(mapStateToProps)(AnswerDistributionPanels);

--- a/src/renderer/ducks/modules/__tests__/protocols-test.js
+++ b/src/renderer/ducks/modules/__tests__/protocols-test.js
@@ -102,7 +102,7 @@ describe('the protocols module', () => {
       isDistributionVariable,
       ordinalAndCategoricalVariables,
       protocolsHaveLoaded,
-      transposedRegistry,
+      transposedCodebook,
     } = selectors;
 
     describe('currentProtocol', () => {
@@ -129,25 +129,25 @@ describe('the protocols module', () => {
 
     describe('ordinalAndCategoricalVariables', () => {
       it('returns node variable names sectioned by entity type', () => {
-        const variableRegistry = {
+        const codebook = {
           node: { 'node-type-id': { name: 'person', variables: { 'var-id-1': { name: 'catVar', type: 'categorical' } } } },
         };
-        const state = { protocols: [{ id: '1', variableRegistry }] };
+        const state = { protocols: [{ id: '1', codebook }] };
         const props = { match: { params: { id: '1' } } };
         expect(ordinalAndCategoricalVariables(state, props)).toEqual({ person: ['catVar'] });
       });
 
       it('ignores sections without these variables', () => {
-        const variableRegistry = {
+        const codebook = {
           node: { 'node-type-id': { name: 'venue', variables: { 'var-id-1': { name: 'intVar', type: 'number' } } } },
         };
-        const state = { protocols: [{ id: '1', variableRegistry }] };
+        const state = { protocols: [{ id: '1', codebook }] };
         const props = { match: { params: { id: '1' } } };
         expect(ordinalAndCategoricalVariables(state, props)).not.toHaveProperty('venue');
       });
 
-      it('returns an empty object if node registry unavailable', () => {
-        const state = { protocols: [{ id: '1', variableRegistry: {} }] };
+      it('returns an empty object if node codebook unavailable', () => {
+        const state = { protocols: [{ id: '1', codebook: {} }] };
         const props = { match: { params: { id: '1' } } };
         expect(ordinalAndCategoricalVariables(state, props)).toEqual({});
       });
@@ -164,24 +164,24 @@ describe('the protocols module', () => {
       });
     });
 
-    describe('transposedRegistry', () => {
-      it('returns a modified registry', () => {
-        const variableRegistry = { node: { 'node-type-id': { name: 'person', variables: {} } } };
-        const state = { protocols: [{ id: '1', variableRegistry }] };
+    describe('transposedCodebook', () => {
+      it('returns a modified codebook', () => {
+        const codebook = { node: { 'node-type-id': { name: 'person', variables: {} } } };
+        const state = { protocols: [{ id: '1', codebook }] };
         const props = { match: { params: { id: '1' } } };
-        const transposed = transposedRegistry(state, props);
+        const transposed = transposedCodebook(state, props);
         expect(transposed).toHaveProperty('node');
         expect(transposed.node).toHaveProperty('person');
       });
 
       it('does not require edge variables', () => {
-        const variableRegistry = {
+        const codebook = {
           node: { 'node-type-id': { name: 'person', variables: {} } },
           edge: { 'edge-type-id': { name: 'edge-name' } },
         };
-        const state = { protocols: [{ id: '1', variableRegistry }] };
+        const state = { protocols: [{ id: '1', codebook }] };
         const props = { match: { params: { id: '1' } } };
-        const transposed = transposedRegistry(state, props);
+        const transposed = transposedCodebook(state, props);
         expect(transposed.edge).toEqual({ 'edge-name': { name: 'edge-name' } });
       });
     });

--- a/src/renderer/ducks/modules/protocols.js
+++ b/src/renderer/ducks/modules/protocols.js
@@ -1,7 +1,7 @@
 import AdminApiClient from '../../utils/adminApiClient';
 import viewModelMapper from '../../utils/baseViewModelMapper';
 import { actionCreators as messageActionCreators } from './appMessages';
-import { transposedRegistrySection } from '../../../main/utils/formatters/network'; // TODO: move
+import { transposedCodebookSection } from '../../../main/utils/formatters/network'; // TODO: move
 
 const LOAD_PROTOCOLS = 'LOAD_PROTOCOLS';
 const PROTOCOLS_LOADED = 'PROTOCOLS_LOADED';
@@ -49,16 +49,16 @@ const currentProtocolId = (state, props) => {
 
 // Transpose all types & variable IDs to names
 // Imported data is transposed; this allows utility components from Architect to work as-is.
-const transposedRegistry = (state, props) => {
+const transposedCodebook = (state, props) => {
   const protocol = currentProtocol(state, props);
   if (!protocol) {
     return {};
   }
 
-  const registry = protocol.variableRegistry || {};
+  const codebook = protocol.codebook || {};
   return {
-    edge: transposedRegistrySection(registry.edge),
-    node: transposedRegistrySection(registry.node),
+    edge: transposedCodebookSection(codebook.edge),
+    node: transposedCodebookSection(codebook.node),
   };
 };
 
@@ -69,11 +69,11 @@ const isDistributionVariable = variable => distributionVariableTypes.includes(va
  * @return {Object} all node ordinal & categorical variable names, sectioned by node type
  */
 const ordinalAndCategoricalVariables = (state, props) => {
-  const registry = transposedRegistry(state, props);
-  if (!registry) {
+  const codebook = transposedCodebook(state, props);
+  if (!codebook) {
     return {};
   }
-  return Object.entries(registry.node || {}).reduce((acc, [entityType, { variables }]) => {
+  return Object.entries(codebook.node || {}).reduce((acc, [entityType, { variables }]) => {
     const variableNames = Object.entries(variables).reduce((arr, [variableName, variable]) => {
       if (isDistributionVariable(variable)) {
         arr.push(variableName);
@@ -140,7 +140,7 @@ const selectors = {
   currentProtocolId,
   isDistributionVariable,
   protocolsHaveLoaded,
-  transposedRegistry,
+  transposedCodebook,
   ordinalAndCategoricalVariables,
 };
 

--- a/src/renderer/styles/_reset.scss
+++ b/src/renderer/styles/_reset.scss
@@ -2,6 +2,7 @@ body {
   height: 100vh;
   margin: 0;
   padding: 0;
+  overflow: hidden;
 }
 
 .app-root {

--- a/src/renderer/styles/_reset.scss
+++ b/src/renderer/styles/_reset.scss
@@ -2,7 +2,6 @@ body {
   height: 100vh;
   margin: 0;
   padding: 0;
-  overflow: hidden;
 }
 
 .app-root {

--- a/src/renderer/styles/_reset.scss
+++ b/src/renderer/styles/_reset.scss
@@ -2,6 +2,8 @@ body {
   height: 100vh;
   margin: 0;
   padding: 0;
+  position: fixed;
+  width: 100%;
 }
 
 .app-root {

--- a/src/renderer/styles/containers/_export.scss
+++ b/src/renderer/styles/containers/_export.scss
@@ -7,9 +7,15 @@
     padding: spacing(large) 0;
   }
 
+  @include element(csv-types) {
+    .form-field-container {
+      margin-bottom: 0;
+    }
+  }
+
   @include element(subpanel) {
     transform-origin: top;
-    padding: 0 1rem;
+    padding: 0 1.5rem;
   }
 
   @include element(subpanel-content) {

--- a/src/renderer/types.js
+++ b/src/renderer/types.js
@@ -19,8 +19,7 @@ const protocol = device;
 const protocols = PropTypes.arrayOf(protocol);
 
 const variableDefinition = PropTypes.shape({
-  label: PropTypes.string.isRequired,
-  name: PropTypes.string,
+  name: PropTypes.string.isRequired,
   options: PropTypes.arrayOf(PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,
@@ -33,7 +32,7 @@ const variableDefinition = PropTypes.shape({
 
 const entityType = PropTypes.shape({ variables: PropTypes.objectOf(variableDefinition) });
 
-const variableRegistry = PropTypes.shape({
+const codebook = PropTypes.shape({
   node: PropTypes.objectOf(entityType),
   edge: PropTypes.objectOf(entityType),
 });
@@ -48,7 +47,7 @@ const Types = {
   protocol,
   protocols,
   variableDefinition,
-  variableRegistry,
+  codebook,
 };
 
 export default Object.freeze(Types);


### PR DESCRIPTION
Resolves #199. This allows ego data to be exported during csv exports. Ego uid can be included, or not, with attribute and edge files. 

Case id is included in ego file export. Note that this depends on #codaco/Network-Canvas/pull/880 to export the case id from NC.

![ego export](https://user-images.githubusercontent.com/16093053/54944324-9edb8f80-4f09-11e9-897c-2d7f9ec7f9cf.png)

In keeping with our usage of a preceding underscore to denote system data (e.g. `_uid`), I've used `_egoID`, `_caseID`, `_source`, and `_target` for exported data. Example of exported files:

[asd.zip](https://github.com/codaco/Server/files/3004980/asd.zip)

This does not directly relate to this PR, but I did notice that graphml exporting could use an update. This should happen as part of #codaco/Network-Canvas/issues/796, or here as an interim solution. Issues I noticed: "null" values are being printed to the graphml, which is a problem if graphml is expecting a "double" instead of a "string", for example. Booleans are showing up as "string" type. And edge "attributes" are exported as one big object in graphml.

