### PR TITLE
Fix/export filename change

### DIFF
--- a/src/main/data-managers/ExportManager.js
+++ b/src/main/data-managers/ExportManager.js
@@ -161,8 +161,12 @@ class ExportManager {
         }
       })
       .then(() => this.sessionDB.findAll(protocol._id, null, null))
-      .then(sessions => sessions.map(session =>
-        ({ ...session.data, _id: session._id, _caseID: session.data.sessionVariables._caseID })))
+      .then(sessions => sessions.map((session) => {
+        const id = session && session._id;
+        const caseID = session && session.data && session.data.sessionVariables &&
+          session.data.sessionVariables._caseID;
+        return { ...session.data, _id: id, _caseID: caseID };
+      }))
       .then(networks => (useEgoData ? insertEgoInNetworks(networks) : networks))
       .then(networks => (exportNetworkUnion ? [unionOfNetworks(networks)] : networks))
       .then((networks) => {

--- a/src/main/data-managers/ProtocolDB.js
+++ b/src/main/data-managers/ProtocolDB.js
@@ -42,7 +42,6 @@ class ProtocolDB extends DatabaseAdapter {
    * @throws If DB save fails
    */
   save(filename, contentsDigest, metadata, { returnOldDoc = false } = {}) {
-    console.log('save', filename);
     return new Promise(async (resolve, reject) => {
       if (!filename || !contentsDigest) {
         reject(new RequestError(ErrorMessages.InvalidContainerFile));

--- a/src/main/data-managers/__tests__/ProtocolManager-test.js
+++ b/src/main/data-managers/__tests__/ProtocolManager-test.js
@@ -319,21 +319,21 @@ describe('ProtocolManager', () => {
     it('rejects when unlink errors if ensureFileDeleted is requested', async () => {
       const mockProtocol = { filename: 'a.netcanvas' };
       const mockError = new Error('mock error');
-      fs.unlink.mockImplementation((path, cb) => { cb(mockError); });
+      fs.unlink.mockImplementation((filepath, cb) => { cb(mockError); });
       await expect(manager.destroyProtocol(mockProtocol, true)).rejects.toEqual(mockError);
     });
 
     it('rejects when db errors', async () => {
       const mockProtocol = { filename: 'a.netcanvas' };
       const mockError = new Error('mock error');
-      fs.unlink.mockImplementation((path, cb) => { cb(); });
+      fs.unlink.mockImplementation((filepath, cb) => { cb(); });
       manager.db.destroy.mockRejectedValue(mockError);
       await expect(manager.destroyProtocol(mockProtocol, true)).rejects.toEqual(mockError);
     });
 
     it('removes a protocol from DB', async () => {
       const mockProtocol = { filename: 'a.netcanvas' };
-      fs.unlink.mockImplementation((path, cb) => { cb(); });
+      fs.unlink.mockImplementation((filepath, cb) => { cb(); });
       manager.db.destroy.mockResolvedValue({});
       await manager.destroyProtocol(mockProtocol);
       expect(manager.db.destroy).toHaveBeenCalledWith(mockProtocol);

--- a/src/main/data-managers/__tests__/ProtocolManager-test.js
+++ b/src/main/data-managers/__tests__/ProtocolManager-test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 import fs from 'fs';
 import JSZip from 'jszip';
+import path from 'path';
 
 import ProtocolManager from '../ProtocolManager';
 import promisedFs from '../../utils/promised-fs';
@@ -171,7 +172,7 @@ describe('ProtocolManager', () => {
 
     it('resolves with the destination filename', async () => {
       fs.copyFile.mockImplementation((src, dest, cb) => { cb(); });
-      const response = { destPath: 'protocols/foo.netcanvas', protocolName: 'foo' };
+      const response = { destPath: path.join('protocols', 'foo.netcanvas'), protocolName: 'foo' };
       await expect(manager.importFile('foo.netcanvas')).resolves.toMatchObject(response);
     });
 

--- a/src/main/utils/formatters/__tests__/matrix-test.js
+++ b/src/main/utils/formatters/__tests__/matrix-test.js
@@ -86,11 +86,11 @@ describe('toCSVStream', () => {
     expect(csv).toEqual(',1,2\r\n1,0,1\r\n2,1,0\r\n');
   });
 
-  it('Works with string UIDs', async () => {
+  it('Converts hex UIDs to decimal', async () => {
     const matrix = mockMatrix([{ from: 'a', to: 'b' }]);
     matrix.toCSVStream(writable);
     const csv = await writable.asString();
-    expect(csv).toEqual(',a,b\r\na,0,1\r\nb,1,0\r\n');
+    expect(csv).toEqual(',10,11\r\n10,0,1\r\n11,1,0\r\n');
   });
 
   it('Handles duplicate edges', async () => {
@@ -111,7 +111,7 @@ describe('toCSVStream', () => {
     matrix.toCSVStream(writable);
     const csv = await writable.asString();
     const rows = [
-      ',1,2,3,4,5,6,7,8,9,10',
+      ',1,2,3,4,5,6,7,8,9,16',
       '1,0,1,0,0,0,0,0,0,0,0',
       '2,1,0,0,0,0,0,0,0,0,0',
       '3,0,0,0,1,0,0,0,0,0,0',
@@ -121,7 +121,7 @@ describe('toCSVStream', () => {
       '7,0,0,0,0,0,0,0,1,0,0',
       '8,0,0,0,0,0,0,1,0,0,0',
       '9,0,0,0,0,0,0,0,0,0,1',
-      '10,0,0,0,0,0,0,0,0,1,0\r\n',
+      '16,0,0,0,0,0,0,0,0,1,0\r\n',
     ];
     expect(csv).toEqual(rows.join('\r\n'));
   });

--- a/src/main/utils/formatters/graphml/createGraphML.js
+++ b/src/main/utils/formatters/graphml/createGraphML.js
@@ -124,7 +124,7 @@ const generateKeyElements = (
           case VariableType.ordinal:
           case VariableType.number: {
             const keyType = getGraphMLTypeForKey(entities, key);
-            keyElement.setAttribute('attr.type', keyType);
+            keyElement.setAttribute('attr.type', keyType || 'string');
             break;
           }
           case VariableType.layout: {

--- a/src/main/utils/formatters/matrix.js
+++ b/src/main/utils/formatters/matrix.js
@@ -3,7 +3,7 @@
 
 const { Readable } = require('stream');
 
-const { nodePrimaryKeyProperty } = require('./network');
+const { convertUuidToDecimal, nodePrimaryKeyProperty } = require('./network');
 const { csvEOL } = require('./csv');
 
 /**
@@ -125,7 +125,8 @@ class AdjacencyMatrix {
     // cannot be used directly to index into arrayViews.
     let matrixIndex = 0;
 
-    const headerRowContent = `,${uniqueNodeIds.join(',')}${csvEOL}`;
+    const decimals = uniqueNodeIds.map(id => convertUuidToDecimal(id));
+    const headerRowContent = `,${decimals.join(',')}${csvEOL}`;
 
     // TODO: escape headerLabels (if not already) & quote
     const dataRowContent = (headerLabel, matrix) => {
@@ -183,7 +184,7 @@ class AdjacencyMatrix {
           this.push(headerRowContent);
           headerWritten = true;
         } else if (rowNum < dataColumnCount) {
-          row = dataRowContent(uniqueNodeIds[rowNum], truncatingView);
+          row = dataRowContent(convertUuidToDecimal(uniqueNodeIds[rowNum]), truncatingView);
           this.push(row);
           rowNum += 1;
 

--- a/src/main/utils/formatters/network.js
+++ b/src/main/utils/formatters/network.js
@@ -24,7 +24,7 @@ const unionOfNetworks = networks =>
     union.edges.push(...network.edges);
     union.ego.push(network.ego);
     return union;
-  }, { nodes: [], edges: [], ego: [] });
+  }, { nodes: [], edges: [], ego: [], _id: '' });
 
 const processEntityVariables = (entity, variables) => ({
   ...entity,
@@ -77,6 +77,7 @@ const filterNetworkEntities = (networks, filterConfig) => {
 
 const insertNetworkEgo = network => (
   {
+    ...network,
     nodes: network.nodes.map(node => (
       { [egoProperty]: network.ego[nodePrimaryKeyProperty], ...node }
     )),


### PR DESCRIPTION
Updates file names for export files. The names are in the format `[case-id]_[session-id]_[type].[extension]`, for example, `tre_250c2911-f8ac-4d2a-9fd6-e2f18a604b60_edgeList_friend.csv` and `gf_6b47198c-ac43-4981-879a-6c759acebe7a_attributeList.csv` and `ffff_ac556376-e7e4-473e-9cb5-7fbfaaae1b21.graphml`. When files are exported in one, I've used the protocol name instead of case-id and session-id since there are many, so `development-protocol.graphml`.

This also fixes an issue with number `attr.type`s in the graphml. We attempt to discern whether `number` should be `double` or `int`, but without any data for a variable we were returning an empty string. This uses a fallback value so gephi won't complain.

This also updates adjacencyMatrix.csv files to use the decimal version of the uuid's, so the value will match the other csv exports.