### PR TITLE
Implement unsafe-pairing-code

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -13,6 +13,10 @@ const ipcMain = {
 };
 
 const app = {
+  commandLine: {
+    hasSwitch: jest.fn(),
+    getSwitchValue: jest.fn(() => 'aaaaaaaaaaaaaaaa'),
+  },
   dock: {
     hide: jest.fn(),
     show: jest.fn(),
@@ -37,7 +41,13 @@ const dialog = {
 };
 
 const remote = {
-  app,
+  app: {
+    commandLine: {
+      hasSwitch: jest.fn(),
+      getSwitchValue: jest.fn(() => 'aaaaaaaaaaaaaaaa'),
+    },
+    getVersion: jest.fn(() => '1.0.0'),
+  },
   dialog,
   process: {
     platform: '',

--- a/config/jest/logger.js
+++ b/config/jest/logger.js
@@ -1,5 +1,0 @@
-/* eslint-env jest */
-module.exports = {
-  log: jest.fn(),
-  debug: jest.fn(),
-};

--- a/config/jest/logger.js
+++ b/config/jest/logger.js
@@ -1,0 +1,5 @@
+/* eslint-env jest */
+module.exports = {
+  log: jest.fn(),
+  debug: jest.fn(),
+};

--- a/src/main/server/devices/DeviceAPI.js
+++ b/src/main/server/devices/DeviceAPI.js
@@ -4,6 +4,7 @@ const os = require('os');
 const restify = require('restify');
 const corsMiddleware = require('restify-cors-middleware');
 const logger = require('electron-log');
+const { app } = require('electron');
 const { ConflictError, NotAcceptableError } = require('restify-errors');
 const { EventEmitter } = require('events');
 const { sendToGui } = require('../../guiProxy');
@@ -605,28 +606,38 @@ class DeviceAPI extends EventEmitter {
           if (abortRequest) { abortRequest(); }
         });
 
-        this.requestService.createRequest()
-          .then((pairingRequest) => {
-            // Send code up to UI, and wait for user response
-            const ack = this.outOfBandDelegate.pairingDidBeginWithRequest(pairingRequest);
-            // Provide hook to abort from client-side
-            abortRequest = ack.abort;
-            return ack.promise;
-          })
-          .then((ackedPairingRequest) => {
-            // Respond to client
-            res.json({
-              status: 'ok',
-              data: {
-                pairingRequestId: ackedPairingRequest._id,
-                salt: ackedPairingRequest.salt,
-              },
-            });
-          })
-          .catch(err => this.handlers.onError(err, res))
-          .then(() => next());
-      },
+        const acknowledgedRequest = (ackedPairingRequest) => {
+          logger.debug(ackedPairingRequest);
+          // Respond to client
+          res.json({
+            status: 'ok',
+            data: {
+              pairingRequestId: ackedPairingRequest._id,
+              salt: ackedPairingRequest.salt,
+            },
+          });
+        };
 
+        // Shortcut pairing acknowledgement if unsafe-pairing-code is set
+        if (app.commandLine.hasSwitch('unsafe-pairing-code')) {
+          this.requestService.createRequest()
+            .then(acknowledgedRequest)
+            .catch(err => this.handlers.onError(err, res))
+            .then(() => next());
+        } else {
+          this.requestService.createRequest()
+            .then((pairingRequest) => {
+              // Send code up to UI, and wait for user response
+              const ack = this.outOfBandDelegate.pairingDidBeginWithRequest(pairingRequest);
+              // Provide hook to abort from client-side
+              abortRequest = ack.abort;
+              return ack.promise;
+            })
+            .then(acknowledgedRequest)
+            .catch(err => this.handlers.onError(err, res))
+            .then(() => next());
+        }
+      },
       onPairingConfirm: (req, res, next) => {
         const encryptedMsg = req.body && req.body.message;
         this.requestService.verifyAndExpireEncryptedRequest(encryptedMsg)

--- a/src/main/server/devices/DeviceAPI.js
+++ b/src/main/server/devices/DeviceAPI.js
@@ -617,7 +617,7 @@ class DeviceAPI extends EventEmitter {
             },
           });
         };
-        
+
         this.requestService.createRequest()
           .then((pairingRequest) => {
             // Shortcut pairing acknowledgement if unsafe-pairing-code is set

--- a/src/main/server/devices/DeviceAPI.js
+++ b/src/main/server/devices/DeviceAPI.js
@@ -617,26 +617,22 @@ class DeviceAPI extends EventEmitter {
             },
           });
         };
-
-        // Shortcut pairing acknowledgement if unsafe-pairing-code is set
-        if (app.commandLine.hasSwitch('unsafe-pairing-code')) {
-          this.requestService.createRequest()
-            .then(acknowledgedRequest)
-            .catch(err => this.handlers.onError(err, res))
-            .then(() => next());
-        } else {
-          this.requestService.createRequest()
-            .then((pairingRequest) => {
-              // Send code up to UI, and wait for user response
-              const ack = this.outOfBandDelegate.pairingDidBeginWithRequest(pairingRequest);
-              // Provide hook to abort from client-side
-              abortRequest = ack.abort;
-              return ack.promise;
-            })
-            .then(acknowledgedRequest)
-            .catch(err => this.handlers.onError(err, res))
-            .then(() => next());
-        }
+        
+        this.requestService.createRequest()
+          .then((pairingRequest) => {
+            // Shortcut pairing acknowledgement if unsafe-pairing-code is set
+            if (app.commandLine.hasSwitch('unsafe-pairing-code')) {
+              return pairingRequest;
+            }
+            // Send code up to UI, and wait for user response
+            const ack = this.outOfBandDelegate.pairingDidBeginWithRequest(pairingRequest);
+            // Provide hook to abort from client-side
+            abortRequest = ack.abort;
+            return ack.promise;
+          })
+          .then(acknowledgedRequest)
+          .catch(err => this.handlers.onError(err, res))
+          .then(() => next());
       },
       onPairingConfirm: (req, res, next) => {
         const encryptedMsg = req.body && req.body.message;

--- a/src/main/server/devices/PairingCodeFactory.js
+++ b/src/main/server/devices/PairingCodeFactory.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const { app } = require('electron');
 
 const { PairingCodeLength, CharacterSet } = require('../../utils/shared-api/pairingCodeConfig');
 
@@ -31,6 +32,12 @@ const generatePairingCodeAsync = () => new Promise((resolve, reject) => {
   const maxValidByte = 256 - (256 % charSet.length) - 1;
 
   let passcode = '';
+
+  if (app.commandLine.hasSwitch('unsafe-pairing-code')) {
+    const unsafePairingCode = app.commandLine.getSwitchValue('unsafe-pairing-code');
+    resolve(unsafePairingCode);
+    return;
+  }
 
   crypto.randomBytes(256, (err, buf) => {
     if (err) {

--- a/src/main/server/devices/__tests__/PairingCodeFactory-test.js
+++ b/src/main/server/devices/__tests__/PairingCodeFactory-test.js
@@ -5,6 +5,8 @@ const Factory = require('../PairingCodeFactory');
 
 const { PairingCodeLength } = require('../../../utils/shared-api/pairingCodeConfig');
 
+jest.mock('electron');
+
 describe('the PairingCodeFactory', () => {
   it('can generate a pairing code', async () => {
     const code = await Factory.generatePairingCodeAsync();

--- a/src/renderer/components/workspace/ServerPanel.js
+++ b/src/renderer/components/workspace/ServerPanel.js
@@ -63,6 +63,7 @@ class ServerPanel extends Component {
     const { className } = this.props;
     const overview = { ...serverOverview };
     const uptimeDisplay = overview.uptime && `${parseInt(overview.uptime / 1000 / 60, 10)}m`;
+
     return (
       <div className={`server-panel ${className}`}>
         <div className="server-panel__wrapper">

--- a/src/renderer/containers/App.js
+++ b/src/renderer/containers/App.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import logger from 'electron-log';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { ipcRenderer, shell } from 'electron';
+import { ipcRenderer, shell, remote } from 'electron';
 import { withRouter } from 'react-router-dom';
 import DialogManager from '../components/DialogManager';
 import AppRoutes from './AppRoutes';
@@ -60,7 +60,10 @@ class App extends Component {
   constructor(props) {
     super(props);
 
-    this.state = { apiReady: false };
+    this.state = {
+      apiReady: false,
+      insecure: remote.app.commandLine.hasSwitch('unsafe-pairing-code'),
+    };
 
     preventGlobalDragDrop();
     enableExternalLinks();
@@ -107,6 +110,7 @@ class App extends Component {
 
     const {
       apiReady,
+      insecure,
     } = this.state;
 
     const appClass = isFrameless() ? 'app app--frameless' : 'app';
@@ -135,6 +139,17 @@ class App extends Component {
               <React.Fragment>
                 <ProtocolNav className="app__sidebar" />
                 <div className="app__screen">
+                  { insecure &&
+                    <div className="unsafe-pairing-warning">
+                      <h3>Warning: Unsafe Pairing Enabled!</h3>
+                      <p>
+                        You have started Server with the <code>unsafe-pairing-code</code>
+                        option set. This option severely undermines the security of Server,
+                        and should <strong>not be used when conducting a study under any
+                        circumstances</strong>.
+                      </p>
+                    </div>
+                  }
                   <AppRoutes />
                 </div>
               </React.Fragment>

--- a/src/renderer/styles/containers/_app.scss
+++ b/src/renderer/styles/containers/_app.scss
@@ -18,6 +18,12 @@
     width: 100%;
   }
 
+  .unsafe-pairing-warning {
+    background: var(--error);
+    color: var(--text-light);
+    padding: unit(2);
+  }
+
 
   @include modifier(frameless) {
     .app__titlebar {

--- a/src/renderer/styles/containers/_app.scss
+++ b/src/renderer/styles/containers/_app.scss
@@ -22,6 +22,7 @@
     background: var(--error);
     color: var(--text-light);
     padding: unit(2);
+    width: 100%;
   }
 
 


### PR DESCRIPTION
This PR adds a command line argument, `unsafe-pairing-mode`, that allows the user to specify a pairing code to use within the app. It shows an appropriately stern warning.

To use:

`./network-canvas-server --unsafe-pairing-code="aaaaaaaaaaaaaaaa"`