### PR TITLE
bump version to 5.0.0

### DIFF
--- a/build-resources/entitlements.mac.inherit.plist
+++ b/build-resources/entitlements.mac.inherit.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+  </dict>
+</plist>

--- a/build-resources/entitlements.mac.inherit.plist
+++ b/build-resources/entitlements.mac.inherit.plist
@@ -8,5 +8,7 @@
     <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
   </dict>
 </plist>

--- a/build-resources/scripts/afterSignHook.js
+++ b/build-resources/scripts/afterSignHook.js
@@ -1,0 +1,35 @@
+// See: https://medium.com/@TwitterArchiveEraser/notarize-electron-apps-7a5f988406db
+
+const fs = require('fs');
+const path = require('path');
+const electronNotarize = require('electron-notarize');
+
+async function note(params) {
+  // Only notarize the app on Mac OS only.
+  if (process.platform !== 'darwin') {
+    return;
+  }
+  console.log('afterSign hook triggered', params);
+
+  const appPath = path.join(params.appOutDir, `${params.packager.appInfo.productFilename}.app`);
+  if (!fs.existsSync(appPath)) {
+    throw new Error(`Cannot find application at: ${appPath}`);
+  }
+
+  console.log(`Notarizing Server found at ${appPath}`);
+
+  try {
+    await electronNotarize.notarize({
+      appBundleId: 'NetworkCanvasServer',
+      appPath,
+      appleId: 'developers@coda.co',
+      appleIdPassword: '@keychain:altoolpw',
+    });
+  } catch (error) {
+    console.error(error);
+  }
+
+  console.log('Done notarizing Server');
+}
+
+module.exports = note;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-server",
-    "version": "4.1.0",
+    "version": "5.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-server",
-    "version": "4.1.0",
+    "version": "5.0.0",
     "productName": "Network Canvas Server",
     "description": "A tool for storing, analyzing, and exporting Network Canvas interview data.",
     "private": true,

--- a/package.json
+++ b/package.json
@@ -140,7 +140,8 @@
         "mac": {
             "category": "public.app-category.education",
             "hardenedRuntime": true,
-            "entitlements": "./build-resources/entitlements.mac.inherit.plist"
+            "entitlements": "./build-resources/entitlements.mac.inherit.plist",
+            "target": "dmg"
         },
         "win": {
             "target": "nsis",

--- a/package.json
+++ b/package.json
@@ -131,13 +131,16 @@
     "build": {
         "extends": null,
         "appId": "NetworkCanvasServer",
+        "afterSign": "./build-resources/scripts/afterSignHook.js",
         "directories": {
             "app": "./www",
             "buildResources": "build-resources",
             "output": "release-builds"
         },
         "mac": {
-            "category": "public.app-category.education"
+            "category": "public.app-category.education",
+            "hardenedRuntime": true,
+            "entitlements": "./build-resources/entitlements.mac.inherit.plist"
         },
         "win": {
             "target": "nsis",

--- a/src/main/package.json
+++ b/src/main/package.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas-server",
-    "version": "4.1.0",
+    "version": "5.0.0",
     "productName": "Network Canvas Server",
     "description": "A tool for storing, analyzing, and exporting Network Canvas interview data.",
     "private": true,


### PR DESCRIPTION
Release branch for 5.0.0

Contains:

- Bump of node and electron versions
- Bump of UI library
- Color coding based on schema version
- Fixes a crash on drag and drop from apps that provide a URL