### PR TITLE
update ui when session imported

### DIFF
--- a/src/renderer/containers/workspace/withSessions.js
+++ b/src/renderer/containers/workspace/withSessions.js
@@ -50,6 +50,7 @@ const withSessions = WrappedComponent =>
 
     componentDidMount() {
       this.loadSessions();
+      ipcRenderer.on('SESSIONS_IMPORTED', this.onSessionsImported);
     }
 
     componentDidUpdate() {


### PR DESCRIPTION
This reinstates the dashboard updating the ui whenever a session is imported to Server. 

This line of code used to be [here a couple refactors ago](https://github.com/codaco/Server/blob/85bf78d08dfa7fe7d28685e0bea5cad05ba2b856/src/renderer/containers/WorkspaceScreen.js#L46), but was [removed without explanation during a refactor](https://github.com/codaco/Server/commit/c2f2b3b4a59ff43587d7afe413c21171e10caec1#diff-828442051854587055541f0c4d636438), so hopefully that was just an oversight and there's not some underlying reason for it. It seems stable to me.