### PR TITLE
add ego info to graphml selection

### DIFF
--- a/src/renderer/containers/ExportScreen.js
+++ b/src/renderer/containers/ExportScreen.js
@@ -26,7 +26,7 @@ class ExportScreen extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      exportFormat: 'graphml',
+      exportFormat: 'csv',
       exportNetworkUnion: false,
       csvTypes: new Set([...Object.keys(availableCsvTypes), 'ego']),
       useDirectedEdges: true,
@@ -182,48 +182,52 @@ class ExportScreen extends Component {
               }}
             />
           </div>
+          <div className="export__csv-types">
+            <Toggle
+              disabled={this.state.exportFormat === 'graphml'}
+              label="Include Ego data?"
+              input={{
+                name: 'export_ego_data',
+                onChange: this.handleEgoDataChange,
+                value: this.state.exportFormat === 'csv' && this.state.useEgoData,
+              }}
+            />
+            <DrawerTransition in={!showCsvOpts}>
+              <div className="export__ego-info">* Ego data not supported for this export format. See <a className="external-link" href="https://documentation.networkcanvas.com/docs/tutorials/server-workflows/#managing-and-exporting-data-in-server">documentation</a>.</div>
+            </DrawerTransition>
+          </div>
           <DrawerTransition in={showCsvOpts}>
-            <div className="export__csv-types">
-              <Toggle
-                label="Include Ego data?"
-                input={{
-                  name: 'export_ego_data',
-                  onChange: this.handleEgoDataChange,
-                  value: this.state.useEgoData,
-                }}
-              />
-              <div className="export__subpanel">
-                <div className="export__subpanel-content">
-                  <h4>Include the following files:</h4>
-                  {
-                    Object.entries(availableCsvTypes).map(([csvType, label]) => (
-                      <div key={`export_csv_type_${csvType}`}>
-                        <Checkbox
-                          label={label}
-                          input={{
-                            name: 'export_csv_types',
-                            checked: this.state.csvTypes.has(csvType),
-                            value: csvType,
-                            onChange: this.handleCsvTypeChange,
-                          }}
-                        />
-                      </div>
-                    ))
-                  }
-                  <DrawerTransition in={this.state.useEgoData}>
-                    <div key="export_csv_type_ego">
+            <div className="export__subpanel">
+              <div className="export__subpanel-content">
+                <h4>Include the following files:</h4>
+                {
+                  Object.entries(availableCsvTypes).map(([csvType, label]) => (
+                    <div key={`export_csv_type_${csvType}`}>
                       <Checkbox
-                        label="Ego Attribute List"
+                        label={label}
                         input={{
-                          name: 'export_ego_attributes',
-                          checked: this.state.csvTypes.has('ego'),
-                          value: 'ego',
+                          name: 'export_csv_types',
+                          checked: this.state.csvTypes.has(csvType),
+                          value: csvType,
                           onChange: this.handleCsvTypeChange,
                         }}
                       />
                     </div>
-                  </DrawerTransition>
-                </div>
+                  ))
+                }
+                <DrawerTransition in={this.state.useEgoData}>
+                  <div key="export_csv_type_ego">
+                    <Checkbox
+                      label="Ego Attribute List"
+                      input={{
+                        name: 'export_ego_attributes',
+                        checked: this.state.csvTypes.has('ego'),
+                        value: 'ego',
+                        onChange: this.handleCsvTypeChange,
+                      }}
+                    />
+                  </div>
+                </DrawerTransition>
               </div>
             </div>
           </DrawerTransition>

--- a/src/renderer/containers/__tests__/ExportScreen-test.js
+++ b/src/renderer/containers/__tests__/ExportScreen-test.js
@@ -70,10 +70,24 @@ describe('<ExportScreen />', () => {
       expect(subject.state('exportFormat')).toEqual('csv');
     });
 
+    it('does not warn about ego data for csv export', () => {
+      const radioWrapper = subject.findWhere(n => n.name() === 'Radio' && n.prop('label') === 'CSV');
+      radioWrapper.dive().find('input').simulate('change', { target: { value: 'csv' } });
+      const toggleWrapper = subject.find('Toggle').at(0);
+      expect(toggleWrapper.dive().find('.form-field-toggle').at(0).hasClass('form-field-toggle--disabled')).toBe(false);
+    });
+
     it('selects graphml format', () => {
       const radioWrapper = subject.findWhere(n => n.name() === 'Radio' && n.prop('label') === 'GraphML');
       radioWrapper.dive().find('input').simulate('change', { target: { value: 'graphml' } });
       expect(subject.state('exportFormat')).toEqual('graphml');
+    });
+
+    it('warns about ego data not downloading', () => {
+      const radioWrapper = subject.findWhere(n => n.name() === 'Radio' && n.prop('label') === 'GraphML');
+      radioWrapper.dive().find('input').simulate('change', { target: { value: 'graphml' } });
+      const toggleWrapper = subject.find('Toggle').at(0);
+      expect(toggleWrapper.dive().find('.form-field-toggle').at(0).hasClass('form-field-toggle--disabled')).toBe(true);
     });
 
     it('selects a csv type', () => {

--- a/src/renderer/styles/containers/_export.scss
+++ b/src/renderer/styles/containers/_export.scss
@@ -37,4 +37,10 @@
     justify-content: flex-end;
     padding: 0 spacing(large);
   }
+
+  &__ego-info {
+    float: right;
+    font-style: italic;
+    font-size: small;
+  }
 }


### PR DESCRIPTION
Fixes #266. Adds a warning message and disables the "include ego" toggle when graphml is selected. Defaults to csv export type.

Needs ui submodule updated when codaco/Network-Canvas-UI/pull/117 is merged.