### PR TITLE
Feature/ego charts

### DIFF
--- a/src/main/data-managers/__tests__/Reportable-test.js
+++ b/src/main/data-managers/__tests__/Reportable-test.js
@@ -109,27 +109,62 @@ describe('Reportable', () => {
       });
     });
 
-    describe('with node variables', () => {
+    describe('with variables', () => {
       beforeAll(() => { mockData = NodeDataSession; });
       it('summarizes an ordinal variable', async () => {
-        await expect(reportDB.optionValueBuckets(mockData.protocolId, ['frequencyOrdinal'])).resolves.toMatchObject({
-          person: {
-            frequencyOrdinal: {
-              1: 1,
-              2: 1,
+        await expect(reportDB.optionValueBuckets(mockData.protocolId, { person: ['frequencyOrdinal'] }, {}, [])).resolves.toMatchObject({
+          nodes: {
+            person: {
+              frequencyOrdinal: {
+                1: 1,
+                2: 1,
+              },
             },
           },
+          edges: {},
+          ego: {},
         });
       });
 
       it('summarizes a categorical variable', async () => {
-        await expect(reportDB.optionValueBuckets(mockData.protocolId, ['preferenceCategorical'])).resolves.toMatchObject({
-          person: {
-            preferenceCategorical: {
-              a: 2,
-              b: 1,
+        await expect(reportDB.optionValueBuckets(mockData.protocolId, { person: ['preferenceCategorical'] }, {}, [])).resolves.toMatchObject({
+          nodes: {
+            person: {
+              preferenceCategorical: {
+                a: 2,
+                b: 1,
+              },
             },
           },
+          edges: {},
+          ego: {},
+        });
+      });
+
+      it('summarizes an edge variable', async () => {
+        await expect(reportDB.optionValueBuckets(mockData.protocolId, {}, { friend: ['catVariable'] }, [])).resolves.toMatchObject({
+          edges: {
+            friend: {
+              catVariable: {
+                1: 1,
+                2: 1,
+              },
+            },
+          },
+          nodes: {},
+          ego: {},
+        });
+      });
+
+      it('summarizes an ego variable', async () => {
+        await expect(reportDB.optionValueBuckets(mockData.protocolId, {}, {}, ['ordVariable'])).resolves.toMatchObject({
+          ego: {
+            ordVariable: {
+              2: 2,
+            },
+          },
+          edges: { friend: {} },
+          nodes: { person: {} },
         });
       });
 
@@ -144,7 +179,8 @@ describe('Reportable', () => {
         const result = await reportDB.entityTimeSeries(mockData.protocolId);
         expect(result.entities).toContainEqual({
           time: expect.any(Number),
-          edge: 0,
+          edge: 2,
+          edge_friend: 2,
           node: 2,
           node_person: 2,
         });

--- a/src/main/data-managers/__tests__/data/node-data-session.json
+++ b/src/main/data-managers/__tests__/data/node-data-session.json
@@ -1,6 +1,37 @@
 {
     "data": {
-        "edges": [],
+        "ego": [
+            {
+                "_uid": "31980bde-1cc1-4681-b482-8a6ede07c2c8",
+                "type": "ego",
+                "attributes": {
+                    "ordVariable": 2
+                }
+            },
+            {
+                "_uid": "35fb6341-91a0-4674-b615-039280c9c212",
+                "type": "person",
+                "attributes": {
+                    "ordVariable": 2
+                }
+            }
+        ],
+        "edges": [
+            {
+                "_uid": "61980bde-1cc1-4681-b482-8a6ede07c2c8",
+                "type": "friend",
+                "attributes": {
+                    "catVariable": 1
+                }
+            },
+            {
+                "_uid": "f5fb6341-91a0-4674-b615-039280c9c212",
+                "type": "friend",
+                "attributes": {
+                    "catVariable": 2
+                }
+            }
+        ],
         "nodes": [
             {
                 "_uid": "91980bde-1cc1-4681-b482-8a6ede07c2c8",

--- a/src/main/server/AdminService.js
+++ b/src/main/server/AdminService.js
@@ -194,8 +194,15 @@ class AdminService {
     });
 
     // nodeNames: { type1: [var1, var2], type2: [var1, var3] },
-    //   edgeNames: { type1: [var1] }, egoNames: [var1, var2]
-    // "buckets": { "person": { "var1": { "val1": 0, "val2": 0 }, "var2": {} } }
+    //   edgeNames: { type1: [var1] }, egoNames: [var1, var2],
+    //   egoNames: [var1, var2]
+    // "buckets": {
+    //      nodes: { "person": { "var1": { "val1": 0, "val2": 0 }, "var2": {} } }
+    //      edges: { "friend": { "var1": { "val1": 0, "val2": 0} } }
+    //      ego: { "var1": { "val1": 0 } }
+    //   }
+    // We use post here, instead of get, because the data is more complicated than just a list
+    // of variables, it's organized by entity and type.
     api.post('/protocols/:id/reports/option_buckets', (req, res, next) => {
       const { nodeNames = '', edgeNames = '', egoNames = '' } = req.body;
       this.reportDb.optionValueBuckets(req.params.id, nodeNames, edgeNames, egoNames)

--- a/src/main/server/AdminService.js
+++ b/src/main/server/AdminService.js
@@ -193,11 +193,12 @@ class AdminService {
         .then(() => next());
     });
 
-    // ?variableNames=var1,var2&entityName=node
+    // nodeNames: { type1: [var1, var2], type2: [var1, var3] },
+    //   edgeNames: { type1: [var1] }, egoNames: [var1, var2]
     // "buckets": { "person": { "var1": { "val1": 0, "val2": 0 }, "var2": {} } }
-    api.get('/protocols/:id/reports/option_buckets', (req, res, next) => {
-      const { variableNames = '', entityName = 'node' } = req.query;
-      this.reportDb.optionValueBuckets(req.params.id, variableNames.split(','), entityName)
+    api.post('/protocols/:id/reports/option_buckets', (req, res, next) => {
+      const { nodeNames = '', edgeNames = '', egoNames = '' } = req.body;
+      this.reportDb.optionValueBuckets(req.params.id, nodeNames, edgeNames, egoNames)
         .then(buckets => res.send({ status: 'ok', buckets }))
         .then(() => next());
     });

--- a/src/main/server/__tests__/AdminService-test.js
+++ b/src/main/server/__tests__/AdminService-test.js
@@ -294,7 +294,7 @@ describe('the AdminService', () => {
 
         it('fetches bucketed categorical/ordinal data', async () => {
           const endpoint = makeUrl('protocols/1/reports/option_buckets', apiBase);
-          const res = await jsonClient.get(endpoint);
+          const res = await jsonClient.post(endpoint, { nodeNames: '', edgeNames: '', egoNames: '' });
           expect(res.json.status).toBe('ok');
           expect(res.json.buckets).toMatchObject(bucketsResult);
         });

--- a/src/renderer/components/workspace/AnswerDistributionPanel.js
+++ b/src/renderer/components/workspace/AnswerDistributionPanel.js
@@ -10,7 +10,7 @@ const chartComponent = variableType => ((variableType === 'categorical') ? PieCh
 
 const headerLabel = variableType => ((variableType === 'categorical') ? 'Categorical' : 'Ordinal');
 
-const entityLabel = (entityKey, entityType) => {
+export const entityLabel = (entityKey, entityType) => {
   if (entityKey === 'nodes') return `Node (${entityType})`;
   if (entityKey === 'edges') return `Edge (${entityType})`;
   if (entityKey === 'ego') return 'Ego';

--- a/src/renderer/components/workspace/AnswerDistributionPanel.js
+++ b/src/renderer/components/workspace/AnswerDistributionPanel.js
@@ -10,6 +10,13 @@ const chartComponent = variableType => ((variableType === 'categorical') ? PieCh
 
 const headerLabel = variableType => ((variableType === 'categorical') ? 'Categorical' : 'Ordinal');
 
+const entityLabel = (entityKey, entityType) => {
+  if (entityKey === 'nodes') return `Node (${entityType})`;
+  if (entityKey === 'edges') return `Edge (${entityType})`;
+  if (entityKey === 'ego') return 'Ego';
+  return null;
+};
+
 const content = (chartData, variableType) => {
   const Chart = chartComponent(variableType);
   if (chartData.length) {
@@ -24,12 +31,12 @@ const content = (chartData, variableType) => {
  */
 class AnswerDistributionPanel extends PureComponent {
   render() {
-    const { chartData, variableDefinition } = this.props;
+    const { chartData, entityKey, entityType, variableDefinition } = this.props;
     const totalObservations = sumValues(chartData);
     return (
       <div className="dashboard__panel dashboard__panel--chart">
         <h4 className="dashboard__header-text">
-          {variableDefinition.name}
+          {entityLabel(entityKey, entityType)}: {variableDefinition.name}
           <small className="dashboard__header-subtext">
             {headerLabel(variableDefinition.type)} distribution
           </small>
@@ -50,10 +57,14 @@ class AnswerDistributionPanel extends PureComponent {
 
 AnswerDistributionPanel.defaultProps = {
   chartData: [],
+  entityType: '',
+  entityKey: '',
 };
 
 AnswerDistributionPanel.propTypes = {
   chartData: PropTypes.array,
+  entityKey: PropTypes.string,
+  entityType: PropTypes.string,
   variableDefinition: Types.variableDefinition.isRequired,
 };
 

--- a/src/renderer/containers/SettingsScreen.js
+++ b/src/renderer/containers/SettingsScreen.js
@@ -4,6 +4,8 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Redirect, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
+
+import { entityLabel } from '../components/workspace/AnswerDistributionPanel';
 import { actionCreators as dialogActions } from '../ducks/modules/dialogs';
 import Types from '../types';
 import CheckboxGroup from '../ui/components/Fields/CheckboxGroup';
@@ -34,21 +36,22 @@ class SettingsScreen extends Component {
           </p>
           {
             distributionVariables &&
-            Object.entries(distributionVariables).map(([section, vars]) => (
-              <CheckboxGroup
-                key={section}
-                className="settings__checkbox-group"
-                label={`Type: ${section}`}
-                input={{
-                  value: this.includedChartVariablesForSection(section),
-                  onChange: (newValue) => {
-                    const newExcluded = vars.filter(v => !newValue.includes(v));
-                    setExcludedVariables(protocol.id, section, newExcluded);
-                  },
-                }}
-                options={vars.map(v => ({ value: v, label: v }))}
-              />
-            ))
+            Object.entries(distributionVariables).map(([entity, varsWithTypes]) => (
+              Object.entries(varsWithTypes).map(([section, vars]) => (
+                <CheckboxGroup
+                  key={section}
+                  className="settings__checkbox-group"
+                  label={entityLabel(entity, section)}
+                  input={{
+                    value: this.includedChartVariablesForSection(entity, section),
+                    onChange: (newValue) => {
+                      const newExcluded = vars.filter(v => !newValue.includes(v));
+                      setExcludedVariables(protocol.id, entity, section, newExcluded);
+                    },
+                  }}
+                  options={vars.map(v => ({ value: v, label: v }))}
+                />
+              ))))
           }
         </div>
       </div>
@@ -69,10 +72,11 @@ class SettingsScreen extends Component {
     }
   }
 
-  includedChartVariablesForSection = (section) => {
+  includedChartVariablesForSection = (entity, section) => {
     const { excludedChartVariables, distributionVariables } = this.props;
-    const excludeSection = excludedChartVariables[section];
-    return distributionVariables[section].filter(
+    const excludeSection = excludedChartVariables[entity] &&
+      excludedChartVariables[entity][section];
+    return distributionVariables[entity][section].filter(
       variable => !excludeSection || !excludeSection.includes(variable));
   }
 

--- a/src/renderer/containers/__tests__/SettingsScreen-test.js
+++ b/src/renderer/containers/__tests__/SettingsScreen-test.js
@@ -42,13 +42,17 @@ describe('<SettingsScreen />', () => {
   });
 
   it('renders checkboxes for chart variable selection', () => {
-    const distributionVariables = { person: ['catVar'] };
+    const distributionVariables = {
+      nodes: { person: ['catVar'] },
+      edges: { friend: ['catVar'] },
+      ego: { ego: ['catVar'] },
+    };
     subject.setProps({ protocol: mockProtocol, distributionVariables });
-    expect(subject.find('CheckboxGroup')).toHaveLength(1);
+    expect(subject.find('CheckboxGroup')).toHaveLength(3);
   });
 
   it('updates excluded variables from checkbox input', () => {
-    const distributionVariables = { person: ['catVar'] };
+    const distributionVariables = { nodes: { person: ['catVar'] } };
     subject.setProps({ protocol: mockProtocol, distributionVariables });
     expect(setExcludedVariables).not.toHaveBeenCalled();
     const checkboxes = subject.find('CheckboxGroup');

--- a/src/renderer/containers/workspace/WorkspaceScreen.js
+++ b/src/renderer/containers/workspace/WorkspaceScreen.js
@@ -68,6 +68,8 @@ class WorkspaceScreen extends Component {
       ...answerDistributionCharts.map(chart => (
         <AnswerDistributionPanel
           key={`AnswerDistributionPanel-${chart.variableType}-${chart.entityType}-${chart.variableDefinition.name}`}
+          entityKey={chart.entityKey}
+          entityType={chart.entityType}
           chartData={chart.chartData}
           variableDefinition={chart.variableDefinition}
         />

--- a/src/renderer/containers/workspace/withAnswerDistributionCharts.js
+++ b/src/renderer/containers/workspace/withAnswerDistributionCharts.js
@@ -27,14 +27,15 @@ const hasData = bucket => bucket && Object.keys(bucket).length > 0;
  * @param {Object} buckets The API response from `option_buckets`
  * @return {Array} chartDefinitions
  */
-const shapeBucketData = (transposedNodeCodebook, buckets, excludedChartVariables) =>
+const shapeBucketDataByType = (
+  transposedNodeCodebook, buckets, excludedChartVariables, entityKey) =>
   Object.entries(transposedNodeCodebook).reduce((acc, [entityType, { variables }]) => {
     const excludedSectionVariables = excludedChartVariables[entityType] || [];
-    Object.entries(variables).forEach(([variableName, def]) => {
+    Object.entries(variables || []).forEach(([variableName, def]) => {
       if (!isDistributionVariable(def) || excludedSectionVariables.includes(def.name)) {
         return;
       }
-      const data = buckets[entityType] && buckets[entityType][variableName];
+      const data = entityKey === 'ego' ? buckets && buckets[variableName] : buckets[entityType] && buckets[entityType][variableName];
       const values = hasData(data) && def.options.map((option) => {
         // Option defs are usually in the format { label, value }, however:
         // - options may be strings or numerics instead of objects
@@ -48,6 +49,7 @@ const shapeBucketData = (transposedNodeCodebook, buckets, excludedChartVariables
         };
       });
       acc.push({
+        entityKey,
         entityType,
         variableType: def.type,
         variableDefinition: def,
@@ -55,6 +57,15 @@ const shapeBucketData = (transposedNodeCodebook, buckets, excludedChartVariables
       });
     });
     return acc;
+  }, []);
+
+const shapeBucketData = (codebook, buckets, excludedChartVariables) =>
+  Object.entries(buckets).reduce((acc, [entityKey]) => {
+    const entityCodebook = entityKey === 'ego' ? { ego: codebook[entityKey] } : codebook[entityKey];
+    const bucketsByType = entityKey === 'ego' ? buckets[entityKey] : buckets[entityKey];
+    const shapeData = shapeBucketDataByType(
+      entityCodebook, bucketsByType, excludedChartVariables, entityKey);
+    return acc.concat(shapeData);
   }, []);
 
 /**
@@ -109,25 +120,39 @@ const withAnswerDistributionCharts = (WrappedComponent) => {
       const {
         excludedChartVariables,
         protocolId,
-        transposedCodebook: { node: nodeCodebook = {} },
+        transposedCodebook: {
+          node: nodeCodebook = {},
+          edge: edgeCodebook = {},
+          ego: egoCodebook = {},
+        },
       } = this.props;
+
+      const nodeNames = Object.values(nodeCodebook).reduce((acc, nodeTypeDefinition) => (
+        {
+          ...acc,
+          [nodeTypeDefinition.name]: Object.keys(nodeTypeDefinition.variables || {}),
+        }
+      ), {});
+      const edgeNames = Object.values(edgeCodebook).reduce((acc, edgeTypeDefinition) => (
+        {
+          ...acc,
+          [edgeTypeDefinition.name]: Object.keys(edgeTypeDefinition.variables || {}),
+        }
+      ), {});
+      const egoNames = Object.keys(egoCodebook.variables || {});
 
       if (!protocolId) {
         return;
       }
 
-      const variableNames = Object.values(nodeCodebook).reduce((acc, nodeTypeDefinition) => {
-        acc.push(...Object.keys(nodeTypeDefinition.variables || {}));
-        return acc;
-      }, []);
-
+      const variableNames = { nodes: nodeCodebook, edges: edgeCodebook, ego: egoCodebook };
       const route = `/protocols/${this.props.protocolId}/reports/option_buckets`;
-      const query = { variableNames };
+      const query = { nodeNames, edgeNames, egoNames };
 
-      this.apiClient.get(route, query)
+      this.apiClient.post(route, query)
         .then(({ buckets }) => {
           this.setState({
-            charts: shapeBucketData(nodeCodebook, buckets, excludedChartVariables),
+            charts: shapeBucketData(variableNames, buckets, excludedChartVariables),
           });
         });
     }

--- a/src/renderer/containers/workspace/withAnswerDistributionCharts.js
+++ b/src/renderer/containers/workspace/withAnswerDistributionCharts.js
@@ -62,7 +62,7 @@ const shapeBucketDataByType = (
 const shapeBucketData = (codebook, buckets, excludedChartVariables) =>
   Object.entries(buckets).reduce((acc, [entityKey]) => {
     const entityCodebook = entityKey === 'ego' ? { ego: codebook[entityKey] } : codebook[entityKey];
-    const bucketsByType = entityKey === 'ego' ? buckets[entityKey] : buckets[entityKey];
+    const bucketsByType = buckets[entityKey];
     const shapeData = shapeBucketDataByType(
       entityCodebook, bucketsByType, excludedChartVariables, entityKey);
     return acc.concat(shapeData);

--- a/src/renderer/containers/workspace/withAnswerDistributionCharts.js
+++ b/src/renderer/containers/workspace/withAnswerDistributionCharts.js
@@ -30,7 +30,8 @@ const hasData = bucket => bucket && Object.keys(bucket).length > 0;
 const shapeBucketDataByType = (
   transposedNodeCodebook, buckets, excludedChartVariables, entityKey) =>
   Object.entries(transposedNodeCodebook).reduce((acc, [entityType, { variables }]) => {
-    const excludedSectionVariables = excludedChartVariables[entityType] || [];
+    const excludedSectionVariables = (excludedChartVariables[entityKey] &&
+      excludedChartVariables[entityKey][entityType]) || [];
     Object.entries(variables || []).forEach(([variableName, def]) => {
       if (!isDistributionVariable(def) || excludedSectionVariables.includes(def.name)) {
         return;

--- a/src/renderer/containers/workspace/withAnswerDistributionCharts.js
+++ b/src/renderer/containers/workspace/withAnswerDistributionCharts.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 import AdminApiClient from '../../utils/adminApiClient';
 import { selectors as protocolSelectors } from '../../ducks/modules/protocols';
@@ -36,7 +37,8 @@ const shapeBucketDataByType = (
       if (!isDistributionVariable(def) || excludedSectionVariables.includes(def.name)) {
         return;
       }
-      const data = entityKey === 'ego' ? buckets && buckets[variableName] : buckets[entityType] && buckets[entityType][variableName];
+      const dataPath = entityKey === 'ego' ? [variableName] : [entityType, variableName];
+      const data = get(buckets, dataPath);
       const values = hasData(data) && def.options.map((option) => {
         // Option defs are usually in the format { label, value }, however:
         // - options may be strings or numerics instead of objects

--- a/src/renderer/ducks/modules/__tests__/excludedChartVariables-test.js
+++ b/src/renderer/ducks/modules/__tests__/excludedChartVariables-test.js
@@ -18,6 +18,7 @@ describe('excludedChartVariables', () => {
       const action = {
         type: actionTypes.SET_EXCLUDED_VARIABLES,
         protocolId: 'protocol1',
+        entity: 'nodes',
         section: 'person',
         variables: ['someVar'],
       };
@@ -27,6 +28,7 @@ describe('excludedChartVariables', () => {
     it('returns current state if no protocol ID given', () => {
       const action = {
         type: actionTypes.SET_EXCLUDED_VARIABLES,
+        entity: 'nodes',
         section: 'person',
         variables: ['someVar'],
       };
@@ -37,21 +39,23 @@ describe('excludedChartVariables', () => {
       const action = {
         type: actionTypes.SET_EXCLUDED_VARIABLES,
         protocolId: '1',
+        entity: 'nodes',
         section: 'person',
         variables: ['someVar'],
       };
       expect(reducer({}, action)).toEqual({
-        1: { person: ['someVar'] },
+        1: { nodes: { person: ['someVar'] } },
       });
     });
   });
 
   describe('setExcludedVariables action creator', () => {
     it('produces an exclude action', () => {
-      const action = actionCreators.setExcludedVariables('1', 'person', ['someVar']);
+      const action = actionCreators.setExcludedVariables('1', 'nodes', 'person', ['someVar']);
       expect(action).toEqual({
         type: actionTypes.SET_EXCLUDED_VARIABLES,
         protocolId: '1',
+        entity: 'nodes',
         section: 'person',
         variables: ['someVar'],
       });
@@ -61,10 +65,10 @@ describe('excludedChartVariables', () => {
   describe('excludedVariablesForCurrentProtocol selector', () => {
     const { excludedVariablesForCurrentProtocol } = selectors;
     it('returns variables for the protocol', () => {
-      const excludedChartVariables = { 1: { person: ['someVar'] } };
+      const excludedChartVariables = { 1: { nodes: { person: ['someVar'] } } };
       const state = { protocols: [{ id: '1' }], excludedChartVariables };
       const props = { match: { params: { id: '1' } } };
-      expect(excludedVariablesForCurrentProtocol(state, props)).toEqual({ person: ['someVar'] });
+      expect(excludedVariablesForCurrentProtocol(state, props)).toEqual({ nodes: { person: ['someVar'] } });
     });
   });
 });

--- a/src/renderer/ducks/modules/__tests__/protocols-test.js
+++ b/src/renderer/ducks/modules/__tests__/protocols-test.js
@@ -128,13 +128,15 @@ describe('the protocols module', () => {
     });
 
     describe('ordinalAndCategoricalVariables', () => {
-      it('returns node variable names sectioned by entity type', () => {
+      it('returns entity variable names sectioned by entity type', () => {
         const codebook = {
           node: { 'node-type-id': { name: 'person', variables: { 'var-id-1': { name: 'catVar', type: 'categorical' } } } },
+          edge: { 'edge-type-id': { name: 'friend', variables: { 'var-id-2': { name: 'ordVar', type: 'ordinal' } } } },
+          ego: { name: 'ego', variables: { 'var-id-3': { name: 'catVar', type: 'categorical' } } },
         };
         const state = { protocols: [{ id: '1', codebook }] };
         const props = { match: { params: { id: '1' } } };
-        expect(ordinalAndCategoricalVariables(state, props)).toEqual({ person: ['catVar'] });
+        expect(ordinalAndCategoricalVariables(state, props)).toEqual({ nodes: { person: ['catVar'] }, edges: { friend: ['ordVar'] }, ego: { ego: ['catVar'] } });
       });
 
       it('ignores sections without these variables', () => {
@@ -146,14 +148,15 @@ describe('the protocols module', () => {
         expect(ordinalAndCategoricalVariables(state, props)).not.toHaveProperty('venue');
       });
 
-      it('returns an empty object if node codebook unavailable', () => {
+      it('returns an empty object if entity codebook unavailable', () => {
         const state = { protocols: [{ id: '1', codebook: {} }] };
         const props = { match: { params: { id: '1' } } };
-        expect(ordinalAndCategoricalVariables(state, props)).toEqual({});
+        expect(ordinalAndCategoricalVariables(state, props)).toEqual(
+          { nodes: {}, edges: {}, ego: {} });
       });
 
       it('returns an empty object if protocol unavailable', () => {
-        expect(ordinalAndCategoricalVariables({}, {})).toEqual({});
+        expect(ordinalAndCategoricalVariables({}, {})).toEqual({ nodes: {}, edges: {}, ego: {} });
       });
     });
 
@@ -166,12 +169,20 @@ describe('the protocols module', () => {
 
     describe('transposedCodebook', () => {
       it('returns a modified codebook', () => {
-        const codebook = { node: { 'node-type-id': { name: 'person', variables: {} } } };
+        const codebook = {
+          node: { 'node-type-id': { name: 'person', variables: {} } },
+          edge: { 'edge-type-id': { name: 'friend', variables: {} } },
+          ego: { name: 'ego', variables: { 'var-id-1': { name: 'ordVar', type: 'ordinal' } } },
+        };
         const state = { protocols: [{ id: '1', codebook }] };
         const props = { match: { params: { id: '1' } } };
         const transposed = transposedCodebook(state, props);
         expect(transposed).toHaveProperty('node');
         expect(transposed.node).toHaveProperty('person');
+        expect(transposed).toHaveProperty('edge');
+        expect(transposed.edge).toHaveProperty('friend');
+        expect(transposed).toHaveProperty('ego');
+        expect(transposed.ego.variables).toHaveProperty('ordVar');
       });
 
       it('does not require edge variables', () => {

--- a/src/renderer/ducks/modules/excludedChartVariables.js
+++ b/src/renderer/ducks/modules/excludedChartVariables.js
@@ -11,7 +11,9 @@ import { selectors as protocolSelectors } from './protocols';
  * ```
  * {
  *   [protocolId]: {
- *     [entityType]: [variableName1, variableName2]
+ *     [entity]: {
+ *       [entityType]: [variableName1, variableName2]
+ *     }
  *   }
  * }
  * ```
@@ -28,7 +30,12 @@ const reducer = (state = initialState, action = {}) => {
       if (!protocolId) {
         return state;
       }
-      const protocolState = { ...state[protocolId], [action.section]: action.variables };
+      const protocolState = { ...state[protocolId],
+        [action.entity]: {
+          ...state[protocolId][action.entity],
+          [action.section]: action.variables,
+        },
+      };
       return { ...state, [protocolId]: protocolState };
     }
     default:
@@ -38,13 +45,15 @@ const reducer = (state = initialState, action = {}) => {
 
 /**
  * @memberof module:excludedChartVariables
+ * @param {string} entity corresponds to an entity (e.g. node, edge, ego)
  * @param {string} section corresponds to an entity (node) type
  * @param {Array} variables list of variable names to exclude
  * @return {Object} excluded variable names, sectioned by entity type
  */
-const setExcludedVariables = (protocolId, section, variables) => ({
+const setExcludedVariables = (protocolId, entity, section, variables) => ({
   type: SET_EXCLUDED_VARIABLES,
   protocolId,
+  entity,
   section,
   variables,
 });

--- a/src/renderer/ducks/modules/excludedChartVariables.js
+++ b/src/renderer/ducks/modules/excludedChartVariables.js
@@ -32,7 +32,7 @@ const reducer = (state = initialState, action = {}) => {
       }
       const protocolState = { ...state[protocolId],
         [action.entity]: {
-          ...state[protocolId][action.entity],
+          ...(state[protocolId] || {})[action.entity],
           [action.section]: action.variables,
         },
       };

--- a/src/renderer/ducks/modules/protocols.js
+++ b/src/renderer/ducks/modules/protocols.js
@@ -63,7 +63,7 @@ const distributionVariableTypes = ['ordinal', 'categorical'];
 const isDistributionVariable = variable => distributionVariableTypes.includes(variable.type);
 
 const getDistributionVariableNames = variables => (
-  Object.entries(variables).reduce((arr, [variableName, variable]) => {
+  Object.entries(variables || {}).reduce((arr, [variableName, variable]) => {
     if (isDistributionVariable(variable)) {
       arr.push(variableName);
     }

--- a/src/renderer/ducks/modules/protocols.js
+++ b/src/renderer/ducks/modules/protocols.js
@@ -1,7 +1,7 @@
 import AdminApiClient from '../../utils/adminApiClient';
 import viewModelMapper from '../../utils/baseViewModelMapper';
 import { actionCreators as messageActionCreators } from './appMessages';
-import { transposedCodebookSection } from '../../../main/utils/formatters/network'; // TODO: move
+import { transposedCodebook as networkTransposedCodebook } from '../../../main/utils/formatters/network'; // TODO: move
 
 const LOAD_PROTOCOLS = 'LOAD_PROTOCOLS';
 const PROTOCOLS_LOADED = 'PROTOCOLS_LOADED';
@@ -56,10 +56,7 @@ const transposedCodebook = (state, props) => {
   }
 
   const codebook = protocol.codebook || {};
-  return {
-    edge: transposedCodebookSection(codebook.edge),
-    node: transposedCodebookSection(codebook.node),
-  };
+  return networkTransposedCodebook(codebook);
 };
 
 const distributionVariableTypes = ['ordinal', 'categorical'];


### PR DESCRIPTION
Resolves #252. This adds both ego and edge ordinal/categorical variables to the server overview screen, and to the settings screen to toggle which ones display.

It also fixes a bug where the counts were incorrect if you had two variables of the same name within the same entity (e.g. node: person with variable: catVar, and node: venue with variable: catVar).